### PR TITLE
Fix relative time picker using wrong start time for calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| Windows | `TaskCoach-2.0.1.9-windows-x64-setup.exe` |
-| Windows (portable) | `TaskCoach-2.0.1.9-windows-x64-portable.zip` | 
-| Debian 12 (Bookworm) | `taskcoach_2.0.1.9_debian-12-bookworm.deb` |
-| Debian 13 (Trixie) | `taskcoach_2.0.1.9_debian-13-trixie.deb` |
-| Debian Sid | `taskcoach_2.0.1.9_debian-sid.deb` |
-| Ubuntu 22.04 (Jammy) | `taskcoach_2.0.1.9_ubuntu-22.04-jammy.deb` |
-| Ubuntu 24.04 (Noble) | `taskcoach_2.0.1.9_ubuntu-24.04-noble.deb` |
+| Windows | `TaskCoach-2.0.1.10-windows-x64-setup.exe` |
+| Windows (portable) | `TaskCoach-2.0.1.10-windows-x64-portable.zip` | 
+| Debian 12 (Bookworm) | `taskcoach_2.0.1.10_debian-12-bookworm.deb` |
+| Debian 13 (Trixie) | `taskcoach_2.0.1.10_debian-13-trixie.deb` |
+| Debian Sid | `taskcoach_2.0.1.10_debian-sid.deb` |
+| Ubuntu 22.04 (Jammy) | `taskcoach_2.0.1.10_ubuntu-22.04-jammy.deb` |
+| Ubuntu 24.04 (Noble) | `taskcoach_2.0.1.10_ubuntu-24.04-noble.deb` |
 | Linux Mint | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| Arch Linux / Manjaro | `taskcoach-2.0.1.9-arch.pkg.tar.zst` |
