### PR TITLE
Add GitHub repository info documentation

### DIFF
--- a/docs/GITHUB_INFO.md
+++ b/docs/GITHUB_INFO.md
@@ -1,0 +1,31 @@
+# GitHub Repository Information
+
+This file tracks the GitHub repository metadata for Task Coach.
+
+## Homepage
+
+https://github.com/taskcoach/taskcoach
+
+## About Description
+
+Task Coach is a free, open-source task manager for organizing projects, tracking time, managing recurring tasks, and planning with due dates and reminders. Break down projects into subtasks, categorize and filter tasks, attach notes and files, and visualize your work in list, tree, calendar, or timeline views. Cross-platform desktop app.
+
+## Topics
+
+```
+desktop-app
+gtd
+linux
+macos
+open-source
+cross-platform
+productivity
+project-management
+python
+python3
+task-manager
+time-tracking
+todo-app
+windows
+wxpython
+```


### PR DESCRIPTION
Track the GitHub About description and topics in docs/GITHUB_INFO.md for version control of repository metadata.