### PR TITLE
Fix sort arrow direction in column headers

### DIFF
--- a/taskcoachlib/gui/viewer/base.py
+++ b/taskcoachlib/gui/viewer/base.py
@@ -1213,8 +1213,9 @@ class SortableViewerWithColumns(
         self.widget.showSortOrder(self.imageIndex[self.getSortOrderImage()])
 
     def getSortOrderImage(self):
+        # Arrow points in direction of sort: down for A→Z/old→new, up for Z→A/new→old
         return (
-            "arrow_up_icon"
+            "arrow_down_icon"
             if self.isSortOrderAscending()
-            else "arrow_down_icon"
+            else "arrow_up_icon"
         )

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -40,8 +40,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.0"  # Major.Minor.Milestone
-patch = "81"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.0.81
+patch = "82"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.0.82
 
 release_day = "28"  # Day of the release (1-31)
 release_month = "December"  # Month of the release


### PR DESCRIPTION
The arrow now points in the direction of the sort order:
- Down arrow for ascending (A→Z, older→newer, lower→higher)
- Up arrow for descending (Z→A, newer→older, higher→lower)

This matches the intuitive expectation that the arrow indicates the direction values increase, like an axis on a diagram.

Fixes: https://sourceforge.net/p/taskcoach/bugs/1544/