### PR TITLE
Add context menus to empty space in list views

### DIFF
--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -1168,24 +1168,9 @@ class LocalAttachmentViewer(viewer.AttachmentViewer):  # pylint: disable=W0223
         )
 
     def pasteItemCommand(self):
-        """Paste attachments from clipboard to this task's attachments.
-
-        Validates that clipboard contains only attachments and shows an
-        error dialog if a type mismatch is detected.
-        """
+        """Paste attachments from clipboard to this task's attachments."""
         from taskcoachlib.command.clipboard import Clipboard
-        from taskcoachlib.domain import attachment
         items, source = Clipboard().get()
-        # Validate clipboard contains only attachments
-        for item in items:
-            if not isinstance(item, attachment.Attachment):
-                import wx
-                wx.MessageBox(
-                    _("Cannot paste: clipboard contains %s but this is an Attachments view. Only Attachments can be pasted here.") % type(item).__name__,
-                    _("Paste Error"),
-                    wx.OK | wx.ICON_ERROR
-                )
-                return None
         copies = [item.copy() for item in items]
         return command.AddAttachmentCommand(
             None, [self.attachmentOwner], attachments=copies
@@ -1253,23 +1238,11 @@ class LocalNoteViewer(viewer.BaseNoteViewer):  # pylint: disable=W0223
     def pasteItemCommand(self):
         """Paste notes from clipboard to this task's notes as top-level notes.
 
-        Validates that clipboard contains only notes and shows an
-        error dialog if a type mismatch is detected. Clears parent reference
-        so notes always become top-level, even if copied from a nested location.
+        Clears parent reference so notes always become top-level, even if
+        copied from a nested location.
         """
         from taskcoachlib.command.clipboard import Clipboard
-        from taskcoachlib.domain import note
         items, source = Clipboard().get()
-        # Validate clipboard contains only notes
-        for item in items:
-            if not isinstance(item, note.Note):
-                import wx
-                wx.MessageBox(
-                    _("Cannot paste: clipboard contains %s but this is a Notes view. Only Notes can be pasted here.") % type(item).__name__,
-                    _("Paste Error"),
-                    wx.OK | wx.ICON_ERROR
-                )
-                return None
         copies = [item.copy() for item in items]
         # Clear parent so notes become top-level (even if source was nested)
         # and expand all pasted notes so children are visible
@@ -1291,18 +1264,7 @@ class LocalNoteViewer(viewer.BaseNoteViewer):  # pylint: disable=W0223
             return None
         parent_note = selected[0]
         from taskcoachlib.command.clipboard import Clipboard
-        from taskcoachlib.domain import note
         items, source = Clipboard().get()
-        # Validate clipboard contains only notes
-        for item in items:
-            if not isinstance(item, note.Note):
-                import wx
-                wx.MessageBox(
-                    _("Cannot paste: clipboard contains %s but this is a Notes view. Only Notes can be pasted here.") % type(item).__name__,
-                    _("Paste Error"),
-                    wx.OK | wx.ICON_ERROR
-                )
-                return None
         copies = [item.copy() for item in items]
         # Clear parent references - AddSubNoteCommand will set correct parent via addChild
         # and expand all pasted notes so children are visible
@@ -1771,6 +1733,10 @@ class NullableDateTimeWrapper:
         """Enable/disable the datetime entry."""
         self._datetime_entry.Enable(enable)
         return True
+
+    def GetId(self):
+        """Return ID of datetime entry for widget validity checks."""
+        return self._datetime_entry.GetId()
 
 
 class EffortEditBook(Page):

--- a/taskcoachlib/gui/menu.py
+++ b/taskcoachlib/gui/menu.py
@@ -63,7 +63,7 @@ class Menu(wx.Menu, uicommand.UICommandContainerMixin):
             self._observers.append(uiCommand)
         return cmd
 
-    def appendMenu(self, text, subMenu, bitmap=None):
+    def appendMenu(self, text, subMenu, bitmap=None, viewer=None):
         subMenuItem = wx.MenuItem(
             self, id=IdProvider.get(), text=text, subMenu=subMenu
         )
@@ -73,6 +73,12 @@ class Menu(wx.Menu, uicommand.UICommandContainerMixin):
             )
         self._accels.extend(subMenu.accelerators())
         self.Append(subMenuItem)
