### PR TITLE
Show (No categories defined yet) in empty Toggle Category menu

### DIFF
--- a/taskcoachlib/gui/menu.py
+++ b/taskcoachlib/gui/menu.py
@@ -940,7 +940,12 @@ class ToggleCategoryMenu(DynamicMenu):
 
     def updateMenuItems(self):
         self.clearMenu()
-        self.addMenuItemsForCategories(self.categories.rootItems(), self)
+        rootItems = self.categories.rootItems()
+        if rootItems:
+            self.addMenuItemsForCategories(rootItems, self)
+        else:
+            menuItem = self.Append(wx.ID_ANY, _("(No categories defined yet)"))
+            menuItem.Enable(False)
 
     def addMenuItemsForCategories(self, categories, menu):
         # pylint: disable=W0621

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -40,7 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.0"  # Major.Minor.Milestone
-patch = "83"  # Patch number - INCREMENT THIS for each release
+patch = "84"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.0.82
 
 release_day = "28"  # Day of the release (1-31)


### PR DESCRIPTION
When there are no categories, the Toggle Category submenu will now show a grayed-out "(No categories defined yet)" item instead of an empty box.  See screenshot below.

moved from SF: minor silly issue, "toggle category" is in the menus when categories don't exist #60