### PR TITLE
Fix macOS build: simplify resource paths and allow unittest

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -118,12 +118,13 @@ jobs:
           from setuptools import setup
 
           APP = ['taskcoach.py']
+          import os
+
           DATA_FILES = [
-              ('icons.in', ['icons.in/taskcoach.png', 'icons.in/taskcoach.icns'] if __import__('os').path.exists('icons.in/taskcoach.icns') else ['icons.in/taskcoach.png']),
+              ('icons.in', ['icons.in/taskcoach.png', 'icons.in/taskcoach.icns'] if os.path.exists('icons.in/taskcoach.icns') else ['icons.in/taskcoach.png']),
           ]
 
           # Include Welcome.tsk if it exists
-          import os
           if os.path.exists('Welcome.tsk'):
               DATA_FILES.append(('.', ['Welcome.tsk']))
 

--- a/taskcoachlib/gui/artprovider.py
+++ b/taskcoachlib/gui/artprovider.py
@@ -26,16 +26,12 @@ import sys
 
 def get_resource_path(relative_path):
     """Get absolute path to resource - works for development and frozen apps."""
-    if getattr(sys, 'frozen', False):
-        # Running as frozen executable (PyInstaller, py2exe, etc.)
-        if hasattr(sys, '_MEIPASS'):
-            # PyInstaller
-            base_path = sys._MEIPASS
-        else:
-            # py2exe
-            base_path = os.path.dirname(sys.executable)
+    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+        # PyInstaller stores resources in _MEIPASS
+        base_path = sys._MEIPASS
     else:
-        # Running in normal Python (development)
+        # Development, py2app, py2exe: use module's directory
+        # py2app/py2exe extract packages so __file__ works correctly
         base_path = os.path.dirname(__file__)
     return os.path.join(base_path, relative_path)
 


### PR DESCRIPTION
- Simplify get_resource_path() to use __file__ for py2app (packages extracted)
- Allow unittest to be bundled (required by pyparsing.testing import)