### PR TITLE
Fix widget style bugs and add macOS CI tests

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -224,8 +224,65 @@ jobs:
 
           echo "App bundle structure looks correct"
 
-          # Try to run the app briefly (will fail without display, but tests binary)
-          # timeout 5 "dist/Task Coach.app/Contents/MacOS/Task Coach" --help 2>/dev/null || true
+      - name: Test app initialization (catch Cocoa assertions)
+        run: |
+          # Use the bundled Python to test widget creation
+          # This catches wxAssertionError that only occur on macOS Cocoa backend
+          PYTHON_BIN="dist/Task Coach.app/Contents/MacOS/python"
+          RESOURCES="dist/Task Coach.app/Contents/Resources"
+
+          # Set up Python path to use bundled libraries
+          export PYTHONHOME="$RESOURCES"
+          export PYTHONPATH="$RESOURCES/lib/python3.11:$RESOURCES/lib/python3.11/site-packages"
+
+          echo "Testing widget initialization..."
+          "$PYTHON_BIN" << 'TEST_EOF'
+          import sys
+          import os
+
+          # Test basic imports
+          print("Testing imports...")
+          import wx
+          print(f"  wx version: {wx.version()}")
+
+          import taskcoachlib
+          print("  taskcoachlib imported")
+
+          # Create app for widget tests
+          print("Creating wx.App...")
+          app = wx.App(False)
+
+          # Test widgets that have caused macOS-specific crashes
+          print("Testing widget creation...")
+          frame = wx.Frame(None, title="Test")
+
+          # Test SearchCtrl with TE_PROCESS_ENTER (caught style bug)
+          from taskcoachlib.widgets import SearchCtrl
+          search = SearchCtrl(frame, style=wx.TE_PROCESS_ENTER, callback=lambda x: None)
+          print("  SearchCtrl: OK")
+
+          # Test MultiLineTextCtrl
+          from taskcoachlib.widgets.textctrl import MultiLineTextCtrl
+          text = MultiLineTextCtrl(frame, style=wx.TE_MULTILINE)
+          print("  MultiLineTextCtrl: OK")
+
+          # Test art provider (caught icon path bug)
+          from taskcoachlib.gui import artprovider
+          artprovider.init()
+          bitmap = wx.ArtProvider.GetBitmap("task", wx.ART_MENU, (16, 16))
+          print(f"  ArtProvider: OK (bitmap valid: {bitmap.IsOk()})")
+
+          # Clean up
+          frame.Destroy()
+
+          print("All widget tests passed!")
+          TEST_EOF
+
+          if [ $? -ne 0 ]; then
+            echo "ERROR: Widget initialization test failed"
+            exit 1
+          fi
+          echo "macOS Cocoa assertion tests passed"
 
       - name: Create DMG
         run: |

--- a/taskcoachlib/widgets/searchctrl.py
+++ b/taskcoachlib/widgets/searchctrl.py
@@ -369,14 +369,14 @@ class SearchCtrl(wx.Panel):
     """
 
     def __init__(self, parent, *args, **kwargs):
-        # Extract style before passing to Panel
-        kwargs.pop("style", 0)  # style is for the inner SearchCtrl, not Panel
+        # Extract style before passing to Panel (style is for inner SearchCtrl)
+        style = kwargs.pop("style", 0)
         super().__init__(parent)
 
         # Create sizer and inner search control
         # Use proportion=0 to prevent Panel from stretching beyond SearchCtrl size
         sizer = wx.BoxSizer(wx.HORIZONTAL)
-        self.__searchCtrl = _SearchCtrlInner(self, self, *args, **kwargs)
+        self.__searchCtrl = _SearchCtrlInner(self, self, *args, style=style, **kwargs)
         sizer.Add(self.__searchCtrl, 0, wx.EXPAND)
         self.SetSizer(sizer)
         # Fit Panel tightly to SearchCtrl for correct popup positioning

--- a/taskcoachlib/widgets/textctrl.py
+++ b/taskcoachlib/widgets/textctrl.py
@@ -220,8 +220,8 @@ class MultiLineTextCtrl(wx.Panel):
         return cls._nativePadding
 
     def __init__(self, parent, text="", *args, **kwargs):
-        # Extract style for the panel - remove text-specific styles
-        kwargs.pop("style", 0)
+        # Extract style for inner text control (not for panel wrapper)
+        style = kwargs.pop("style", 0)
         super().__init__(parent, style=wx.BORDER_NONE)
 
         # Track focus state for border drawing
@@ -230,8 +230,8 @@ class MultiLineTextCtrl(wx.Panel):
         # Get native padding from theme
         self._padding = self._getNativePadding(parent)
 
-        # Create the inner text control
-        self._textCtrl = _MultiLineTextCtrlInner(self, text, *args, **kwargs)
+        # Create the inner text control with the extracted style
+        self._textCtrl = _MultiLineTextCtrlInner(self, text, *args, style=style, **kwargs)
 
         # Match background colors
         self.SetBackgroundColour(self._textCtrl.GetBackgroundColour())


### PR DESCRIPTION
Bug fixes:
- SearchCtrl: style parameter was popped but not passed to inner control
- MultiLineTextCtrl: same issue - style was discarded

These caused wxAssertionError on macOS when using wx.TE_PROCESS_ENTER because the Cocoa backend strictly enforces style requirements.

CI improvement:
- Add widget initialization tests to macOS build workflow
- Tests SearchCtrl, MultiLineTextCtrl, and ArtProvider
- Catches Cocoa-specific assertions before release