### PR TITLE
Fix column selection broken by Wayland popup menu fix

### DIFF
--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -40,7 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.0"  # Major.Minor.Milestone
-patch = "93"  # Patch number - INCREMENT THIS for each release
+patch = "94"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.0.82
 
 release_day = "2"  # Day of the release (1-31)

--- a/taskcoachlib/widgets/searchctrl.py
+++ b/taskcoachlib/widgets/searchctrl.py
@@ -97,10 +97,7 @@ class SearchCtrl(tooltip.ToolTipMixin, wx.SearchCtrl):
         x, y = rect[0], rect[1] + rect[3] + 3
         # Hide tooltip first to avoid Wayland popup parent conflict
         self.HideTip()
-        # Use top-level parent for Wayland compatibility
-        pos = self.ClientToScreen(wx.Point(x, y))
-        pos = self.GetTopLevelParent().ScreenToClient(pos)
-        self.GetTopLevelParent().PopupMenu(self.Getmenu(), pos)
+        super().PopupMenu(self.Getmenu(), wx.Point(x, y))
 
     def bindEventHandlers(self):
         # pylint: disable=W0142,W0612,W0201

--- a/taskcoachlib/widgets/tooltip.py
+++ b/taskcoachlib/widgets/tooltip.py
@@ -50,8 +50,7 @@ class ToolTipMixin(object):
         # Hide any visible tooltip first to avoid Wayland popup parent conflict
         # (GTK bug #1785: popup menus fail when tooltip is visible)
         self.HideTip()
-        # Use top-level parent for Wayland compatibility
-        self.GetTopLevelParent().PopupMenu(menu)
+        super().PopupMenu(menu)
         self.__frozen = True
 
     def ShowTip(self, x, y):


### PR DESCRIPTION
The Wayland fix incorrectly called PopupMenu on GetTopLevelParent() instead of self. This broke event routing because menu events were bound to the viewer/widget but sent to the main window.

The actual fix for Wayland (GTK bug #1785) is just hiding the tooltip before showing the popup - no need to change which window calls PopupMenu.

Fixes: column add/remove not working, settings not persisting

