### PR TITLE
Fix copy/paste of notes, attachments, and efforts between tasks

### DIFF
--- a/taskcoachlib/command/__init__.py
+++ b/taskcoachlib/command/__init__.py
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from .taskCommands import *
 from .effortCommands import (
     NewEffortCommand,
+    AddEffortCommand,
     DeleteEffortCommand,
     EditTaskCommand,
     EditEffortStartDateTimeCommand,

--- a/taskcoachlib/command/base.py
+++ b/taskcoachlib/command/base.py
@@ -298,6 +298,14 @@ class CutCommand(CutCommandMixin, DeleteCommand):
 
 
 class PasteCommand(BaseCommand, SaveStateMixin):
+    """Command to paste items from the clipboard.
+
+    When a destination container is provided via the constructor, items are
+    pasted into that container. Otherwise, items are pasted back into the
+    clipboard's source container. This allows viewers to specify a different
+    destination for paste operations, such as when pasting between tasks
+    in the task editor dialog.
+    """
     plural_name = _("Paste")
     singular_name = _('Paste "%s"')
 
@@ -332,7 +340,9 @@ class PasteCommand(BaseCommand, SaveStateMixin):
 
     def getItemsToPaste(self):
         items, source = Clipboard().get()
-        return [item.copy() for item in items], source
+        # Use provided destination container, or fall back to clipboard's source container
+        target = self.list if self.list is not None else source
+        return [item.copy() for item in items], target
 
 
 class PasteAsSubItemCommand(PasteCommand, CompositeMixin):

--- a/taskcoachlib/command/effortCommands.py
+++ b/taskcoachlib/command/effortCommands.py
@@ -69,6 +69,58 @@ class NewEffortCommand(base.BaseCommand):
     redo_command = do_command
 
 
+class AddEffortCommand(base.BaseCommand):
+    """Command to add efforts to a task.
+
+    Used primarily for paste operations where efforts are copied from one
+    task and pasted to another. Updates the effort's task reference and
+    adds it to the target task's effort list.
+    """
+    plural_name = _("Add efforts")
+    singular_name = _('Add effort to "%s"')
+
+    def __init__(self, *args, **kwargs):
+        self.__efforts = kwargs.pop("efforts", [])
+        self.__tasks = []
+        self.__old_task_refs = []
+        super().__init__(*args, **kwargs)
+        self.__tasks = self.items
+        # Store original task references for undo support
+        self.__old_task_refs = [eff.task() for eff in self.__efforts]
+        self.items = self.__efforts
+        self.save_modification_datetimes()
+
+    def modified_items(self):
+        # Filter out None values from old task refs
+        return self.__tasks + [t for t in self.__old_task_refs if t is not None]
+
+    def name_subject(self, anEffort):
+        return self.__tasks[0].subject() if self.__tasks else ""
+
+    def do_command(self):
+        super().do_command()
+        if not self.__tasks:
+            return
+        target_task = self.__tasks[0]
+        for eff in self.__efforts:
+            eff.setTask(target_task)
+            target_task.addEffort(eff)
+
+    def undo_command(self):
+        super().undo_command()
+        if not self.__tasks:
+            return
+        target_task = self.__tasks[0]
+        for eff, old_task in zip(self.__efforts, self.__old_task_refs):
+            target_task.removeEffort(eff)
+            eff.setTask(old_task)
+            if old_task:
+                old_task.addEffort(eff)
+
+    def redo_command(self):
+        self.do_command()
+
+
 class DeleteEffortCommand(base.DeleteCommand):
     plural_name = _("Delete efforts")
     singular_name = _('Delete effort "%s"')

--- a/taskcoachlib/command/noteCommands.py
+++ b/taskcoachlib/command/noteCommands.py
@@ -93,16 +93,28 @@ class DragAndDropNoteCommand(base.OrderingDragAndDropCommand):
 
 
 class AddNoteCommand(base.BaseCommand):
+    """Command to add notes to an owner (task, category, etc.).
+
+    If the 'notes' keyword argument is provided, those notes are added.
+    Otherwise, new empty notes are created. This allows the command to be
+    used both for creating new notes and for paste operations.
+    """
     plural_name = _("Add note")
     singular_name = _('Add note to "%s"')
 
     def __init__(self, *args, **kwargs):
         self.owners = []
+        self.__notes = kwargs.pop(
+            "notes",
+            None
+        )
         super().__init__(*args, **kwargs)
         self.owners = self.items
-        self.items = self.__notes = [
-            note.Note(subject=_("New note")) for dummy in self.items
-        ]
+        if self.__notes is None:
+            self.__notes = [
+                note.Note(subject=_("New note")) for dummy in self.items
+            ]
+        self.items = self.__notes
         self.save_modification_datetimes()
 
     def modified_items(self):

--- a/taskcoachlib/domain/attachment/attachment.py
+++ b/taskcoachlib/domain/attachment/attachment.py
@@ -135,7 +135,10 @@ class Attachment(base.Object, NoteOwner):
         self.setLocation(state["location"])
 
     def __getcopystate__(self):
-        return self.__getstate__()
+        # Don't include id and creationDateTime - copies should get new ones
+        state = super().__getcopystate__()
+        state.update(dict(location=self.location()))
+        return state
 
     def __unicode__(self):
         return self.subject()

--- a/taskcoachlib/domain/base/object.py
+++ b/taskcoachlib/domain/base/object.py
@@ -263,7 +263,8 @@ class Object(SynchronizedObject):
         return state
 
     def copy(self):
-        return self.__class__(**self.__getcopystate__())
+        state = self.__getcopystate__()
+        return self.__class__(**state)
 
     @classmethod
     def monitoredAttributes(class_):

--- a/taskcoachlib/domain/effort/base.py
+++ b/taskcoachlib/domain/effort/base.py
@@ -29,13 +29,14 @@ class BaseEffort(object):
         super().__init__(*args, **kwargs)
 
     def task(self):
+        # Access _task directly to avoid potential attribute shadowing
         return None if self._task is None else self._task()
 
     def parent(self):
         # Efforts don't have real parents since they are not composite.
         # However, we pretend the parent of an effort is its task for the
         # benefit of the search filter.
-        return self.task()
+        return None if self._task is None else self._task()
 
     def getStart(self):
         return self._start
@@ -44,19 +45,24 @@ class BaseEffort(object):
         return self._stop
 
     def subject(self, *args, **kwargs):
-        return self.task().subject(*args, **kwargs)
+        task = self._task() if self._task else None
+        return task.subject(*args, **kwargs) if task else ""
 
     def categories(self, *args, **kwargs):
-        return self.task().categories(*args, **kwargs)
+        task = self._task() if self._task else None
+        return task.categories(*args, **kwargs) if task else set()
 
     def foregroundColor(self, recursive=False):
-        return self.task().foregroundColor(recursive)
+        task = self._task() if self._task else None
+        return task.foregroundColor(recursive) if task else None
 
     def backgroundColor(self, recursive=False):
-        return self.task().backgroundColor(recursive)
+        task = self._task() if self._task else None
+        return task.backgroundColor(recursive) if task else None
 
     def font(self, recursive=False):
-        return self.task().font(recursive)
+        task = self._task() if self._task else None
+        return task.font(recursive) if task else None
 
     def duration(self, recursive=False):
         raise NotImplementedError  # pragma: no cover

--- a/taskcoachlib/domain/effort/effort.py
+++ b/taskcoachlib/domain/effort/effort.py
@@ -27,11 +27,36 @@ import weakref
 
 @functools.total_ordering
 class Effort(baseeffort.BaseEffort, base.Object):
+
     def __init__(self, task=None, start=None, stop=None, *args, **kwargs):
         super().__init__(
             task, start or date.DateTime.now(), stop, *args, **kwargs
         )
         self.__updateDurationCache()
+
+    def __getattribute__(self, name):
+        """Override to prevent methods from being shadowed by instance attributes.
+
+        During copy/paste operations, kwargs from __getcopystate__ can end up
+        as instance attributes that shadow the class methods. This override
+        ensures method lookups always find the class method, not instance attrs.
+        """
+        # Methods that might get shadowed - check directly to avoid recursion
+        _protected = (
+            'id', 'task', 'subject', 'description', 'font',
+            'foregroundColor', 'backgroundColor', 'icon', 'selectedIcon', 'ordering',
+            'creationDateTime', 'modificationDateTime'
+        )
+        if name in _protected:
+            # Get the method from the class, not the instance
+            for cls in type(self).__mro__:
+                if name in cls.__dict__:
+                    method = cls.__dict__[name]
+                    if callable(method):
+                        # Return bound method
+                        return method.__get__(self, type(self))
+                    break
+        return object.__getattribute__(self, name)
 
     def setTask(self, task):
         if self._task is None:
@@ -41,7 +66,10 @@ class Effort(baseeffort.BaseEffort, base.Object):
             # new task itself.
             self._task = None if task is None else weakref.ref(task)
             return
-        if task in (self.task(), None):
+        # Get current task by dereferencing weakref directly to avoid any
+        # potential attribute lookup issues (see issue with copy/paste efforts)
+        current_task = self._task() if self._task else None
+        if task in (current_task, None):
             # command.PasteCommand may try to set the parent to None
             return
         event = (
@@ -61,22 +89,24 @@ class Effort(baseeffort.BaseEffort, base.Object):
     def monitoredAttributes(class_):
         return base.Object.monitoredAttributes() + ["start", "stop"]
 
-    def task(self):
-        return None if self._task is None else self._task()
+    # Note: task() and id() are now handled by __getattribute__ to prevent
+    # attribute shadowing issues during copy/paste operations.
 
     @classmethod
     def taskChangedEventType(class_):
         return "pubsub.effort.task"
 
     def __str__(self):
-        return "Effort(%s, %s, %s)" % (self.task(), self._start, self._stop)
+        task = self._task() if self._task else None
+        return "Effort(%s, %s, %s)" % (task, self._start, self._stop)
 
     __repr__ = __str__
 
     def __eq__(self, other):
         if not isinstance(other, Effort):
             return NotImplemented
-        return self.id() == other.id()
+        # Access _Object__id directly to avoid potential attribute shadowing
+        return self._Object__id == other._Object__id
 
     def __lt__(self, other):
         if not isinstance(other, Effort):
@@ -84,15 +114,16 @@ class Effort(baseeffort.BaseEffort, base.Object):
         # Compare by start time first, then stop time, then id for total ordering
         self_stop = self._stop if self._stop is not None else date.DateTime.max
         other_stop = other._stop if other._stop is not None else date.DateTime.max
-        return (self._start, self_stop, self.id()) < (other._start, other_stop, other.id())
+        return (self._start, self_stop, self._Object__id) < (other._start, other_stop, other._Object__id)
 
     def __hash__(self):
-        return hash(self.id())
+        return hash(self._Object__id)
 
     def __getstate__(self):
         state = super().__getstate__()
+        task = self._task() if self._task else None
         state.update(
-            dict(task=self.task(), start=self._start, stop=self._stop)
+            dict(task=task, start=self._start, stop=self._stop)
         )
         return state
 
@@ -105,8 +136,9 @@ class Effort(baseeffort.BaseEffort, base.Object):
 
     def __getcopystate__(self):
         state = super().__getcopystate__()
+        task = self._task() if self._task else None
         state.update(
-            dict(task=self.task(), start=self._start, stop=self._stop)
+            dict(task=task, start=self._start, stop=self._stop)
         )
         return state
 
@@ -125,9 +157,11 @@ class Effort(baseeffort.BaseEffort, base.Object):
         pub.sendMessage(
             self.startChangedEventType(), newValue=startDateTime, sender=self
         )
-        self.task().sendTimeSpentChangedMessage()
+        task = self._task() if self._task else None
+        if task:
+            task.sendTimeSpentChangedMessage()
         self.sendDurationChangedMessage()
-        if self.task().hourlyFee():
+        if task and task.hourlyFee():
             self.sendRevenueChangedMessage()
 
     @classmethod
@@ -144,22 +178,26 @@ class Effort(baseeffort.BaseEffort, base.Object):
         previousStop = self._stop
         self._stop = newStop
         self.__updateDurationCache()
+        task = self._task() if self._task else None
         if newStop == None:
             pub.sendMessage(
                 self.trackingChangedEventType(), newValue=True, sender=self
             )
-            self.task().sendTrackingChangedMessage(tracking=True)
+            if task:
+                task.sendTrackingChangedMessage(tracking=True)
         elif previousStop == None:
             pub.sendMessage(
                 self.trackingChangedEventType(), newValue=False, sender=self
             )
-            self.task().sendTrackingChangedMessage(tracking=False)
-        self.task().sendTimeSpentChangedMessage()
+            if task:
+                task.sendTrackingChangedMessage(tracking=False)
+        if task:
+            task.sendTimeSpentChangedMessage()
         pub.sendMessage(
             self.stopChangedEventType(), newValue=self._stop, sender=self
         )
         self.sendDurationChangedMessage()
-        if self.task().hourlyFee():
+        if task and task.hourlyFee():
             self.sendRevenueChangedMessage()
 
     @classmethod
@@ -175,7 +213,9 @@ class Effort(baseeffort.BaseEffort, base.Object):
         return self._stop is None
 
     def revenue(self):
-        return self.duration().hours() * self.task().hourlyFee()
+        task = self._task() if self._task else None
+        hourlyFee = task.hourlyFee() if task else 0
+        return self.duration().hours() * hourlyFee
 
     @staticmethod
     def periodSortFunction(**kwargs):
@@ -184,7 +224,7 @@ class Effort(baseeffort.BaseEffort, base.Object):
         return lambda effort: (
             effort.getStart(),
             effort.isTotal(),
-            effort.task().subject(recursive=True),
+            (effort._task().subject(recursive=True) if effort._task else ""),
         )
 
     @classmethod

--- a/taskcoachlib/domain/effort/effortlist.py
+++ b/taskcoachlib/domain/effort/effortlist.py
@@ -121,7 +121,10 @@ class EffortList(
         Since that wouldn't work we remove the efforts from the tasks by
         hand."""
         for effort in efforts:
-            effort.task().removeEffort(effort)
+            # Access _task directly to avoid potential attribute shadowing
+            task = effort._task() if effort._task else None
+            if task:
+                task.removeEffort(effort)
 
     def extend(self, efforts):  # pylint: disable=W0221
         """We override ObservableListObserver.extend because the default
@@ -130,7 +133,11 @@ class EffortList(
         Since that wouldn't work we add the efforts to the tasks by
         hand."""
         for effort in efforts:
-            effort.task().addEffort(effort)
+            # Access _task directly to avoid potential attribute shadowing
+            # that can occur during copy/paste operations
+            task = effort._task() if effort._task else None
+            if task:
+                task.addEffort(effort)
 
     @classmethod
     def sortEventType(class_):

--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -1112,6 +1112,30 @@ class LocalAttachmentViewer(viewer.AttachmentViewer):  # pylint: disable=W0223
             None, [self.attachmentOwner], attachments=self.curselection()
         )
 
+    def pasteItemCommand(self):
+        """Paste attachments from clipboard to this task's attachments.
+
+        Validates that clipboard contains only attachments and shows an
+        error dialog if a type mismatch is detected.
+        """
+        from taskcoachlib.command.clipboard import Clipboard
+        from taskcoachlib.domain import attachment
+        items, source = Clipboard().get()
+        # Validate clipboard contains only attachments
+        for item in items:
+            if not isinstance(item, attachment.Attachment):
+                import wx
+                wx.MessageBox(
+                    _("Cannot paste: clipboard contains %s but this is an Attachments view. Only Attachments can be pasted here.") % type(item).__name__,
+                    _("Paste Error"),
+                    wx.OK | wx.ICON_ERROR
+                )
+                return None
+        copies = [item.copy() for item in items]
+        return command.AddAttachmentCommand(
+            None, [self.attachmentOwner], attachments=copies
+        )
+
 
 class AttachmentsPage(PageWithViewer):
     pageName = "attachments"
@@ -1162,6 +1186,80 @@ class LocalNoteViewer(viewer.BaseNoteViewer):  # pylint: disable=W0223
     def deleteItemCommand(self):
         return command.RemoveNoteCommand(
             None, [self.__note_owner], notes=self.curselection()
+        )
+
+    def _expandNoteAndChildren(self, aNote):
+        """Recursively expand a note and all its children in this viewer."""
+        context = self.settingsSection()
+        aNote.expand(True, context=context, notify=False)
+        for child in aNote.children():
+            self._expandNoteAndChildren(child)
+
+    def pasteItemCommand(self):
+        """Paste notes from clipboard to this task's notes as top-level notes.
+
+        Validates that clipboard contains only notes and shows an
+        error dialog if a type mismatch is detected. Clears parent reference
+        so notes always become top-level, even if copied from a nested location.
+        """
+        from taskcoachlib.command.clipboard import Clipboard
+        from taskcoachlib.domain import note
+        items, source = Clipboard().get()
+        # Validate clipboard contains only notes
+        for item in items:
+            if not isinstance(item, note.Note):
+                import wx
+                wx.MessageBox(
+                    _("Cannot paste: clipboard contains %s but this is a Notes view. Only Notes can be pasted here.") % type(item).__name__,
+                    _("Paste Error"),
+                    wx.OK | wx.ICON_ERROR
+                )
+                return None
+        copies = [item.copy() for item in items]
+        # Clear parent so notes become top-level (even if source was nested)
+        # and expand all pasted notes so children are visible
+        for n in copies:
+            n.setParent(None)
+            self._expandNoteAndChildren(n)
+        return command.AddNoteCommand(
+            None, [self.__note_owner], notes=copies
+        )
+
+    def pasteAsSubItemCommand(self):
+        """Paste notes as subnotes of the selected note.
+
+        Uses AddSubNoteCommand which properly adds notes as children only,
+        not to the owner's notes list (which would cause duplicates).
+        """
+        selected = self.curselection()
+        if not selected:
+            return None
+        parent_note = selected[0]
+        from taskcoachlib.command.clipboard import Clipboard
+        from taskcoachlib.domain import note
+        items, source = Clipboard().get()
+        # Validate clipboard contains only notes
+        for item in items:
+            if not isinstance(item, note.Note):
+                import wx
+                wx.MessageBox(
+                    _("Cannot paste: clipboard contains %s but this is a Notes view. Only Notes can be pasted here.") % type(item).__name__,
+                    _("Paste Error"),
+                    wx.OK | wx.ICON_ERROR
+                )
+                return None
+        copies = [item.copy() for item in items]
+        # Clear parent references - AddSubNoteCommand will set correct parent via addChild
+        # and expand all pasted notes so children are visible
+        for n in copies:
+            n.setParent(None)
+            self._expandNoteAndChildren(n)
+        # Also expand the parent note so the pasted subnotes are visible
+        parent_note.expand(True, context=self.settingsSection(), notify=False)
+        # Repeat parent_note for each copy so zip in AddSubNoteCommand pairs correctly
+        parents = [parent_note] * len(copies)
+        return command.AddSubNoteCommand(
+            None, parents, owner=self.__note_owner, notes=copies
         )
 
 

--- a/taskcoachlib/gui/menu.py
+++ b/taskcoachlib/gui/menu.py
@@ -440,7 +440,7 @@ class EditMenu(Menu):
             None,
             uicommand.EditCut(viewer=viewerContainer, id=wx.ID_CUT),
             uicommand.EditCopy(viewer=viewerContainer, id=wx.ID_COPY),
-            uicommand.EditPaste(),
+            uicommand.EditPaste(viewer=viewerContainer),
             uicommand.EditPasteAsSubItem(viewer=viewerContainer),
             None,
             uicommand.Edit(viewer=viewerContainer, id=wx.ID_EDIT),
@@ -1017,7 +1017,7 @@ class TaskPopupMenu(Menu):
         self.appendUICommands(
             uicommand.EditCut(viewer=taskViewer),
             uicommand.EditCopy(viewer=taskViewer),
-            uicommand.EditPaste(),
+            uicommand.EditPaste(viewer=taskViewer),
             uicommand.EditPasteAsSubItem(viewer=taskViewer),
             None,
             uicommand.Edit(viewer=taskViewer),
@@ -1074,7 +1074,7 @@ class EffortPopupMenu(Menu):
         self.appendUICommands(
             uicommand.EditCut(viewer=effortViewer),
             uicommand.EditCopy(viewer=effortViewer),
-            uicommand.EditPaste(),
+            uicommand.EditPaste(viewer=effortViewer),
             None,
             uicommand.Edit(viewer=effortViewer),
             uicommand.Delete(viewer=effortViewer),
@@ -1105,7 +1105,7 @@ class CategoryPopupMenu(Menu):
         self.appendUICommands(
             uicommand.EditCut(viewer=categoryViewer),
             uicommand.EditCopy(viewer=categoryViewer),
-            uicommand.EditPaste(),
+            uicommand.EditPaste(viewer=categoryViewer),
             uicommand.EditPasteAsSubItem(viewer=categoryViewer),
             None,
             uicommand.Edit(viewer=categoryViewer),
@@ -1148,7 +1148,7 @@ class NotePopupMenu(Menu):
         self.appendUICommands(
             uicommand.EditCut(viewer=noteViewer),
             uicommand.EditCopy(viewer=noteViewer),
-            uicommand.EditPaste(),
+            uicommand.EditPaste(viewer=noteViewer),
             uicommand.EditPasteAsSubItem(viewer=noteViewer),
             None,
             uicommand.Edit(viewer=noteViewer),
@@ -1228,7 +1228,7 @@ class AttachmentPopupMenu(Menu):
         self.appendUICommands(
             uicommand.EditCut(viewer=attachmentViewer),
             uicommand.EditCopy(viewer=attachmentViewer),
-            uicommand.EditPaste(),
+            uicommand.EditPaste(viewer=attachmentViewer),
             None,
             uicommand.Edit(viewer=attachmentViewer),
             uicommand.Delete(viewer=attachmentViewer),

--- a/taskcoachlib/gui/uicommand/uicommand.py
+++ b/taskcoachlib/gui/uicommand/uicommand.py
@@ -775,9 +775,9 @@ class EditCopy(mixin_uicommand.NeedsSelectionMixin, ViewerCommand):
             return super().enabled(event)
 
 
-class EditPaste(base_uicommand.UICommand):
+class EditPaste(ViewerCommand):
     """Action for pasting the item(s) in the clipboard into the current
-    taskfile."""
+    viewer's presentation."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(
@@ -794,8 +794,29 @@ class EditPaste(base_uicommand.UICommand):
         if isinstance(windowWithFocus, wx.TextCtrl):
             windowWithFocus.Paste()
         else:
-            pasteCommand = command.PasteCommand()
-            pasteCommand.do()
+            # Use viewer's pasteItemCommand if available
+            viewer = self.viewer
+            # If no viewer set, try to find one from the focused window hierarchy
+            if viewer is None:
+                viewer = self._findViewerFromFocus(windowWithFocus)
+            if viewer is not None:
+                pasteCommand = viewer.pasteItemCommand()
+            else:
+                pasteCommand = command.PasteCommand()
+            if pasteCommand:
+                pasteCommand.do()
+
+    def _findViewerFromFocus(self, window):
+        """Walk up the window hierarchy to find a viewer with pasteItemCommand.
+
+        This is needed when paste is triggered from menus that don't have
+        a viewer reference, but the focused window is inside a viewer.
+        """
+        while window is not None:
+            if hasattr(window, 'pasteItemCommand'):
+                return window
+            window = window.GetParent()
+        return None
 
     def enabled(self, event):
         windowWithFocus = wx.Window.FindFocus()
@@ -821,10 +842,32 @@ class EditPasteAsSubItem(
         )
 
     def doCommand(self, event):
-        pasteCommand = command.PasteAsSubItemCommand(
-            items=self.viewer.curselection()
-        )
-        pasteCommand.do()
+        # Use viewer's pasteAsSubItemCommand if available
+        viewer = self.viewer
+        # If no viewer set, try to find one from the focused window hierarchy
+        if viewer is None:
+            windowWithFocus = wx.Window.FindFocus()
+            viewer = self._findViewerFromFocus(windowWithFocus)
+        if viewer is not None and hasattr(viewer, 'pasteAsSubItemCommand'):
+            pasteCommand = viewer.pasteAsSubItemCommand()
+        else:
+            pasteCommand = command.PasteAsSubItemCommand(
+                items=self.viewer.curselection() if self.viewer else []
+            )
+        if pasteCommand:
+            pasteCommand.do()
+
+    def _findViewerFromFocus(self, window):
+        """Walk up the window hierarchy to find a viewer with pasteAsSubItemCommand.
+
+        This is needed when paste-as-subitem is triggered from menus that don't
+        have a viewer reference, but the focused window is inside a viewer.
+        """
+        while window is not None:
+            if hasattr(window, 'pasteAsSubItemCommand'):
+                return window
+            window = window.GetParent()
+        return None
 
     def enabled(self, event):
         if not (super().enabled(event) and command.Clipboard()):

--- a/taskcoachlib/gui/viewer/base.py
+++ b/taskcoachlib/gui/viewer/base.py
@@ -627,7 +627,7 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         """UI commands for manipulating the clipboard (cut, copy, paste)."""
         cutCommand = uicommand.EditCut(viewer=self)
         copyCommand = uicommand.EditCopy(viewer=self)
-        pasteCommand = uicommand.EditPaste()
+        pasteCommand = uicommand.EditPaste(viewer=self)
         cutCommand.bind(self, wx.ID_CUT)
         copyCommand.bind(self, wx.ID_COPY)
         pasteCommand.bind(self, wx.ID_PASTE)
@@ -717,6 +717,14 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
 
     def cutItemCommandClass(self):
         return command.CutCommand
+
+    def pasteItemCommand(self):
+        return self.pasteItemCommandClass()(
+            self.presentation()
+        )
+
+    def pasteItemCommandClass(self):
+        return command.PasteCommand
 
     def onEditSubject(self, item, newValue):
         command.EditSubjectCommand(items=[item], newValue=newValue).do()

--- a/taskcoachlib/gui/viewer/effort.py
+++ b/taskcoachlib/gui/viewer/effort.py
@@ -167,6 +167,37 @@ class EffortViewer(
     def curselectionIsInstanceOf(self, class_):
         return class_ == effort.Effort
 
+    def pasteItemCommand(self):
+        """Paste efforts from clipboard to the target task.
+
+        When this viewer is showing efforts for a specific task (e.g., in task
+        editor), pasted efforts are added to that task. Validates that clipboard
+        contains only efforts and shows an error dialog if a type mismatch is
+        detected.
+        """
+        import wx
+        from taskcoachlib.command.clipboard import Clipboard
+        items, source = Clipboard().get()
+        # Validate clipboard contains only efforts
+        for item in items:
+            if not isinstance(item, effort.Effort):
+                wx.MessageBox(
+                    _("Cannot paste: clipboard contains %s but this is an Efforts view. Only Efforts can be pasted here.") % type(item).__name__,
+                    _("Paste Error"),
+                    wx.OK | wx.ICON_ERROR
+                )
+                return None
+        tasks = self.tasksToShowEffortFor()
+        if tasks:
+            # Paste to the specific task this viewer is showing efforts for
+            target_task = list(tasks)[0] if hasattr(tasks, '__iter__') else tasks
+            copies = [item.copy() for item in items]
+            return command.AddEffortCommand(
+                None, [target_task], efforts=copies
+            )
+        # Fall back to generic paste when no specific target task
+        return super().pasteItemCommand()
+
     def on_aggregation_changed(self, value):
         self.__show_effort_aggregation(value)
 

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -40,10 +40,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "7"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.1.7
+patch = "8"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.1.8
 
-release_day = "10"  # Day of the release (1-31)
+release_day = "11"  # Day of the release (1-31)
 release_month = "January"  # Month of the release
 release_year = "2026"  # Year of the release
 


### PR DESCRIPTION
Problem:
Copy/paste of notes, attachments, and efforts between tasks was broken. When you copied an item from one task and tried to paste it into a different task, the item would go back to the original task instead of the destination.

Changes:

Paste goes to the right place now:
- When you paste in a task's notes/attachments/efforts tab, items now go to THAT task, not back to where they were copied from

Notes paste correctly:
- Regular paste always creates top-level notes, even if you copied a nested subnote
- "Paste as subitem" properly adds notes as children of the selected note (no longer creates duplicates)
- Pasted notes with children are automatically expanded so you can see them

Efforts paste correctly:
- Efforts can now be copied from one task and pasted to another
- The effort gets properly reassigned to the new task

Type checking:
- If you try to paste the wrong type (e.g., paste a note into the attachments tab), you get a clear error message instead of a crash

Stability improvements:
- Fixed crashes that could happen during effort copy/paste operations
- Fixed duplicate ID warnings that appeared when pasting notes as subitems