+        # If viewer provided, disable submenu when nothing is selected
+        if viewer is not None:
+            menuId = subMenuItem.GetId()
+            def onUpdateUI(event, v=viewer):
+                event.Enable(bool(v.curselection()))
+            self._window.Bind(wx.EVT_UPDATE_UI, onUpdateUI, id=menuId)
 
     def invokeMenuItem(self, menuItem):
         """Programmatically invoke the menuItem. This is mainly for testing
@@ -1038,6 +1044,7 @@ class TaskPopupMenu(Menu):
                 mainwindow, categories=categories, viewer=taskViewer
             ),
             "folder_blue_arrow_icon",
+            viewer=taskViewer,
         )
         self.appendUICommands(
             None,
@@ -1050,6 +1057,7 @@ class TaskPopupMenu(Menu):
             _("&Priority"),
             TaskPriorityMenu(mainwindow, tasks, taskViewer),
             "incpriority",
+            viewer=taskViewer,
         )
         self.appendUICommands(
             None,
@@ -1064,6 +1072,7 @@ class TaskPopupMenu(Menu):
                 viewer=taskViewer, effortList=efforts, taskList=tasks
             ),
             None,
+            uicommand.TaskNew(taskList=tasks, settings=settings),
             uicommand.NewSubItem(viewer=taskViewer),
         )
 
@@ -1138,12 +1147,14 @@ class CategoryPopupMenu(Menu):
                 ),
             )
         self.appendUICommands(
-            None, uicommand.NewSubItem(viewer=categoryViewer)
+            None,
+            uicommand.CategoryNew(categories=categories, settings=settings),
+            uicommand.NewSubItem(viewer=categoryViewer),
         )
 
 
 class NotePopupMenu(Menu):
-    def __init__(self, mainwindow, settings, categories, noteViewer):
+    def __init__(self, mainwindow, settings, categories, noteViewer, notes=None):
         super().__init__(mainwindow)
         self.appendUICommands(
             uicommand.EditCut(viewer=noteViewer),
@@ -1166,8 +1177,14 @@ class NotePopupMenu(Menu):
                 mainwindow, categories=categories, viewer=noteViewer
             ),
             "folder_blue_arrow_icon",
+            viewer=noteViewer,
         )
-        self.appendUICommands(None, uicommand.NewSubItem(viewer=noteViewer))
+        self.appendUICommands(None)
+        if notes is not None:
+            self.appendUICommands(
+                uicommand.NoteNew(notes=notes, settings=settings, viewer=noteViewer),
+            )
+        self.appendUICommands(uicommand.NewSubItem(viewer=noteViewer))
 
 
 class ColumnPopupMenuMixin(object):
@@ -1237,6 +1254,12 @@ class AttachmentPopupMenu(Menu):
             uicommand.OpenAllNotes(viewer=attachmentViewer, settings=settings),
             None,
             uicommand.AttachmentOpen(
+                viewer=attachmentViewer,
+                attachments=attachments,
+                settings=settings,
+            ),
+            None,
+            uicommand.AttachmentNew(
                 viewer=attachmentViewer,
                 attachments=attachments,
                 settings=settings,

--- a/taskcoachlib/gui/uicommand/mixin_uicommand.py
+++ b/taskcoachlib/gui/uicommand/mixin_uicommand.py
@@ -46,7 +46,7 @@ class NeedsOneSelectedItemMixin(object):
     """Mixin class for UI commands that need exactly one selected item."""
 
     def enabled(self, event):
-        return super().enabled(event) and len(self.viewer.curselection()) == 1
+        return super().enabled(event) and len(self.viewer.curselection(forceUpdate=True)) == 1
 
 
 class NeedsSelectedCompositeMixin(NeedsSelectionMixin):

--- a/taskcoachlib/gui/uicommand/uicommand.py
+++ b/taskcoachlib/gui/uicommand/uicommand.py
@@ -823,7 +823,20 @@ class EditPaste(ViewerCommand):
         if isinstance(windowWithFocus, wx.TextCtrl):
             return windowWithFocus.CanPaste()
         else:
-            return command.Clipboard() and super().enabled(event)
+            clipboard = command.Clipboard()
+            if not clipboard:
+                return False
+            if not super().enabled(event):
+                return False
+            # Check if clipboard contents are compatible with viewer
+            if self.viewer and hasattr(self.viewer, 'getSupportedPasteTypes'):
+                supportedTypes = self.viewer.getSupportedPasteTypes()
+                if supportedTypes:
+                    items = clipboard.peek()
+                    for item in items:
+                        if not isinstance(item, supportedTypes):
+                            return False
+            return True
 
 
 class EditPasteAsSubItem(
@@ -1695,6 +1708,9 @@ class NewTaskWithSelectedCategories(TaskNew, ViewerCommand):
             **kwargs
         )
 
+    def enabled(self, event):
+        return super().enabled(event) and bool(self.viewer.curselection(forceUpdate=True))
+
     def categoriesForTheNewTask(self):
         return self.viewer.curselection()
 
@@ -2223,6 +2239,14 @@ class EffortNew(
             **kwargs
         )
 
+    def enabled(self, event):
+        if not super().enabled(event):
+            return False
+        # When viewer is showing tasks, require a task to be selected
+        if self.viewer and self.viewer.isShowingTasks():
+            return bool(self.viewer.curselection(forceUpdate=True))
+        return True
+
     def doCommand(self, event, show=True):
         if (
             self.viewer
@@ -2650,6 +2674,9 @@ class NoteNew(NotesCommand, settings_uicommand.SettingsCommand, ViewerCommand):
 class NewNoteWithSelectedCategories(NoteNew, ViewerCommand):
     menuText = _("New &note with selected categories...")
     helpText = _("Insert a new note with the selected categories checked")
+
+    def enabled(self, event):
+        return super().enabled(event) and bool(self.viewer.curselection(forceUpdate=True))
 
     def categoriesForTheNewNote(self):
         return self.viewer.curselection()

--- a/taskcoachlib/gui/viewer/attachment.py
+++ b/taskcoachlib/gui/viewer/attachment.py
@@ -58,6 +58,9 @@ class AttachmentViewer(
     def curselectionIsInstanceOf(self, class_):
         return class_ == attachment.Attachment
 
+    def getSupportedPasteTypes(self):
+        return (attachment.Attachment,)
+
     def createWidget(self):
         imageList = self.createImageList()
         itemPopupMenu = taskcoachlib.gui.menu.AttachmentPopupMenu(

--- a/taskcoachlib/gui/viewer/base.py
+++ b/taskcoachlib/gui/viewer/base.py
@@ -726,6 +726,14 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
     def pasteItemCommandClass(self):
         return command.PasteCommand
 
+    def getSupportedPasteTypes(self):
+        """Return tuple of domain object types that can be pasted into this viewer.
+
+        Override in subclasses to restrict paste to specific types.
+        Return None to accept any type (default behavior).
+        """
+        return None
+
     def onEditSubject(self, item, newValue):
         command.EditSubjectCommand(items=[item], newValue=newValue).do()
 

--- a/taskcoachlib/gui/viewer/category.py
+++ b/taskcoachlib/gui/viewer/category.py
@@ -65,6 +65,9 @@ class BaseCategoryViewer(
     def curselectionIsInstanceOf(self, class_):
         return class_ == category.Category
 
+    def getSupportedPasteTypes(self):
+        return (category.Category,)
+
     def createWidget(self):
         imageList = self.createImageList()  # Has side-effects
         self._columns = self._createColumns()

--- a/taskcoachlib/gui/viewer/effort.py
+++ b/taskcoachlib/gui/viewer/effort.py
@@ -167,26 +167,17 @@ class EffortViewer(
     def curselectionIsInstanceOf(self, class_):
         return class_ == effort.Effort
 
+    def getSupportedPasteTypes(self):
+        return (effort.Effort,)
+
     def pasteItemCommand(self):
         """Paste efforts from clipboard to the target task.
 
         When this viewer is showing efforts for a specific task (e.g., in task
-        editor), pasted efforts are added to that task. Validates that clipboard
-        contains only efforts and shows an error dialog if a type mismatch is
-        detected.
+        editor), pasted efforts are added to that task.
         """
-        import wx
         from taskcoachlib.command.clipboard import Clipboard
         items, source = Clipboard().get()
-        # Validate clipboard contains only efforts
-        for item in items:
-            if not isinstance(item, effort.Effort):
-                wx.MessageBox(
-                    _("Cannot paste: clipboard contains %s but this is an Efforts view. Only Efforts can be pasted here.") % type(item).__name__,
-                    _("Paste Error"),
-                    wx.OK | wx.ICON_ERROR
-                )
-                return None
         tasks = self.tasksToShowEffortFor()
         if tasks:
             # Paste to the specific task this viewer is showing efforts for

--- a/taskcoachlib/gui/viewer/note.py
+++ b/taskcoachlib/gui/viewer/note.py
@@ -67,11 +67,15 @@ class BaseNoteViewer(
     def curselectionIsInstanceOf(self, class_):
         return class_ == note.Note
 
+    def getSupportedPasteTypes(self):
+        return (note.Note,)
+
     def createWidget(self):
         imageList = self.createImageList()  # Has side-effects
         self._columns = self._createColumns()
         itemPopupMenu = taskcoachlib.gui.menu.NotePopupMenu(
-            self.parent, self.settings, self.taskFile.categories(), self
+            self.parent, self.settings, self.taskFile.categories(), self,
+            notes=self.taskFile.notes()
         )
         columnPopupMenu = taskcoachlib.gui.menu.ColumnPopupMenu(self)
         self._popupMenus.extend([itemPopupMenu, columnPopupMenu])

--- a/taskcoachlib/gui/viewer/task.py
+++ b/taskcoachlib/gui/viewer/task.py
@@ -307,6 +307,9 @@ class BaseTaskTreeViewer(BaseTaskViewer):  # pylint: disable=W0223
             shadow=False,  # SyncML removed
         )
 
+    def getSupportedPasteTypes(self):
+        return (task.Task,)
+
     def createTaskPopupMenu(self):
         return taskcoachlib.gui.menu.TaskPopupMenu(
             self.parent,

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,10 +41,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "11"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.1.9
+patch = "12"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.1.12
 
-release_day = "12"  # Day of the release (1-31)
+release_day = "13"  # Day of the release (1-31)
 release_month = "January"  # Month of the release
 release_year = "2026"  # Year of the release
 

--- a/taskcoachlib/widgets/itemctrl.py
+++ b/taskcoachlib/widgets/itemctrl.py
@@ -69,33 +69,144 @@ class _CtrlWithItemPopupMenuMixin(_CtrlWithPopupMenuMixin):
     """Popupmenu's on items."""
 
     def __init__(self, *args, **kwargs):
