### PR TITLE
Add tab navigation: mouse wheel scroll and Ctrl+Tab

### DIFF
--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -2051,14 +2051,21 @@ class Editor(BalloonTipManager, widgets.Dialog):
         # FIXME: there are more keyboard shortcuts that don't work in dialogs
         # at the moment, like DELETE
         self.__new_effort_id = IdProvider.get()
+        self.__next_tab_id = IdProvider.get()
+        self.__prev_tab_id = IdProvider.get()
         table = wx.AcceleratorTable(
             [
                 (wx.ACCEL_CMD, ord("Z"), wx.ID_UNDO),
                 (wx.ACCEL_CMD, ord("Y"), wx.ID_REDO),
                 (wx.ACCEL_CMD, ord("E"), self.__new_effort_id),
+                (wx.ACCEL_CTRL, wx.WXK_TAB, self.__next_tab_id),
+                (wx.ACCEL_CTRL | wx.ACCEL_SHIFT, wx.WXK_TAB, self.__prev_tab_id),
             ]
         )
         self._interior.SetAcceleratorTable(table)
+        # Bind tab navigation commands
+        self._interior.Bind(wx.EVT_MENU, self.__on_next_tab, id=self.__next_tab_id)
+        self._interior.Bind(wx.EVT_MENU, self.__on_prev_tab, id=self.__prev_tab_id)
         # pylint: disable=W0201
         self.__undo_command = uicommand.EditUndo()
         self.__redo_command = uicommand.EditRedo()
@@ -2073,6 +2080,14 @@ class Editor(BalloonTipManager, widgets.Dialog):
         self.__undo_command.bind(self._interior, wx.ID_UNDO)
         self.__redo_command.bind(self._interior, wx.ID_REDO)
         self.__new_effort_command.bind(self._interior, self.__new_effort_id)
+
+    def __on_next_tab(self, event):
+        """Handle Ctrl+Tab to move to next tab."""
+        self._interior.AdvanceSelectionForward()
+
+    def __on_prev_tab(self, event):
+        """Handle Ctrl+Shift+Tab to move to previous tab."""
+        self._interior.AdvanceSelectionBackward()
 
     def createInterior(self):
         return self.EditBookClass(
@@ -2097,6 +2112,8 @@ class Editor(BalloonTipManager, widgets.Dialog):
         if self.__timer is not None:
             IdProvider.put(self.__timer.GetId())
         IdProvider.put(self.__new_effort_id)
+        IdProvider.put(self.__next_tab_id)
+        IdProvider.put(self.__prev_tab_id)
         self.Destroy()
 
     def on_activate(self, event):

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -40,7 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.0"  # Major.Minor.Milestone
-patch = "82"  # Patch number - INCREMENT THIS for each release
+patch = "83"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.0.82
 
 release_day = "28"  # Day of the release (1-31)

--- a/taskcoachlib/widgets/masked.py
+++ b/taskcoachlib/widgets/masked.py
@@ -32,11 +32,12 @@ class FixOverwriteSelectionMixin(object):
         super()._SetSelection(start, end)
 
     def _OnKeyDown(self, event):
-        # Allow keyboard navigation in notebook. Just skipping the event does not work;
-        # propagate it all the way up...
+        # Allow Ctrl+Tab keyboard navigation in notebook.
+        # Just skipping the event does not work; propagate it all the way up...
+        # Note: Only handle Ctrl+Tab, not Shift+Tab (which is normal reverse navigation)
         if (
             event.GetKeyCode() == wx.WXK_TAB
-            and event.GetModifiers()
+            and event.ControlDown()
             and hasattr(self.GetParent(), "NavigateBook")
         ):
             if self.GetParent().NavigateBook(event):

--- a/taskcoachlib/widgets/notebook.py
+++ b/taskcoachlib/widgets/notebook.py
@@ -195,3 +195,23 @@ class Notebook(BookMixin, aui.AuiNotebook):
             & ~aui.AUI_NB_MIDDLE_CLICK_CLOSE
         )
         super().__init__(*args, **kwargs)
+        # Bind mouse wheel directly on the tab control for tab scrolling
+        tabCtrl = self.GetActiveTabCtrl()
+        if tabCtrl:
+            tabCtrl.Bind(wx.EVT_MOUSEWHEEL, self.__onTabMouseWheel)
+
+    def __onTabMouseWheel(self, event):
+        """Handle mouse wheel scrolling on the tab bar to switch tabs."""
+        rotation = event.GetWheelRotation()
+        if rotation > 0:
+            self.AdvanceSelection(False)  # Previous tab
+        elif rotation < 0:
+            self.AdvanceSelection(True)  # Next tab
+
+    def AdvanceSelectionForward(self):
+        """Move to the next tab (wraps around)."""
+        self.AdvanceSelection(True)
+
+    def AdvanceSelectionBackward(self):
+        """Move to the previous tab (wraps around)."""
+        self.AdvanceSelection(False)


### PR DESCRIPTION
- Add mouse wheel scrolling on tab bar to switch tabs (binds directly to AuiTabCtrl for proper event handling)
- Add Ctrl+Tab / Ctrl+Shift+Tab keyboard shortcuts for tab navigation (uses accelerator table at dialog level so shortcuts work regardless of focus)
- Applies to all editor dialogs (task editor, preferences, etc.)

moved from SF: possible to bring back scroll-wheel moving through tabs? #59

Completed with mouse scroll button and ctl-tab, which are the most common, see the table below:

```
Platform/Application       Mouse Wheel    Shortcut 1     Shortcut 2
-------------------------  -------------  -------------  -------------
Windows (general)          No             Ctrl+Tab       Ctrl+PgUp/Dn
macOS (general)            No             Cmd+Shift+]    Cmd+Opt+←/→
Linux GTK                  No             Ctrl+Tab       Ctrl+PgUp/Dn
Chrome/Firefox             Hover+Scroll   Ctrl+Tab       Ctrl+PgUp/Dn
VS Code                    Hover+Scroll   Ctrl+Tab       Ctrl+PgUp/Dn
IntelliJ/JetBrains         Hover+Scroll   Alt+←/→        Ctrl+PgUp/Dn
Sublime Text               No             Ctrl+Tab       Ctrl+PgUp/Dn
GNOME Terminal             No             Ctrl+Tab       Ctrl+PgUp/Dn
Kate (KDE)                 No             Ctrl+Tab       Ctrl+PgUp/Dn
```

**Summary:**
- **Ctrl+Tab**: Very common (Windows, Linux, most apps)
- **Ctrl+PgUp/PgDn**: Common but sometimes intercepted by scroll widgets
- **Mouse wheel over tabs**: Modern IDEs and browsers support this