### PR TITLE
Fix Windows encoding issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.23-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.23-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.23_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.23_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.23_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.23-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.24-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.24-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.24_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.24_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.24_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.24-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.23-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.23-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.23_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.23_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.23-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.23-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.24-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.24-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.24_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.24_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.24-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.24-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.23_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.23_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.24_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.24_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.23-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.23-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.24-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.24-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.23-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.23-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.24-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.24-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.23-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.23-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.24-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.24-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.23-x86_64.AppImage
+./TaskCoach-2.0.1.24-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/taskcoachlib/gui/uicommand/uicommand.py
+++ b/taskcoachlib/gui/uicommand/uicommand.py
@@ -1675,7 +1675,7 @@ class TaskNewFromTemplate(TaskNew):
         )  # pylint: disable=E1103
 
     def __readTemplate(self):
-        return persistence.TemplateXMLReader(open(self.__filename, "r")).read()
+        return persistence.TemplateXMLReader(open(self.__filename, "r", encoding="utf-8")).read()
 
     def doCommand(self, event, show=True):  # pylint: disable=W0221
         # The task template is read every time because it's the

--- a/taskcoachlib/help/__init__.py
+++ b/taskcoachlib/help/__init__.py
@@ -803,14 +803,14 @@ helpHTML = (
 def _get_splash_url():
     """Get the file:// URL to the splash screen image.
 
-    Returns a properly formatted file:// URL that works on all platforms
-    (Windows needs file:///C:/path, Unix needs file:///path).
+    Returns a properly formatted file:// URL that works on all platforms.
+    Uses pathlib.Path.as_uri() for reliable cross-platform URI generation.
     """
-    from urllib.request import pathname2url
-    splash_path = os.path.join(os.path.dirname(__file__), "..", "gui", "icons", "splash.jpg")
-    splash_path = os.path.normpath(os.path.abspath(splash_path))
-    if os.path.exists(splash_path):
-        return "file://" + pathname2url(splash_path)
+    from pathlib import Path
+    splash_path = Path(__file__).parent / ".." / "gui" / "icons" / "splash.jpg"
+    splash_path = splash_path.resolve()
+    if splash_path.exists():
+        return splash_path.as_uri()
     return None
 
 

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "23"  # Patch number - INCREMENT THIS for each release
+patch = "24"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.1.18
 
 release_day = "15"  # Day of the release (1-31)

--- a/taskcoachlib/persistence/taskfile.py
+++ b/taskcoachlib/persistence/taskfile.py
@@ -450,7 +450,7 @@ class TaskFile(patterns.Observer):
         return SafeWriteFile(self.__filename + suffix)
 
     def _openForRead(self):
-        return open(self.__filename, "r")
+        return open(self.__filename, "r", encoding="utf-8")
 
     def load(self, filename=None):
         pub.sendMessage("taskfile.aboutToRead", taskFile=self)

--- a/taskcoachlib/persistence/templatelist.py
+++ b/taskcoachlib/persistence/templatelist.py
@@ -37,7 +37,7 @@ class TemplateList(object):
 
     def _readTemplate(self, filename, TemplateReader, openFile):
         try:
-            fd = openFile(os.path.join(self._path, filename), "r")
+            fd = openFile(os.path.join(self._path, filename), "r", encoding="utf-8")
         except IOError:
             return
         try:
@@ -74,7 +74,7 @@ class TemplateList(object):
         )
 
         for task, name in self._templates:
-            templateFile = open(os.path.join(self._path, name), "w")
+            templateFile = open(os.path.join(self._path, name), "w", encoding="utf-8")
             writer = TemplateXMLWriter(templateFile)
             writer.write(task)
             templateFile.close()
@@ -87,11 +87,11 @@ class TemplateList(object):
     def addTemplate(self, task):
         handle, filename = tempfile.mkstemp(".tsktmpl", dir=self._path)
         os.close(handle)
-        templateFile = open(filename, "w")
+        templateFile = open(filename, "w", encoding="utf-8")
         writer = TemplateXMLWriter(templateFile)
         writer.write(task.copy())
         templateFile.close()
-        theTask = TemplateXMLReader(open(filename, "r")).read()
+        theTask = TemplateXMLReader(open(filename, "r", encoding="utf-8")).read()
         self._templates.append((theTask, os.path.split(filename)[-1]))
         return theTask
 

--- a/taskcoachlib/persistence/xml/reader.py
+++ b/taskcoachlib/persistence/xml/reader.py
@@ -235,7 +235,7 @@ class XMLReader(object):
         changesName = self.__fd.name + ".delta"
         if os.path.exists(changesName):
             changes = ChangesXMLReader(
-                open(self.__fd.name + ".delta", "r")
+                open(self.__fd.name + ".delta", "r", encoding="utf-8")
             ).read()
         else:
             changes = dict()


### PR DESCRIPTION
- Fix UTF-8 encoding for task files on Windows by adding explicit encoding="utf-8" to all file open() calls. This fixes:
  - Accented characters (e.g., "Instalação") being mangled after save/reopen
  - Unicode bullets in Welcome.tsk appearing garbled

- Fix About dialog splash image not displaying on Windows by using pathlib.Path.as_uri() instead of urllib.request.pathname2url() for more reliable cross-platform file:// URI generation