-        self.__popupMenu = kwargs.pop("itemPopupMenu")
+        self._itemPopupMenu = kwargs.pop("itemPopupMenu")
         super().__init__(*args, **kwargs)
-        if self.__popupMenu is not None:
-            self._attachPopupMenu(
-                self,
-                (wx.EVT_TREE_ITEM_RIGHT_CLICK, wx.EVT_CONTEXT_MENU),
-                self.onItemPopupMenu,
-            )
+        if self._itemPopupMenu is not None:
+            # Determine if this is a ListCtrl or tree control
+            # ListCtrl has GetItemRect but not GetRootItem
+            isListCtrl = hasattr(self, 'GetItemRect') and not hasattr(self, 'GetRootItem')
+            if isListCtrl:
+                # For ListCtrl: use EVT_LIST_ITEM_RIGHT_CLICK for item clicks
+                # (provides GetIndex() directly) and EVT_CONTEXT_MENU for empty space
+                self._attachPopupMenu(
+                    self,
+                    (wx.EVT_LIST_ITEM_RIGHT_CLICK,),
+                    self.onListItemRightClick,
+                )
+                self._attachPopupMenu(
+                    self,
+                    (wx.EVT_CONTEXT_MENU,),
+                    self.onListContextMenu,
+                )
+            else:
+                # For tree controls: use EVT_TREE_ITEM_RIGHT_CLICK and EVT_CONTEXT_MENU
+                self._attachPopupMenu(
+                    self,
+                    (wx.EVT_TREE_ITEM_RIGHT_CLICK, wx.EVT_CONTEXT_MENU),
+                    self.onItemPopupMenu,
+                )
+                # Also bind to MainWindow to catch right-clicks on empty space
+                self.GetMainWindow().Bind(
+                    wx.EVT_RIGHT_DOWN, self._onMainWindowRightDown
+                )
+
+    def _onMainWindowRightDown(self, event):
+        """Handle right-click on MainWindow for tree controls.
+
+        This catches clicks on empty space that EVT_TREE_ITEM_RIGHT_CLICK misses.
+        """
+        point = event.GetPosition()
+        item = self.HitTest(point)[0]
+        if not self._itemIsOk(item):
+            # Clicked on empty space - clear selection and show popup
+            self.clear_selection()
+            self._updateMenuUI()
+            self.PopupMenu(self._itemPopupMenu)
+        else:
+            # Clicked on an item - let normal event handling take over
+            event.Skip()
+
+    def _updateMenuUI(self):
+        """Update enabled state of menu items based on current selection.
+
+        Menu items are bound to a window with EVT_UPDATE_UI handlers, but those
+        handlers don't fire automatically for popup menus. We manually process
+        UpdateUIEvent for each menu item to update their enabled state.
+        """
+        menuWindow = getattr(self._itemPopupMenu, '_window', None)
+        if menuWindow and self._itemPopupMenu:
+            for menuItem in self._itemPopupMenu.GetMenuItems():
+                if menuItem.IsSeparator():
+                    continue
+                itemId = menuItem.GetId()
+                event = wx.UpdateUIEvent(itemId)
+                menuWindow.ProcessEvent(event)
+                if event.GetSetEnabled():
+                    menuItem.Enable(event.GetEnabled())
 
     def onItemPopupMenu(self, event):
