### PR TITLE
Centralize version in VERSION and VERSION_DATE files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,22 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| Debian 12 (Bookworm) | `taskcoach_2.0.0.76_debian-12-bookworm.deb` |
-| Debian 13 (Trixie) | `taskcoach_2.0.0.76_debian-13-trixie.deb` |
-| Debian Sid | `taskcoach_2.0.0.76_debian-sid.deb` |
-| Ubuntu 22.04 (Jammy) | `taskcoach_2.0.0.76_ubuntu-22.04-jammy.deb` |
-| Ubuntu 24.04 (Noble) | `taskcoach_2.0.0.76_ubuntu-24.04-noble.deb` |
+| Debian 12 (Bookworm) | `taskcoach_2.0.0.80_debian-12-bookworm.deb` |
+| Debian 13 (Trixie) | `taskcoach_2.0.0.80_debian-13-trixie.deb` |
+| Debian Sid | `taskcoach_2.0.0.80_debian-sid.deb` |
+| Ubuntu 22.04 (Jammy) | `taskcoach_2.0.0.80_ubuntu-22.04-jammy.deb` |
+| Ubuntu 24.04 (Noble) | `taskcoach_2.0.0.80_ubuntu-24.04-noble.deb` |
 | Linux Mint | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| Arch Linux / Manjaro | `taskcoach-2.0.0.76-arch.pkg.tar.zst` |
-| Fedora 39/40 | `taskcoach-2.0.0.76-fedora39.noarch.rpm` |
-| Any Linux (x86_64) | `TaskCoach-2.0.0.76-x86_64.AppImage` |
+| Arch Linux / Manjaro | `taskcoach-2.0.0.80-arch.pkg.tar.zst` |
+| Fedora 39/40 | `taskcoach-2.0.0.80-fedora39.noarch.rpm` |
+| Any Linux (x86_64) | `TaskCoach-2.0.0.80-x86_64.AppImage` |
 
 **Example: Install on Debian/Ubuntu**
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.0.76_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.0.76_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.0.80_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.0.80_debian-13-trixie.deb
 taskcoach.py
 ```
 
@@ -39,8 +39,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.0.76-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.0.76-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.0.80-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.0.80-arch.pkg.tar.zst
 taskcoach.py
 ```
 
