### PR TITLE
Fix .tsk file argument handling for Python 3

### DIFF
--- a/taskcoachlib/application/application.py
+++ b/taskcoachlib/application/application.py
@@ -534,7 +534,7 @@ class Application(object, metaclass=patterns.Singleton):
 
         # Get filename from args or last file
         if self._args:
-            filename = self._args[0].decode(sys.getfilesystemencoding())
+            filename = self._args[0]
         else:
             filename = self.settings.get("file", "lastfile")
 

--- a/taskcoachlib/gui/iocontroller.py
+++ b/taskcoachlib/gui/iocontroller.py
@@ -129,7 +129,7 @@ class IOController(object):
                 'skip' = file locked, user chose not to break (start fresh)
         """
         if commandLineArgs:
-            filename = commandLineArgs[0].decode(sys.getfilesystemencoding())
+            filename = commandLineArgs[0]
         else:
             filename = self.__settings.get("file", "lastfile")
         if filename:

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -40,10 +40,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.0"  # Major.Minor.Milestone
-patch = "90"  # Patch number - INCREMENT THIS for each release
+patch = "91"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.0.82
 
-release_day = "29"  # Day of the release (1-31)
+release_day = "30"  # Day of the release (1-31)
 release_month = "December"  # Month of the release
 release_year = "2025"  # Year of the release
 


### PR DESCRIPTION
Command line arguments are already strings in Python 3, so calling .decode() on them causes AttributeError. This prevented opening .tsk files via command line, file manager double-click, or right-click "Open with".

Opening a .tsk file directly from file manager does not work #24