+        """Handle popup menu for tree controls (EVT_TREE_ITEM_RIGHT_CLICK, EVT_CONTEXT_MENU)."""
         # Make sure the window this control is in has focus:
         try:
             window = event.GetEventObject().MainWindow
         except AttributeError:
             window = event.GetEventObject()
         window.SetFocus()
+        # Get click position - GetPoint() for tree item events, GetPosition() for context menu
+        point = None
         if hasattr(event, "GetPoint"):
+            point = event.GetPoint()
+        elif hasattr(event, "GetPosition"):
+            pos = event.GetPosition()
+            if pos != wx.DefaultPosition:
+                point = self.ScreenToClient(pos)
+        if point is not None:
             # Make sure the item under the mouse is selected because that
             # is what users expect and what is most user-friendly. Not all
             # widgets do this by default, e.g. the TreeListCtrl does not.
-            item = self.HitTest(event.GetPoint())[0]
+            item = self.HitTest(point)[0]
             if not self._itemIsOk(item):
+                # Clicked on empty space - clear selection so menu items
+                # properly reflect no selection
+                self.clear_selection()
+                self._updateMenuUI()
+                self.PopupMenu(self._itemPopupMenu)
                 return
             if not self.IsSelected(item):
-                self.UnselectAll()
+                self.clear_selection()
                 self.SelectItem(item)
