### PR TITLE
Fix double-click opening wrong item when clicking from another pane

### DIFF
--- a/taskcoachlib/gui/uicommand/uicommand.py
+++ b/taskcoachlib/gui/uicommand/uicommand.py
@@ -1355,8 +1355,10 @@ class Edit(mixin_uicommand.NeedsSelectionMixin, ViewerCommand):
             columnName = event.columnName
         except AttributeError:
             columnName = ""
+        # Use forceUpdate=True to ensure we get the current selection,
+        # not a stale cached value (important for fast double-click)
         editor = self.viewer.editItemDialog(
-            self.viewer.curselection(), self.bitmap, columnName
+            self.viewer.curselection(forceUpdate=True), self.bitmap, columnName
         )
         editor.Show(show)
 

--- a/taskcoachlib/gui/viewer/base.py
+++ b/taskcoachlib/gui/viewer/base.py
@@ -401,9 +401,17 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         self.__curselection = items
         self.widget.select(items)
 
-    def curselection(self):
+    def curselection(self, forceUpdate=False):
         """Return a list of items (domain objects) currently selected in our
-        widget."""
+        widget.
+
+        If forceUpdate is True, refresh the cached selection from the widget
+        before returning. This is useful when selection may have changed but
+        the cached value hasn't been updated yet (e.g., during double-click
+        handling where wx.CallAfter hasn't executed yet).
+        """
+        if forceUpdate:
+            self.updateSelection(sendViewerStatusEvent=False)
         return self.__curselection
 
     def curselectionIsInstanceOf(self, class_):

--- a/taskcoachlib/gui/viewer/effort.py
+++ b/taskcoachlib/gui/viewer/effort.py
@@ -608,8 +608,8 @@ class EffortViewer(
     def getItemImages(self, index, column=0):  # pylint: disable=W0613
         return {wx.TreeItemIcon_Normal: -1}
 
-    def curselection(self):
-        selection = super().curselection()
+    def curselection(self, forceUpdate=False):
+        selection = super().curselection(forceUpdate=forceUpdate)
         if self.aggregation != "details":
             selection = [
                 anEffort

--- a/taskcoachlib/gui/viewer/task.py
+++ b/taskcoachlib/gui/viewer/task.py
@@ -527,10 +527,10 @@ class TimelineViewer(BaseTaskTreeViewer):
         edit = uicommand.Edit(viewer=self)
         edit(item)
 
-    def curselection(self):
+    def curselection(self, forceUpdate=False):  # pylint: disable=W0613
         # Override curselection, because there is no need to translate indices
         # back to domain objects. Our widget already returns the selected domain
-        # object itself.
+        # object itself. forceUpdate is ignored since widget always returns fresh data.
         return self.widget.curselection()
 
     def bounds(self, item):
@@ -749,10 +749,10 @@ class SquareTaskViewer(BaseTaskTreeViewer):
             self.__zero = 0
         self.refresh()
 
-    def curselection(self):
+    def curselection(self, forceUpdate=False):  # pylint: disable=W0613
         # Override curselection, because there is no need to translate indices
         # back to domain objects. Our widget already returns the selected domain
-        # object itself.
+        # object itself. forceUpdate is ignored since widget always returns fresh data.
         return self.widget.curselection()
 
     def nrOfVisibleTasks(self):

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -40,7 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.0"  # Major.Minor.Milestone
-patch = "87"  # Patch number - INCREMENT THIS for each release
+patch = "88"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.0.82
 
 release_day = "29"  # Day of the release (1-31)


### PR DESCRIPTION
moved from SF: wrong item opened when double-clicking on *inactive* pane #52

When double-clicking on an item in one pane while an edit dialog from another pane was open, the previously selected item would open instead of the clicked item.

Root cause: The viewer's curselection() returns a cached value that is updated via wx.CallAfter in onSelect. When opening an edit dialog, the double-click event fires before CallAfter executes, so curselection() returns stale data.

Fix:
- Add forceUpdate parameter to curselection() that synchronously refreshes the cache before returning
- Use forceUpdate=True in Edit.doCommand() to ensure fresh selection
- Update curselection() overrides in task.py and effort.py to accept the new parameter