@@ -54,8 +54,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.0.76-fedora40.noarch.rpm
-sudo dnf install ./taskcoach-2.0.0.76-fedora40.noarch.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.0.80-fedora40.noarch.rpm
+sudo dnf install ./taskcoach-2.0.0.80-fedora40.noarch.rpm
 taskcoach.py
 ```
 
@@ -69,9 +69,9 @@ sudo dnf autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.0.76-x86_64.AppImage
-chmod +x TaskCoach-2.0.0.76-x86_64.AppImage
-./TaskCoach-2.0.0.76-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.0.80-x86_64.AppImage
+chmod +x TaskCoach-2.0.0.80-x86_64.AppImage
+./TaskCoach-2.0.0.80-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,12 @@
+# Task Coach Version File
+# This is the single source of truth for the application version.
+#
+# For releases:
+#   1. Increment the version number below
+#   2. Update release_day, release_month, release_year in taskcoachlib/meta/data.py
+#   3. Update changelogs (debian/changelog, build.in/fedora/taskcoach.spec)
+#
+# Format: MAJOR.MINOR.PATCH.BUILD
+# Lines starting with # are comments and ignored.
+
+2.0.0.80

--- a/VERSION_DATE
+++ b/VERSION_DATE
@@ -1,0 +1,5 @@
+# Release date for the current version (ISO 8601 format: YYYY-MM-DD)
+# Update this file when releasing a new version.
+# Lines starting with # are comments and ignored.
+
+2025-12-27

--- a/build.in/arch/PKGBUILD
+++ b/build.in/arch/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Aaron Wolf <https://github.com/realcarbonneau>
 
 pkgname=taskcoach
-pkgver=2.0.0.76
+pkgver=2.0.0.80
 pkgrel=1
 pkgdesc="Your friendly task manager - personal task manager with composite tasks, effort tracking, and more"
 arch=('any')

--- a/build.in/fedora/taskcoach.spec
+++ b/build.in/fedora/taskcoach.spec
@@ -11,7 +11,7 @@
 # (at your option) any later version.
 
 Name:           taskcoach
-Version:        2.0.0.76
+Version:        2.0.0.80
 Release:        1%{?dist}
 Summary:        Your friendly task manager
 
@@ -133,7 +133,8 @@ install -Dm644 Welcome.tsk \
 %{_datadir}/%{name}/
 
 %changelog
-* Fri Dec 27 2025 Task Coach Developers <developers@taskcoach.org> - 2.0.0.76-1
+* Fri Dec 27 2025 Task Coach Developers <developers@taskcoach.org> - 2.0.0.80-1
+- Centralize version in single VERSION file
 - Fix Calendar viewer crash on startup when previously opened
 - Fix wxPython 4.2+ compatibility issues with float arguments
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
-taskcoach (2.0.0.76-1) UNRELEASED; urgency=medium
+taskcoach (2.0.0.80-1) UNRELEASED; urgency=medium
 
+  * Centralize version in single VERSION file
   * Fix Calendar viewer crash on startup when previously opened
   * Fix wxPython 4.2+ compatibility issues with float arguments
 

--- a/docs/DEBIAN_BOOKWORM_SETUP.md
+++ b/docs/DEBIAN_BOOKWORM_SETUP.md
@@ -10,10 +10,10 @@ The easiest way to install TaskCoach on Debian Bookworm is using the pre-built `
 
 ```bash
 # Download the latest .deb from GitHub releases
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.0.76_debian-12-bookworm.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.0.80_debian-12-bookworm.deb
 
 # Install it (this will also install dependencies)
-sudo apt install ./taskcoach_2.0.0.76_debian-12-bookworm.deb
+sudo apt install ./taskcoach_2.0.0.80_debian-12-bookworm.deb
 
 # Run TaskCoach
 taskcoach

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -291,13 +291,13 @@ build_appimage() {
 
     cd "$BUILD_DIR"
 
-    # Get version from TaskCoach
-    VERSION=$(python3 -c "
-import sys
-sys.path.insert(0, '$PROJECT_ROOT')
-from taskcoachlib.meta import data
-print(data.version_full)
-" 2>/dev/null || echo "1.6.1")
+    # Get version from VERSION file (single source of truth)
+    if [ -f "$PROJECT_ROOT/VERSION" ]; then
+        VERSION=$(grep -v '^#' "$PROJECT_ROOT/VERSION" | grep -v '^$' | head -1 | tr -d '[:space:]')
+    else
+        echo "ERROR: VERSION file not found"
+        exit 1
+    fi
 
     echo "Version: $VERSION"
 

--- a/scripts/build-arch.sh
+++ b/scripts/build-arch.sh
@@ -79,13 +79,16 @@ if ! command -v makepkg &> /dev/null; then
 fi
 echo -e "${GREEN}✓ makepkg found${NC}"
 
-# Get version from meta data
+# Get version from VERSION file (single source of truth)
 echo -e "${BLUE}[2/5] Getting version information...${NC}"
 cd "$PROJECT_ROOT"
 
-VERSION=$(python3 -c "import sys; sys.path.insert(0, '.'); from taskcoachlib.meta import data; print(data.version)")
-PATCH=$(python3 -c "import sys; sys.path.insert(0, '.'); from taskcoachlib.meta import data; print(data.version_patch)")
-FULL_VERSION="${VERSION}.${PATCH}"
+if [ -f "$PROJECT_ROOT/VERSION" ]; then
+    FULL_VERSION=$(grep -v '^#' "$PROJECT_ROOT/VERSION" | grep -v '^$' | head -1 | tr -d '[:space:]')
+else
+    echo -e "${RED}✗ VERSION file not found${NC}"
+    exit 1
+fi
 
 echo "Version: $FULL_VERSION"
 echo -e "${GREEN}✓ Version detected${NC}"

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -71,16 +71,14 @@ clean_build() {
     rm -f "${PROJECT_DIR}"/../taskcoach_*.tar.*
 }
 
-# Get version from Python
+# Get version from VERSION file (single source of truth)
 get_version() {
-    cd "$PROJECT_DIR"
-    VERSION=$(python3 -c "
-import sys
-sys.path.insert(0, '.')
-from taskcoachlib.meta import data
-print(data.version_full)
-")
-    echo "$VERSION"
+    if [ -f "$PROJECT_DIR/VERSION" ]; then
+        grep -v '^#' "$PROJECT_DIR/VERSION" | grep -v '^$' | head -1 | tr -d '[:space:]'
+    else
+        error "VERSION file not found"
+        exit 1
+    fi
 }
 
 # Build the package

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -20,12 +20,70 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # pylint: disable=C0103
 
-# Edit these for every release:
-# IMPORTANT: Always increment version_patch AND update release_day/release_month below!
+import os as _os
 
-version = "2.0.0"  # Current version number of the application
-version_patch = "79"  # Patch level - INCREMENT THIS AND UPDATE DATE BELOW!
-version_full = f"{version}.{version_patch}"  # Full version string: 2.0.0.76
+def _read_version():
+    """Read version from VERSION file (single source of truth)."""
+    # Try multiple locations for VERSION file
+    this_dir = _os.path.dirname(_os.path.abspath(__file__))
+    locations = [
+        _os.path.join(this_dir, "..", "..", "VERSION"),  # Development: taskcoachlib/meta/../../VERSION
+        _os.path.join(this_dir, "..", "VERSION"),        # Installed: taskcoachlib/VERSION
+        "/usr/share/taskcoach/VERSION",                  # System install
+    ]
+    for loc in locations:
+        try:
+            with open(loc, "r") as f:
+                for line in f:
+                    line = line.strip()
+                    # Skip comments and empty lines
+                    if line and not line.startswith("#"):
+                        return line
+        except (IOError, OSError):
+            continue
+    return "0.0.0.0"  # Fallback if VERSION file not found
+
+version_full = _read_version()  # e.g., "2.0.0.80"
+_version_parts = version_full.rsplit(".", 1)
+version = _version_parts[0] if len(_version_parts) == 2 else version_full  # e.g., "2.0.0"
+version_patch = _version_parts[1] if len(_version_parts) == 2 else "0"  # e.g., "80"
+
+
+def _read_version_date():
+    """Read release date from VERSION_DATE file (ISO format: YYYY-MM-DD)."""
+    this_dir = _os.path.dirname(_os.path.abspath(__file__))
+    locations = [
+        _os.path.join(this_dir, "..", "..", "VERSION_DATE"),  # Development
+        _os.path.join(this_dir, "..", "VERSION_DATE"),        # Installed
+        "/usr/share/taskcoach/VERSION_DATE",                  # System install
+    ]
+    for loc in locations:
+        try:
+            with open(loc, "r") as f:
+                for line in f:
+                    line = line.strip()
+                    # Skip comments and empty lines
+                    if line and not line.startswith("#"):
+                        return line
+        except (IOError, OSError):
+            continue
+    return "1970-01-01"  # Fallback
+
+
+def _parse_release_date(iso_date):
+    """Parse ISO date string and return (day, month_name, year) tuple."""
+    import datetime
+    try:
+        dt = datetime.datetime.strptime(iso_date, "%Y-%m-%d")
+        month_names = ["January", "February", "March", "April", "May", "June",
+                       "July", "August", "September", "October", "November", "December"]
+        return str(dt.day), month_names[dt.month - 1], str(dt.year)
+    except ValueError:
+        return "1", "January", "1970"
+
+
+_release_date_iso = _read_version_date()
+release_day, release_month, release_year = _parse_release_date(_release_date_iso)
 
 
 def _get_git_commit_hash():
@@ -61,10 +119,8 @@ git_commit_hash = _get_git_commit_hash()
 version_commit = git_commit_hash if git_commit_hash else "(n/a)"
 
 tskversion = 37  # Current version number of the task file format, changed to 37 for release 1.3.23.
-release_day = "27"  # Day number of the release, 1-31, as string
-release_month = "December"  # Month of the release in plain English
-release_year = "2025"  # Year of the release as string
 release_status = "stable"  # One of 'alpha', 'beta', 'stable'
+# Note: release_day, release_month, release_year are now read from VERSION_DATE file above
 
 # Legacy: keep version_with_patch for backwards compatibility
 version_with_patch = version_full


### PR DESCRIPTION
- Add VERSION file as single source of truth for version number
- Add VERSION_DATE file for release date in ISO format (YYYY-MM-DD)
- Update meta/data.py to read from both files
- Update build scripts (arch, deb, appimage) to read from VERSION file
- Both files support # comments for documentation
- Bump version to 2.0.0.80

For releases, now only need to update:
1. VERSION - version number
2. VERSION_DATE - release date
3. Changelogs for release notes