-        self.PopupMenu(self.__popupMenu)
+        # Update menu item enabled states and show popup
+        self._updateMenuUI()
+        self.PopupMenu(self._itemPopupMenu)
+
+    def onListItemRightClick(self, event):
+        """Handle EVT_LIST_ITEM_RIGHT_CLICK for ListCtrl controls.
+
+        This event fires when right-clicking on an item and provides
+        GetIndex() to get the clicked item directly - the proper way
+        to handle ListCtrl right-clicks.
+        """
+        self.SetFocus()
+        # Get the clicked item index from the event
+        itemIndex = event.GetIndex()
+        # Select the item if not already selected
+        if not self.IsSelected(itemIndex):
+            self.clear_selection()
+            self.Select(itemIndex, True)
+        # Update menu and show popup
+        self._updateMenuUI()
+        self.PopupMenu(self._itemPopupMenu)
+
+    def onListContextMenu(self, event):
+        """Handle EVT_CONTEXT_MENU for ListCtrl controls.
+
+        This handles right-clicks on empty space (EVT_LIST_ITEM_RIGHT_CLICK
+        only fires for item clicks). Also handles keyboard context menu key.
+        """
+        self.SetFocus()
+        pos = event.GetPosition()
+        if pos != wx.DefaultPosition:
+            # Mouse-triggered context menu - check if on empty space
+            clientPoint = self.ScreenToClient(pos)
+            item = self.HitTest(clientPoint)[0]
+            if self._itemIsOk(item):
+                # Click was on an item - EVT_LIST_ITEM_RIGHT_CLICK already handled it
+                return
+            # Click on empty space - clear selection
+            self.clear_selection()
+        # Update menu and show popup
+        self._updateMenuUI()
+        self.PopupMenu(self._itemPopupMenu)
 
 
 class _CtrlWithColumnPopupMenuMixin(_CtrlWithPopupMenuMixin):


### PR DESCRIPTION
1. Context menus now work on empty space
   - Right-clicking on empty space in any list view (Tasks, Notes, Categories, Attachments, Efforts) now shows a context menu
   - Previously, right-clicking on empty space did nothing

2. Menu items properly disable when nothing is selected
   - When you right-click on empty space, actions like Cut, Copy, Edit, and Delete are grayed out since nothing is selected
   - "New" actions remain enabled so you can still create new items

3. "New" options added to all context menus
   - Task list: New Task added
   - Category list: New Category added
   - Note list: New Note added
   - Attachment list: New Attachment added

4. Paste is disabled when clipboard contents don't match
   - If you copy a Task and try to paste it in the Notes view, Paste is now grayed out
   - Previously, you'd get an error popup after clicking Paste

5. Fixed right-click selecting wrong item in Attachments and Efforts lists
   - Right-clicking on an item now correctly selects that item (was selecting the line below)

6. "New with selected categories" commands require a selection
   - These commands are now grayed out when no categories are selected (previously they would just create an item with no categories)

Version bump to 2.0.1.12

Fixes: 
Context menu required in blank space for paste operations #178