-| Fedora 39/40 | `taskcoach-2.0.1.9-fedora40.noarch.rpm` |
-| Any Linux (x86_64) | `TaskCoach-2.0.1.9-x86_64.AppImage` |
+| Arch Linux / Manjaro | `taskcoach-2.0.1.10-arch.pkg.tar.zst` |
+| Fedora 39/40 | `taskcoach-2.0.1.10-fedora40.noarch.rpm` |
+| Any Linux (x86_64) | `TaskCoach-2.0.1.10-x86_64.AppImage` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -28,8 +28,8 @@ After installing, Task Coach should be in normal system launchers (Applications 
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.9_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.9_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.10_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.10_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -42,8 +42,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.9-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.9-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.10-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.10-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.9-fedora40.noarch.rpm
-sudo dnf install ./taskcoach-2.0.1.9-fedora40.noarch.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.10-fedora40.noarch.rpm
+sudo dnf install ./taskcoach-2.0.1.10-fedora40.noarch.rpm
 ```
 
 To uninstall:
@@ -70,13 +70,13 @@ sudo dnf autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.9-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.9-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.10-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.10-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.9-x86_64.AppImage
+./TaskCoach-2.0.1.10-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -510,6 +510,35 @@ class DatesPage(Page):
             None if value == date.DateTime() else value
         )
 
+    def __bindDueDateFocus(self, widget):
+        """Bind focus and mouse events to widget and children to update relative choices.
+
+        This ensures the relative time picker uses the current planned start
+        value from the widget, even before commit_on_focus_loss commits.
+        Uses both focus and mouse-down events to catch all interaction paths.
+        """
+        widget.Bind(wx.EVT_SET_FOCUS, self.__onDueDateFocus)
+        widget.Bind(wx.EVT_LEFT_DOWN, self.__onDueDateMouseDown)
+        for child in widget.GetChildren():
+            self.__bindDueDateFocus(child)
+
+    def __onDueDateFocus(self, event):
+        """Update relative choices when due date entry gets focus."""
+        event.Skip()
+        self.__updateDueDateRelativeChoices()
+
+    def __onDueDateMouseDown(self, event):
+        """Update relative choices on mouse down before button click."""
+        event.Skip()
+        self.__updateDueDateRelativeChoices()
+
+    def __updateDueDateRelativeChoices(self):
+        """Update the due date relative choices with current planned start value."""
+        start = self._plannedStartDateTimeEntry.GetValue()
+        self._dueDateTimeEntry.SetRelativeChoicesStart(
+            start=None if start == date.DateTime() else start
+        )
+
     def addEntries(self):
         self.addDateEntries()
         self.addLine()
@@ -535,6 +564,9 @@ class DatesPage(Page):
         self._dueDateTimeEntry.Bind(
             sdtc.EVT_TIME_CHOICES_CHANGE, self.__onTimeChoicesChange
         )
+        # Update relative choices when due date or any child gets focus
+        # This ensures relative picker uses current planned start even before commit
+        self.__bindDueDateFocus(self._dueDateTimeEntry)
 
     def addDateEntry(self, label, taskMethodName):
         TaskMethodName = taskMethodName[0].capitalize() + taskMethodName[1:]
@@ -1813,6 +1845,33 @@ class EffortEditBook(Page):
     def __onChoicesChanged(self, event):
         self._settings.settext("feature", "sdtcspans_effort", event.GetValue())
 
+    def __bindFocusToUpdateRelativeChoices(self, widget):
+        """Bind focus and mouse events to widget and children to update relative choices.
+
+        This ensures the relative time picker uses the current start value
+        from the widget, even before commit_on_focus_loss commits the change.
+        Uses both focus and mouse-down events to catch all interaction paths.
+        """
+        widget.Bind(wx.EVT_SET_FOCUS, self.__onStopDateTimeFocus)
+        widget.Bind(wx.EVT_LEFT_DOWN, self.__onStopDateTimeMouseDown)
+        for child in widget.GetChildren():
+            self.__bindFocusToUpdateRelativeChoices(child)
+
+    def __onStopDateTimeFocus(self, event):
+        """Update relative choices when stop datetime entry gets focus."""
+        event.Skip()
+        self.__updateStopRelativeChoices()
+
+    def __onStopDateTimeMouseDown(self, event):
+        """Update relative choices on mouse down before button click."""
+        event.Skip()
+        self.__updateStopRelativeChoices()
+
+    def __updateStopRelativeChoices(self):
+        """Update the stop datetime relative choices with current start value."""
+        start_value = self._startDateTimeEntry.GetValue()
+        self._stopDateTimeEntry.SetRelativeChoicesStart(start=start_value)
+
     def __add_start_and_stop_entries(self):
         # pylint: disable=W0201,W0142
         # Using 4 columns: Label, Checkbox, DateTime, Button
@@ -1927,6 +1986,9 @@ class EffortEditBook(Page):
         stop_datetime_entry.Bind(
             sdtc.EVT_TIME_CHOICES_CHANGE, self.__onChoicesChanged
         )
+        # Update relative choices when stop datetime entry or any child gets focus
+        # This ensures relative picker uses current start value even before commit
+        self.__bindFocusToUpdateRelativeChoices(stop_datetime_entry)
         # Add warning message spanning full width
         self.addEntry(
             self._invalidPeriodMessage,
@@ -1936,8 +1998,14 @@ class EffortEditBook(Page):
     def __onStopCheckboxToggle(self, event):
         """Handle stop checkbox toggle - enable/disable datetime entry."""
         if self._stopCheckbox.GetValue():
-            # Checkbox checked - enable and set to now
-            new_value = date.DateTime.now()
+            # Checkbox checked - enable and set based on start time
+            # Get current start value from widget (may not be committed yet)
+            start_value = self._startDateTimeEntry.GetValue()
+            # Update relative choices to use current start value
+            self._stopDateTimeEntry.SetRelativeChoicesStart(start=start_value)
+            # Set stop to now, but ensure it's at least as late as start
+            now = date.DateTime.now()
+            new_value = start_value if start_value > now else now
             self._stopDateTimeEntry.SetValue(new_value)
             command.EditEffortStopDateTimeCommand(
                 None, self.items, newValue=new_value

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -26,7 +26,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # IMPORTANT: When releasing a new version:
 #   1. Increment patch below (and version if needed)
 #   2. Update release_day, release_month, release_year below
-#   3. Update changelogs (debian/changelog, build.in/fedora/taskcoach.spec)
+#   3. Update version numbers in README.md
+#   4. Update changelogs (debian/changelog, build.in/fedora/taskcoach.spec)
 #
 # The version is defined HERE in data.py as the single source of truth.
 # This ensures the version is always available since it's embedded in the
@@ -40,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "9"  # Patch number - INCREMENT THIS for each release
+patch = "10"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.1.9
 
 release_day = "12"  # Day of the release (1-31)


### PR DESCRIPTION
When modifying the start date/time in the Effort dialog or Planned Start in the Task Dates dialog, then clicking the relative time picker button, the picker would use the old (uncommitted) start value instead of the modified value from the widget.

The issue was that AttributeSync with commit_on_focus_loss=True delays the callback that updates SetRelativeChoicesStart until focus leaves the field. When clicking the relative picker button, the popup was created before the callback could fire.

Fix:
- Bind EVT_LEFT_DOWN to stop datetime entry and all children to update relative choices on mouse down, before button click is processed
- Bind EVT_SET_FOCUS as backup for keyboard navigation
- Update relative choices in checkbox toggle handler for effort stop
- Apply same fix to Task Dates due date relative picker

Locations fixed:
- Effort Dialog: Stop datetime relative picker
- Task Edit Dialog: Due Date relative picker

Fixes:
New effort, selecting of of 1-4 hours blocks takes wrong offset (bug) #176

![Peek 2026-01-12 13-53](https://github.com/user-attachments/assets/b58a2a31-a5a0-471a-994a-a5e6079edbbd)
