### PR TITLE
Fix macOS tooltip: replace deprecated MoveXY with Move (v2.0.1.19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| Windows | `TaskCoach-2.0.1.18-windows-x64-setup.exe` |
-| Windows (portable) | `TaskCoach-2.0.1.18-windows-x64-portable.zip` | 
-| Debian 12 (Bookworm) | `taskcoach_2.0.1.18_debian-12-bookworm.deb` |
-| Debian 13 (Trixie) | `taskcoach_2.0.1.18_debian-13-trixie.deb` |
-| Debian Sid | `taskcoach_2.0.1.18_debian-sid.deb` |
-| Ubuntu 22.04 (Jammy) | `taskcoach_2.0.1.18_ubuntu-22.04-jammy.deb` |
-| Ubuntu 24.04 (Noble) | `taskcoach_2.0.1.18_ubuntu-24.04-noble.deb` |
+| Windows | `TaskCoach-2.0.1.19-windows-x64-setup.exe` |
+| Windows (portable) | `TaskCoach-2.0.1.19-windows-x64-portable.zip` | 
+| Debian 12 (Bookworm) | `taskcoach_2.0.1.19_debian-12-bookworm.deb` |
+| Debian 13 (Trixie) | `taskcoach_2.0.1.19_debian-13-trixie.deb` |
+| Debian Sid | `taskcoach_2.0.1.19_debian-sid.deb` |
+| Ubuntu 22.04 (Jammy) | `taskcoach_2.0.1.19_ubuntu-22.04-jammy.deb` |
+| Ubuntu 24.04 (Noble) | `taskcoach_2.0.1.19_ubuntu-24.04-noble.deb` |
 | Linux Mint | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| Arch Linux / Manjaro | `taskcoach-2.0.1.18-arch.pkg.tar.zst` |
-| Fedora 39/40 | `taskcoach-2.0.1.18-fedora40.noarch.rpm` |
-| Any Linux (x86_64) | `TaskCoach-2.0.1.18-x86_64.AppImage` |
+| Arch Linux / Manjaro | `taskcoach-2.0.1.19-arch.pkg.tar.zst` |
+| Fedora 39/40 | `taskcoach-2.0.1.19-fedora40.noarch.rpm` |
+| Any Linux (x86_64) | `TaskCoach-2.0.1.19-x86_64.AppImage` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -28,8 +28,8 @@ After installing, Task Coach should be in normal system launchers (Applications 
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.18_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.18_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.19_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.19_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -42,8 +42,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.18-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.18-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.19-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.19-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.18-fedora40.noarch.rpm
-sudo dnf install ./taskcoach-2.0.1.18-fedora40.noarch.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.19-fedora40.noarch.rpm
+sudo dnf install ./taskcoach-2.0.1.19-fedora40.noarch.rpm
 ```
 
 To uninstall:
@@ -70,13 +70,13 @@ sudo dnf autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.18-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.18-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.19-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.19-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.18-x86_64.AppImage
+./TaskCoach-2.0.1.19-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "18"  # Patch number - INCREMENT THIS for each release
+patch = "19"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.1.18
 
 release_day = "13"  # Day of the release (1-31)

--- a/taskcoachlib/widgets/tooltip.py
+++ b/taskcoachlib/widgets/tooltip.py
@@ -172,14 +172,14 @@ elif operating_system.isMac():
                 self.__maxWidth = max(self.__maxWidth, x + width)
                 self.__maxHeight = max(self.__maxHeight, y + height)
 
-            self.MoveXY(self.__maxWidth, self.__maxHeight)
+            self.Move(self.__maxWidth, self.__maxHeight)
             super().Show()
 
         def Show(self, x, y, width, height):  # pylint: disable=W0221
             self.SetSize(x, y, width, height)
 
         def Hide(self):  # pylint: disable=W0221
-            self.MoveXY(self.__maxWidth, self.__maxHeight)
+            self.Move(self.__maxWidth, self.__maxHeight)
 
 else:
 


### PR DESCRIPTION
MoveXY is deprecated in wxPython 4.x. Use Move(x, y) instead. This was causing wxPyDeprecationWarning on macOS.