### PR TITLE
Fix date-picker month header text invisible in dark theme

### DIFF
--- a/taskcoachlib/thirdparty/README.txt
+++ b/taskcoachlib/thirdparty/README.txt
@@ -41,7 +41,9 @@ Date: 2012-11-03
 License: GPL v3
 Source: https://bitbucket.org/fraca7/smartdatetimectrl
 Copied on: 2012-11-03
-Changes for Task Coach: Timer cleanup fix for wx.Timer crash on window destroy
+Changes for Task Coach:
+  - Timer cleanup fix for wx.Timer crash on window destroy
+  - 2025-12: Fixed dark theme issue - set explicit text foreground color for month header in calendar popup (issue #43)
 
 ---
 

--- a/taskcoachlib/thirdparty/smartdatetimectrl.py
+++ b/taskcoachlib/thirdparty/smartdatetimectrl.py
@@ -2261,6 +2261,7 @@ class _CalendarPopup(_PopupWindow):
 
         dc.SetPen(wx.BLACK_PEN)
         dc.SetBrush(wx.BLACK_BRUSH)
+        dc.SetTextForeground(wx.BLACK)  # Ensure header text is visible on white background
 
         header = decodeSystemString(
             datetime.date(


### PR DESCRIPTION
Fix date-picker month header text invisible in dark theme

The Problem: The month header text (e.g., "December 2025") in the date-picker calendar popup was white-on-white in dark-themed systems because the code never set an explicit text color before drawing, and dark themes default to white text.

The Fix: Added dc.SetTextForeground(wx.BLACK) before drawing the header in smartdatetimectrl.py:2264.

Why it's third-party: Task Coach uses smartdatetimectrl, a custom date/time widget library from 2012, because it provides features the standard wxPython controls don't:

    Natural language parsing ("tomorrow", "+3d", etc.)
    Combined date+time widget
    Optional "None" checkbox for nullable dates
    Keyboard shortcuts (press "t" for today)

The original source (Bitbucket) is likely defunct. This isn't something a wxPython update would fix - it's Task Coach's own bundled code that needed the fix.