### PR TITLE
Fix debian package version and bump to 2.0.0.89

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -80,7 +80,7 @@ jobs:
             lintian \
             fakeroot
 
-      - name: Get version info
+      - name: Get version info and update debian/changelog
         id: version
         run: |
           # Extract version from meta/data.py
@@ -92,6 +92,19 @@ jobs:
           ")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"
+
+          # Update debian/changelog with the correct version
+          # This ensures the .deb package metadata matches the actual version
+          CODENAME="${{ matrix.codename }}"
+          DATE=$(date -R)
+          echo "taskcoach (${VERSION}-1) ${CODENAME}; urgency=medium" > debian/changelog
+          echo "" >> debian/changelog
+          echo "  * Release ${VERSION}" >> debian/changelog
+          echo "" >> debian/changelog
+          echo " -- Task Coach developers <developers@taskcoach.org>  ${DATE}" >> debian/changelog
+          echo "" >> debian/changelog
+          echo "Updated debian/changelog:"
+          cat debian/changelog
 
       - name: Bundle pip packages for distros with old versions
         run: |

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -40,7 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.0"  # Major.Minor.Milestone
-patch = "88"  # Patch number - INCREMENT THIS for each release
+patch = "89"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.0.82
 
 release_day = "29"  # Day of the release (1-31)


### PR DESCRIPTION
The debian/changelog had a hardcoded version, causing apt to see all .deb packages as version 2.0.0.80 regardless of the actual version. This prevented upgrades from working properly.

Fix: Dynamically generate debian/changelog with the correct version from data.py before building, matching how the RPM build works.

strange apt install issue, not updating without removing first #79