### PR TITLE
Fix macOS startup: remove Carbon and Cocoa dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| Windows | `TaskCoach-2.0.1.15-windows-x64-setup.exe` |
-| Windows (portable) | `TaskCoach-2.0.1.15-windows-x64-portable.zip` | 
-| Debian 12 (Bookworm) | `taskcoach_2.0.1.15_debian-12-bookworm.deb` |
-| Debian 13 (Trixie) | `taskcoach_2.0.1.15_debian-13-trixie.deb` |
-| Debian Sid | `taskcoach_2.0.1.15_debian-sid.deb` |
-| Ubuntu 22.04 (Jammy) | `taskcoach_2.0.1.15_ubuntu-22.04-jammy.deb` |
-| Ubuntu 24.04 (Noble) | `taskcoach_2.0.1.15_ubuntu-24.04-noble.deb` |
+| Windows | `TaskCoach-2.0.1.16-windows-x64-setup.exe` |
+| Windows (portable) | `TaskCoach-2.0.1.16-windows-x64-portable.zip` | 
+| Debian 12 (Bookworm) | `taskcoach_2.0.1.16_debian-12-bookworm.deb` |
+| Debian 13 (Trixie) | `taskcoach_2.0.1.16_debian-13-trixie.deb` |
+| Debian Sid | `taskcoach_2.0.1.16_debian-sid.deb` |
+| Ubuntu 22.04 (Jammy) | `taskcoach_2.0.1.16_ubuntu-22.04-jammy.deb` |
+| Ubuntu 24.04 (Noble) | `taskcoach_2.0.1.16_ubuntu-24.04-noble.deb` |
 | Linux Mint | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| Arch Linux / Manjaro | `taskcoach-2.0.1.15-arch.pkg.tar.zst` |
