### PR TITLE
Fix Windows scrollbar issues in HyperTreeList AUI panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.24-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.24-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.24_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.24_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.24_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.24-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.25-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.25-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.25_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.25_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.25_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.25-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.24-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.24-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.24_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.24_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.24-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.24-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.25-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.25-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.25_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.25_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.25-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.25-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.24_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.24_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.25_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.25_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.24-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.24-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.25-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.25-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.24-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.24-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.25-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.25-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.24-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.24-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.25-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.25-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.24-x86_64.AppImage
+./TaskCoach-2.0.1.25-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "24"  # Patch number - INCREMENT THIS for each release
+patch = "25"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.1.18
 
 release_day = "15"  # Day of the release (1-31)

--- a/taskcoachlib/widgets/treectrl.py
+++ b/taskcoachlib/widgets/treectrl.py
@@ -42,6 +42,32 @@ class BaseHyperTreeList(hypertreelist.HyperTreeList):
         super().__init__(
             parent, id, pos, size, style, agwStyle, validator, name
         )
+        # Bind our own size handler to fix scrollbar issues on Windows.
+        # The base HyperTreeList.OnSize only calls DoHeaderLayout() which
+        # repositions child windows but doesn't recalculate scrollbars.
+        self.Bind(wx.EVT_SIZE, self.__onSize)
+
+    def __onSize(self, event):
+        """Handle size events to ensure scrollbars are recalculated.
+
+        On Windows, side-docked AUI panes don't get scrollbars when the content
+        exceeds the visible area because HyperTreeList's OnSize handler only
+        repositions child windows without recalculating scrollbars. We fix this
+        by calling AdjustMyScrollbars() after the base OnSize handler runs.
+        """
+        event.Skip()  # Let base class handle layout first
+        # Schedule scrollbar adjustment after the layout is complete
+        wx.CallAfter(self.__safeAdjustScrollbars)
+
+    def __safeAdjustScrollbars(self):
+        """Safely adjust scrollbars, guarding against deleted C++ objects."""
+        try:
+            main_win = self.GetMainWindow()
+            if main_win:
+                main_win.AdjustMyScrollbars()
+        except RuntimeError:
+            # wrapped C/C++ object has been deleted
+            pass
 
 
 class HyperTreeList(draganddrop.TreeCtrlDragAndDropMixin, BaseHyperTreeList):


### PR DESCRIPTION
On Windows, side-docked AUI panes (Notes, Categories, etc.) were not showing scrollbars when content exceeded the visible area. This was because HyperTreeList's OnSize handler only calls DoHeaderLayout() which repositions child windows but doesn't recalculate scrollbars.

GTK handles this automatically, but Windows requires explicit calls.

Fix: Add EVT_SIZE handler in BaseHyperTreeList that calls AdjustMyScrollbars() via wx.CallAfter() after layout completes. This propagates to all tree controls including those in Edit dialogs.

Bump version to 2.0.1.25.

No more elevator bar on the task windows #221
