### PR TITLE
Fix macOS editor crash and improve crash diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| Windows | `TaskCoach-2.0.1.19-windows-x64-setup.exe` |
-| Windows (portable) | `TaskCoach-2.0.1.19-windows-x64-portable.zip` | 
-| Debian 12 (Bookworm) | `taskcoach_2.0.1.19_debian-12-bookworm.deb` |
-| Debian 13 (Trixie) | `taskcoach_2.0.1.19_debian-13-trixie.deb` |
-| Debian Sid | `taskcoach_2.0.1.19_debian-sid.deb` |
-| Ubuntu 22.04 (Jammy) | `taskcoach_2.0.1.19_ubuntu-22.04-jammy.deb` |
-| Ubuntu 24.04 (Noble) | `taskcoach_2.0.1.19_ubuntu-24.04-noble.deb` |
+| Windows | `TaskCoach-2.0.1.20-windows-x64-setup.exe` |
+| Windows (portable) | `TaskCoach-2.0.1.20-windows-x64-portable.zip` | 
+| Debian 12 (Bookworm) | `taskcoach_2.0.1.20_debian-12-bookworm.deb` |
+| Debian 13 (Trixie) | `taskcoach_2.0.1.20_debian-13-trixie.deb` |
+| Debian Sid | `taskcoach_2.0.1.20_debian-sid.deb` |
+| Ubuntu 22.04 (Jammy) | `taskcoach_2.0.1.20_ubuntu-22.04-jammy.deb` |
+| Ubuntu 24.04 (Noble) | `taskcoach_2.0.1.20_ubuntu-24.04-noble.deb` |
 | Linux Mint | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| Arch Linux / Manjaro | `taskcoach-2.0.1.19-arch.pkg.tar.zst` |
-| Fedora 39/40 | `taskcoach-2.0.1.19-fedora40.noarch.rpm` |
-| Any Linux (x86_64) | `TaskCoach-2.0.1.19-x86_64.AppImage` |
+| Arch Linux / Manjaro | `taskcoach-2.0.1.20-arch.pkg.tar.zst` |
+| Fedora 39/40 | `taskcoach-2.0.1.20-fedora40.noarch.rpm` |
+| Any Linux (x86_64) | `TaskCoach-2.0.1.20-x86_64.AppImage` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -28,8 +28,8 @@ After installing, Task Coach should be in normal system launchers (Applications 
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.19_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.19_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.20_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.20_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -42,8 +42,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.19-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.19-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.20-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.20-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.19-fedora40.noarch.rpm
-sudo dnf install ./taskcoach-2.0.1.19-fedora40.noarch.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.20-fedora40.noarch.rpm
+sudo dnf install ./taskcoach-2.0.1.20-fedora40.noarch.rpm
 ```
 
 To uninstall:
@@ -70,13 +70,13 @@ sudo dnf autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.19-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.19-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.20-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.20-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.19-x86_64.AppImage
+./TaskCoach-2.0.1.20-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/taskcoach.py
+++ b/taskcoach.py
@@ -20,25 +20,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import sys
+import faulthandler
 
-# Early startup logging for debugging pythonw.exe silent failures
-def _setup_startup_log():
-    """Redirect stderr to a log file for debugging when run without console."""
-    if sys.platform == 'win32' and not sys.stderr.isatty():
-        try:
-            # Log to user's LOCALAPPDATA or temp directory
-            log_dir = os.environ.get('LOCALAPPDATA', os.environ.get('TEMP', '.'))
-            log_path = os.path.join(log_dir, 'TaskCoach', 'startup.log')
-            os.makedirs(os.path.dirname(log_path), exist_ok=True)
-            sys.stderr = open(log_path, 'w', encoding='utf-8')
-            print(f"Task Coach startup log: {log_path}", file=sys.stderr)
-            print(f"Python: {sys.executable}", file=sys.stderr)
-            print(f"Working dir: {os.getcwd()}", file=sys.stderr)
-            print(f"Script: {__file__}", file=sys.stderr)
-        except Exception as e:
-            pass  # Can't log if we can't create the log file
-
-_setup_startup_log()
+# IMPORTANT: DO NOT REMOVE faulthandler even if current bugs are fixed!
+# This provides detailed Python stack traces on crashes (SIGSEGV, SIGBUS, etc.)
+# which are essential for diagnosing future issues. Without it, crashes only show
+# "Fatal Python error: Segmentation fault" with no actionable information.
+faulthandler.enable()
 
 # Fix DLL loading on Windows with Python embeddable package
 # The embeddable package doesn't process .pth files by default.

--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -2266,6 +2266,7 @@ class Editor(BalloonTipManager, widgets.Dialog):
         if operating_system.isMac():
             self._interior.SetFocusIgnoringChildren()
         if self.__timer is not None:
+            self.__timer.Stop()
             IdProvider.put(self.__timer.GetId())
         IdProvider.put(self.__new_effort_id)
         IdProvider.put(self.__next_tab_id)

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "19"  # Patch number - INCREMENT THIS for each release
+patch = "20"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.1.18
 
 release_day = "13"  # Day of the release (1-31)


### PR DESCRIPTION
macOS crash fix:
- Stop editor timer before window destruction to prevent crash when closing task/note/effort editor dialogs

Crash diagnostics:
- Enable faulthandler for detailed Python stack traces on crashes (SIGSEGV, SIGBUS, etc.) - works on all platforms
- Remove Windows-specific stderr log redirection (users should run from console to debug issues)