-| Fedora 39/40 | `taskcoach-2.0.1.15-fedora40.noarch.rpm` |
-| Any Linux (x86_64) | `TaskCoach-2.0.1.15-x86_64.AppImage` |
+| Arch Linux / Manjaro | `taskcoach-2.0.1.16-arch.pkg.tar.zst` |
+| Fedora 39/40 | `taskcoach-2.0.1.16-fedora40.noarch.rpm` |
+| Any Linux (x86_64) | `TaskCoach-2.0.1.16-x86_64.AppImage` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -28,8 +28,8 @@ After installing, Task Coach should be in normal system launchers (Applications 
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.15_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.15_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.16_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.16_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -42,8 +42,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.15-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.15-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.16-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.16-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.15-fedora40.noarch.rpm
-sudo dnf install ./taskcoach-2.0.1.15-fedora40.noarch.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.16-fedora40.noarch.rpm
+sudo dnf install ./taskcoach-2.0.1.16-fedora40.noarch.rpm
 ```
 
 To uninstall:
@@ -70,13 +70,13 @@ sudo dnf autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.15-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.15-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.16-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.16-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.15-x86_64.AppImage
+./TaskCoach-2.0.1.16-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/taskcoachlib/config/settings.py
+++ b/taskcoachlib/config/settings.py
@@ -430,14 +430,7 @@ class Settings(CachingConfigParser):
                 except Exception:
                     return os.getcwd()  # Last resort fallback
         elif operating_system.isMac():
-            import Carbon.Folder, Carbon.Folders, Carbon.File
-
-            pathRef = Carbon.Folder.FSFindFolder(
-                Carbon.Folders.kUserDomain,
-                Carbon.Folders.kDocumentsFolderType,
-                True,
-            )
-            return Carbon.File.pathname(pathRef)
+            return os.path.expanduser("~/Documents")
         elif operating_system.isGTK():
             try:
                 from PyKDE4.kdeui import KGlobalSettings
@@ -534,15 +527,7 @@ class Settings(CachingConfigParser):
 
                 path = BaseDirectory.save_config_path(meta.name)
             elif operating_system.isMac():
-                import Carbon.Folder, Carbon.Folders, Carbon.File
-
-                pathRef = Carbon.Folder.FSFindFolder(
-                    Carbon.Folders.kUserDomain,
-                    Carbon.Folders.kPreferencesFolderType,
-                    True,
-                )
-                path = Carbon.File.pathname(pathRef)
-                # XXXFIXME: should we release pathRef ? Doesn't seem so since I get a SIGSEGV if I try.
+                path = os.path.expanduser("~/Library/Preferences")
             elif operating_system.isWindows():
                 from win32com.shell import shell, shellcon
 
@@ -565,16 +550,10 @@ class Settings(CachingConfigParser):
 
             path = BaseDirectory.save_data_path(meta.name)
         elif operating_system.isMac():
-            import Carbon.Folder, Carbon.Folders, Carbon.File
-
-            pathRef = Carbon.Folder.FSFindFolder(
-                Carbon.Folders.kUserDomain,
-                Carbon.Folders.kApplicationSupportFolderType,
-                True,
+            path = os.path.join(
+                os.path.expanduser("~/Library/Application Support"),
+                meta.name
             )
-            path = Carbon.File.pathname(pathRef)
-            # XXXFIXME: should we release pathRef ? Doesn't seem so since I get a SIGSEGV if I try.
-            path = os.path.join(path, meta.name)
         elif operating_system.isWindows():
             if self.__iniFileSpecifiedOnCommandLine and not forceGlobal:
                 path = self.pathToIniFileSpecifiedOnCommandLine()

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,8 +41,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "15"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.1.15
+patch = "16"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.1.16
 
 release_day = "13"  # Day of the release (1-31)
 release_month = "January"  # Month of the release

--- a/taskcoachlib/render.py
+++ b/taskcoachlib/render.py
@@ -219,76 +219,23 @@ if operating_system.isWindows():
         )
 
 elif operating_system.isMac():
-    import Cocoa, calendar
-
-    # We don't actually respect the 'seconds' parameter; this assumes that the short time format does
-    # not include them, but the medium format does.
-    _shortFormatter = Cocoa.NSDateFormatter.alloc().init()
-    _shortFormatter.setFormatterBehavior_(Cocoa.NSDateFormatterBehavior10_4)
-    _shortFormatter.setTimeStyle_(Cocoa.NSDateFormatterShortStyle)
-    _shortFormatter.setDateStyle_(Cocoa.NSDateFormatterNoStyle)
-    _shortFormatter.setTimeZone_(
-        Cocoa.NSTimeZone.timeZoneForSecondsFromGMT_(0)
-    )
-    _mediumFormatter = Cocoa.NSDateFormatter.alloc().init()
-    _mediumFormatter.setFormatterBehavior_(Cocoa.NSDateFormatterBehavior10_4)
-    _mediumFormatter.setTimeStyle_(Cocoa.NSDateFormatterMediumStyle)
-    _mediumFormatter.setDateStyle_(Cocoa.NSDateFormatterNoStyle)
-    _mediumFormatter.setTimeZone_(
-        Cocoa.NSTimeZone.timeZoneForSecondsFromGMT_(0)
-    )
-    # Special case for hour without minutes or seconds. I don't know if it is possible to get the AM/PM
-    # setting alone, so parse the format string instead.
-    # See http://www.unicode.org/reports/tr35/tr35-25.html#Date_Format_Patterns
-    _state = 0
-    _hourFormat = ""
-    _ampmFormat = ""
-    for c in _mediumFormatter.dateFormat():
-        if _state == 0:
-            if c == "'":
-                _state = 1  # After single quote
-            elif c in ["h", "H", "k", "K", "j"]:
-                _hourFormat += c
-            elif c == "a":
-                _ampmFormat = c
-        elif _state == 1:
-            if c == "'":
-                _state = 0
-            else:
-                _state = 2  # Escaped string
-        elif _state == 2:
-            if c == "'":
-                _state = 0
-    _hourFormatter = Cocoa.NSDateFormatter.alloc().init()
-    _hourFormatter.setFormatterBehavior_(Cocoa.NSDateFormatterBehavior10_4)
-    _hourFormatter.setDateFormat_(
-        _hourFormat + (" %s" % _ampmFormat if _ampmFormat else "")
-    )
-    _hourFormatter.setTimeZone_(Cocoa.NSTimeZone.timeZoneForSecondsFromGMT_(0))
-    _dateFormatter = Cocoa.NSDateFormatter.alloc().init()
-    _dateFormatter.setFormatterBehavior_(Cocoa.NSDateFormatterBehavior10_4)
-    _dateFormatter.setDateStyle_(Cocoa.NSDateFormatterShortStyle)
-    _dateFormatter.setTimeStyle_(Cocoa.NSDateFormatterNoStyle)
-    _dateFormatter.setTimeZone_(Cocoa.NSTimeZone.timeZoneForSecondsFromGMT_(0))
-
-    def _applyFormatter(dt, fmt):
-        dt_native = Cocoa.NSDate.dateWithTimeIntervalSince1970_(
-            (dt - datetime.datetime(1970, 1, 1, 0, 0, 0, 0)).total_seconds()
-        )
-        return fmt.stringFromDate_(dt_native)
-
+    # Use simple strftime formatting on macOS
+    # PyObjC/Cocoa formatting was removed as it adds complexity and
+    # dependency issues without significant benefit for a task manager
     def rawTimeFunc(dt, minutes=True, seconds=False):
-        if minutes:
-            if seconds:
-                return _applyFormatter(dt, _mediumFormatter)
-            return _applyFormatter(dt, _shortFormatter)
-        return _applyFormatter(dt, _hourFormatter)
+        if dt is None:
+            dt = datetime.datetime.now()
+        if seconds:
+            return dt.strftime("%H:%M:%S")
+        elif minutes:
+            return dt.strftime("%H:%M")
+        else:
+            return dt.strftime("%H")
 
     def rawDateFunc(dt):
-        return _applyFormatter(
-            datetime.datetime.combine(dt, datetime.time(0, 0, 0, 0)),
-            _dateFormatter,
-        )
+        if dt is None:
+            dt = datetime.datetime.now()
+        return dt.strftime("%x")
 
 
 timeFunc = lambda dt, minutes=True, seconds=False: operating_system.decodeSystemString(


### PR DESCRIPTION
- Remove deprecated Carbon API calls for folder paths (settings.py)
- Replace with os.path.expanduser for Documents, Preferences, Application Support
- Remove PyObjC/Cocoa dependency for date formatting (render.py)
- Use simple strftime instead - works reliably without external dependencies