### PR TITLE
Replace safety claims with verification instructions in install docs

### DIFF
--- a/README_INSTALL_MACOS.md
+++ b/README_INSTALL_MACOS.md
@@ -102,7 +102,9 @@ Task Coach is open-source software that isn't notarized with Apple. Notarization
 1. A paid Apple Developer account ($99/year)
 2. Submitting the app to Apple's automated security checks
 
-This is impractical for volunteer-maintained open-source projects. The software is safe - you can verify by:
+This is impractical for volunteer-maintained open-source projects.
 
-- Reviewing the [source code on GitHub](https://github.com/taskcoach/taskcoach)
-- Checking the SHA256 hash on the release page matches your download
+If you want to verify your download:
+
+- **Check the SHA256 hash** - Compare the hash on the [release page](https://github.com/taskcoach/taskcoach/releases) with your downloaded file using `shasum -a 256 <filename>` in Terminal
+- **Review the source code** - The complete source is available on [GitHub](https://github.com/taskcoach/taskcoach)

--- a/README_INSTALL_WINDOWS.md
+++ b/README_INSTALL_WINDOWS.md
@@ -85,8 +85,10 @@ Some antivirus software may flag the installer. This is a false positive common 
 
 ## Why the Security Warning?
 
-Task Coach is open-source software distributed without a paid code signing certificate. Microsoft charges hundreds of dollars per year for Extended Validation (EV) certificates, which is impractical for volunteer-maintained projects. The software is safe - you can verify by:
+Task Coach is open-source software distributed without a paid code signing certificate. Microsoft charges hundreds of dollars per year for Extended Validation (EV) certificates, which is impractical for volunteer-maintained projects.
 
-- Reviewing the [source code on GitHub](https://github.com/taskcoach/taskcoach)
-- Checking the SHA256 hash on the release page matches your download
-- Scanning with [VirusTotal](https://www.virustotal.com)
+If you want to verify your download:
+
+- **Check the SHA256 hash** - Compare the hash on the [release page](https://github.com/taskcoach/taskcoach/releases) with your downloaded file using `certutil -hashfile <filename> SHA256`
+- **Review the source code** - The complete source is available on [GitHub](https://github.com/taskcoach/taskcoach)
+- **Scan the file** - Upload to [VirusTotal](https://www.virustotal.com) or use your antivirus software


### PR DESCRIPTION
Remove unsubstantiated "the software is safe" claims from install documentation. Replace with neutral instructions for users to verify downloads themselves (SHA256 checksums, source code review).