### PR TITLE
Fix macOS crash: validate colors before creating brushes (v2.0.1.18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| Windows | `TaskCoach-2.0.1.17-windows-x64-setup.exe` |
-| Windows (portable) | `TaskCoach-2.0.1.17-windows-x64-portable.zip` | 
-| Debian 12 (Bookworm) | `taskcoach_2.0.1.17_debian-12-bookworm.deb` |
-| Debian 13 (Trixie) | `taskcoach_2.0.1.17_debian-13-trixie.deb` |
-| Debian Sid | `taskcoach_2.0.1.17_debian-sid.deb` |
-| Ubuntu 22.04 (Jammy) | `taskcoach_2.0.1.17_ubuntu-22.04-jammy.deb` |
-| Ubuntu 24.04 (Noble) | `taskcoach_2.0.1.17_ubuntu-24.04-noble.deb` |
+| Windows | `TaskCoach-2.0.1.18-windows-x64-setup.exe` |
+| Windows (portable) | `TaskCoach-2.0.1.18-windows-x64-portable.zip` | 
+| Debian 12 (Bookworm) | `taskcoach_2.0.1.18_debian-12-bookworm.deb` |
+| Debian 13 (Trixie) | `taskcoach_2.0.1.18_debian-13-trixie.deb` |
+| Debian Sid | `taskcoach_2.0.1.18_debian-sid.deb` |
+| Ubuntu 22.04 (Jammy) | `taskcoach_2.0.1.18_ubuntu-22.04-jammy.deb` |
+| Ubuntu 24.04 (Noble) | `taskcoach_2.0.1.18_ubuntu-24.04-noble.deb` |
 | Linux Mint | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| Arch Linux / Manjaro | `taskcoach-2.0.1.17-arch.pkg.tar.zst` |
-| Fedora 39/40 | `taskcoach-2.0.1.17-fedora40.noarch.rpm` |
-| Any Linux (x86_64) | `TaskCoach-2.0.1.17-x86_64.AppImage` |
+| Arch Linux / Manjaro | `taskcoach-2.0.1.18-arch.pkg.tar.zst` |
+| Fedora 39/40 | `taskcoach-2.0.1.18-fedora40.noarch.rpm` |
+| Any Linux (x86_64) | `TaskCoach-2.0.1.18-x86_64.AppImage` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -28,8 +28,8 @@ After installing, Task Coach should be in normal system launchers (Applications 
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.17_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.17_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.18_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.18_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -42,8 +42,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.17-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.17-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.18-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.18-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.17-fedora40.noarch.rpm
-sudo dnf install ./taskcoach-2.0.1.17-fedora40.noarch.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.18-fedora40.noarch.rpm
+sudo dnf install ./taskcoach-2.0.1.18-fedora40.noarch.rpm
 ```
 
 To uninstall:
@@ -70,13 +70,13 @@ sudo dnf autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.17-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.17-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.18-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.18-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.17-x86_64.AppImage
+./TaskCoach-2.0.1.18-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,8 +41,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "17"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.1.17
+patch = "18"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.1.18
 
 release_day = "13"  # Day of the release (1-31)
 release_month = "January"  # Month of the release

--- a/taskcoachlib/patches/hypertreelist.py
+++ b/taskcoachlib/patches/hypertreelist.py
@@ -312,6 +312,15 @@ import six
 # Version Info
 __version__ = "1.4"
 
+
+def _isValidColour(colour):
+    """Check if a colour is valid and can be used for drawing.
+
+    On macOS Cocoa, using invalid colours (None, wx.NullColour, or
+    uninitialized colours) causes wxAssertionError in wxMacCreateCGColor().
+    """
+    return colour is not None and isinstance(colour, wx.Colour) and colour.IsOk()
+
 # --------------------------------------------------------------------------
 # Constants
 # --------------------------------------------------------------------------
@@ -2987,14 +2996,18 @@ class TreeListMainWindow(CustomTreeCtrl):
         # determine background and show it
         if attr and attr.HasBackgroundColour():
             colBg = attr.GetBackgroundColour()
-            drawItemBackground = True
+            drawItemBackground = _isValidColour(colBg)
         else:
             colBg = self._backgroundColour
 
-        dc.SetBrush(wx.Brush(colBg))
+        if _isValidColour(colBg):
+            dc.SetBrush(wx.Brush(colBg))
         if attr and attr.HasBorderColour():
             colBorder = attr.GetBorderColour()
-            dc.SetPen(wx.Pen(colBorder, 1))
+            if _isValidColour(colBorder):
+                dc.SetPen(wx.Pen(colBorder, 1))
+            else:
+                dc.SetPen(wx.TRANSPARENT_PEN)
         else:
             dc.SetPen(wx.TRANSPARENT_PEN)
 
@@ -3177,7 +3190,7 @@ class TreeListMainWindow(CustomTreeCtrl):
                         itemrect = wx.Rect(text_x-2, item.GetY() + off_h, text_w+2*_MARGIN, total_h - off_h)
                         colBgX = item.GetBackgroundColour(i)
 
-                        if colBgX is not None and i != 0:
+                        if _isValidColour(colBgX) and i != 0:
                             dc.SetBrush(wx.Brush(colBgX, wx.SOLID))
                             dc.SetPen(wx.TRANSPARENT_PEN)
                             dc.DrawRectangle(itemrect)
@@ -3194,7 +3207,7 @@ class TreeListMainWindow(CustomTreeCtrl):
                         itemrect = wx.Rect(text_x-2, item.GetY() + off_h, text_w+2*_MARGIN, total_h - off_h)
                         colBgX = item.GetBackgroundColour(i)
 
-                        if colBgX is not None:
+                        if _isValidColour(colBgX):
                             dc.SetBrush(wx.Brush(colBgX, wx.SOLID))
                             dc.SetPen(wx.TRANSPARENT_PEN)
                             dc.DrawRectangle(itemrect)
@@ -3362,13 +3375,14 @@ class TreeListMainWindow(CustomTreeCtrl):
                 attr = item.GetAttributes()
 
                 if attr and attr.HasBackgroundColour():
-                    width = self._owner.GetEventHandler().GetColumn(self._main_column).GetWidth()
                     colBg = attr.GetBackgroundColour()
-                    itemrect = wx.Rect(x_maincol, y-h-1, width, h+1)
+                    if _isValidColour(colBg):
+                        width = self._owner.GetEventHandler().GetColumn(self._main_column).GetWidth()
+                        itemrect = wx.Rect(x_maincol, y-h-1, width, h+1)
 
-                    dc.SetBrush(wx.Brush(colBg, wx.SOLID))
-                    dc.SetPen(wx.TRANSPARENT_PEN)
-                    dc.DrawRectangle(itemrect)
+                        dc.SetBrush(wx.Brush(colBg, wx.SOLID))
+                        dc.SetPen(wx.TRANSPARENT_PEN)
+                        dc.DrawRectangle(itemrect)
 
             # draw item
             self.PaintItem(item, dc)
@@ -3511,7 +3525,9 @@ class TreeListMainWindow(CustomTreeCtrl):
             dc = wx.BufferedPaintDC(self)
             rect = self.GetUpdateRegion().GetBox()
             dc.SetClippingRegion(rect)
-            dc.SetBackground(wx.Brush(self.GetBackgroundColour()))
+            bgColour = self.GetBackgroundColour()
+            if _isValidColour(bgColour):
+                dc.SetBackground(wx.Brush(bgColour))
             if self._backgroundImage:
                 self.TileBackground(dc)
             else:


### PR DESCRIPTION
On macOS Cocoa, using invalid/uninitialized wx.Colour with brushes or pens causes wxAssertionError from wxMacCreateCGColor. This is macOS-specific - GTK and Windows backends don't have this strict assertion.

Added _isValidColour() helper function in hypertreelist.py to validate colors before use with SetBrush/SetPen/SetTextForeground operations.

Fixes wxAssertionError crash when displaying tasks/categories on macOS.

Reference: wxWidgets Issue #18470