### PR TITLE
Fix macOS build: bundle unittest for pyparsing compatibility

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -150,7 +150,7 @@ jobs:
               },
               'packages': ['taskcoachlib', 'wx', 'pubsub', 'watchdog', 'lxml', 'keyring', 'numpy', 'dateutil', 'chardet', 'pyparsing', 'fasteners', 'squaremap'],
               'includes': ['ctypes', 'ctypes.util'],
-              'excludes': ['tkinter', 'test', 'unittest', 'pyparsing.testing'],
+              'excludes': ['tkinter', 'test'],  # unittest needed by pyparsing.testing import
           }
 
           setup(


### PR DESCRIPTION
pyparsing unconditionally imports pyparsing.testing which requires unittest. Simply allow unittest to be bundled. Task Coach doesn't use unittest at runtime - it's only needed for pyparsing's import.