### PR TITLE
Fix category filter showing uncategorized parent when categorized child is hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.26-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.26-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.26_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.26_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.26_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.26-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.27-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.27-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.27_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.27_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.27_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.27-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.26-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.26-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.26_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.26_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.26-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.26-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.27-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.27-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.27_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.27_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.27-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.27-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.26_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.26_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.27_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.27_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.26-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.26-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.27-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.27-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.26-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.26-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.27-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.27-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.26-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.26-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.27-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.27-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.26-x86_64.AppImage
+./TaskCoach-2.0.1.27-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/taskcoachlib/config/defaults.py
+++ b/taskcoachlib/config/defaults.py
@@ -487,6 +487,7 @@ defaults = {
         "blinktaskbariconwhentrackingeffort": "True",
         # Theme: 'automatic' (detect from system), 'light', or 'dark'
         "theme": "light",
+        "splash": "False",  # Show splash screen on startup
     },
     "effortdialog": {
         "size": "(-1, -1)",  # Size of the dialogs, calculated by default

--- a/taskcoachlib/domain/base/filter.py
+++ b/taskcoachlib/domain/base/filter.py
@@ -23,8 +23,24 @@ from taskcoachlib.domain.base import object as domainobject
 
 
 class Filter(patterns.SetDecorator):
+    """Base class for filters that can operate in tree or list mode.
+
+    In tree mode, when an item matches the filter criteria, its ancestors are
+    automatically included to maintain the tree hierarchy. These ancestor items
+    are tracked as "filter_forced" - they were added to preserve structure, not
+    because they matched the filter criteria themselves.
+
+    This tracking is important for filter chains (e.g., CategoryFilter -> ViewFilter).
+    When an outer filter removes items, it can use getAccumulatedFilterForced() to
+    identify ancestors that may have become orphans (no visible children) and should
+    also be removed. See ViewFilter.reset() for the cleanup implementation.
+    """
+
     def __init__(self, *args, **kwargs):
         self.__treeMode = kwargs.pop("treeMode", False)
+        # Track items added as ancestors to maintain tree hierarchy, not because
+        # they matched filter criteria. Used by outer filters for orphan cleanup.
+        self.__filterForced = set()
         super().__init__(*args, **kwargs)
         self.reset()
 
@@ -46,19 +62,68 @@ class Filter(patterns.SetDecorator):
 
     @patterns.eventSource
     def reset(self, event=None):
+        """Recompute the filtered set based on current filter criteria.
+
+        In tree mode, ancestors of matching items are included to maintain
+        hierarchy. These ancestors are tracked in __filterForced so that
+        outer filters can identify and remove them if they become orphans
+        (i.e., all their matching descendants are later filtered out).
+        """
         if self.isFrozen():
             return
 
-        filteredItems = set(self.filterItems(self.observable()))
+        # Get items that directly match this filter's criteria
+        directMatches = set(self.filterItems(self.observable()))
+        filteredItems = directMatches.copy()
+
+        # Reset and rebuild filter_forced tracking
+        self.__filterForced = set()
         if self.treeMode():
-            for item in filteredItems.copy():
-                filteredItems.update(set(item.ancestors()))
+            # In tree mode, include ancestors of matching items to maintain
+            # tree structure. Track these as "filter_forced" since they don't
+            # match criteria themselves - they're only included for hierarchy.
+            for item in directMatches:
+                for ancestor in item.ancestors():
+                    if ancestor not in directMatches:
+                        self.__filterForced.add(ancestor)
+                        filteredItems.add(ancestor)
+
         self.removeItemsFromSelf(
             [item for item in self if item not in filteredItems], event=event
         )
         self.extendSelf(
             [item for item in filteredItems if item not in self], event=event
         )
+
+    def getFilterForced(self):
+        """Return items that were added as ancestors, not directly matched.
+
+        These items are in the filter only to maintain tree hierarchy, not
+        because they passed the filter criteria.
+        """
+        return self.__filterForced.copy()
+
+    def getAccumulatedFilterForced(self):
+        """Return filter_forced items accumulated from the entire filter chain.
+
+        Walks up the filter chain (via observable()) to collect all items that
+        were added as ancestors by any filter in the chain. This is used by
+        the outermost filter (typically ViewFilter) to identify items that may
+        need cleanup if they've become orphans.
+
+        Example: CategoryFilter adds a parent as ancestor of a categorized child.
+        ViewFilter later hides the child (completed). ViewFilter uses this method
+        to find that the parent was filter_forced, and removes it since it has
+        no visible children.
+        """
+        accumulated = self.__filterForced.copy()
+        try:
+            inner = self.observable()
+            if hasattr(inner, 'getAccumulatedFilterForced'):
+                accumulated |= inner.getAccumulatedFilterForced()
+        except AttributeError:
+            pass
+        return accumulated
 
     def filterItems(self, items):
         """filter returns the items that pass the filter."""

--- a/taskcoachlib/domain/task/filter.py
+++ b/taskcoachlib/domain/task/filter.py
@@ -84,6 +84,65 @@ class ViewFilter(tasklist.TaskListQueryMixin, base.Filter):
         self.__hideCompositeTasks = hide
         self.reset()
 
+    @patterns.eventSource
+    def reset(self, event=None):
+        """Override reset to add recursive cleanup of orphan ancestors.
+
+        This fixes a bug where uncategorized parent tasks would appear when
+        filtering by category, if they had a categorized child that was hidden
+        by the status filter.
+
+        The problem:
+        - Filter chain: TaskList -> CategoryFilter -> ViewFilter
+        - CategoryFilter includes parent as ancestor of categorized child
+        - ViewFilter hides the child (e.g., completed)
+        - Without cleanup, parent remains visible despite having no visible
+          children and not matching the category filter itself
+
+        The solution:
+        - After normal filtering, get all "filter_forced" items from the chain
+          (items added as ancestors, not because they matched filter criteria)
+        - Recursively remove filter_forced items that have no visible children
+        - The recursion handles grandparents that become orphans when their
+          children are removed
+        """
+        # Call parent reset first (does normal filtering + ancestor addition)
+        super().reset(event=event)
+
+        if not self.treeMode():
+            return
+
+        # Get filter_forced items from entire filter chain (e.g., parents added
+        # by CategoryFilter as ancestors of categorized children)
+        filterForced = self.getAccumulatedFilterForced()
+        if not filterForced:
+            return
+
+        # Recursive cleanup: remove filter_forced items with no visible children.
+        # We loop until no more removals because removing a parent may make its
+        # grandparent an orphan too.
+        currentItems = set(self)
+        changed = True
+        while changed:
+            changed = False
+            for item in list(filterForced):
+                if item in currentItems:
+                    # Check if item has any children still in the visible set
+                    hasVisibleChild = any(
+                        child in currentItems for child in item.children()
+                    )
+                    if not hasVisibleChild:
+                        # This item was only included as an ancestor and now has
+                        # no visible children - remove it
+                        currentItems.discard(item)
+                        filterForced.discard(item)
+                        changed = True  # Removal may create new orphans
+
+        # Apply the cleanup by removing orphaned items
+        orphans = set(self) - currentItems
+        if orphans:
+            self.removeItemsFromSelf(list(orphans), event=event)
+
     def filterItems(self, tasks):
         return [
             task for task in tasks if self.filterTask(task)

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "26"  # Patch number - INCREMENT THIS for each release
+patch = "27"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.1.18
 
 release_day = "15"  # Day of the release (1-31)

--- a/tests/unittests/domainTests/CategoryFilterTest.py
+++ b/tests/unittests/domainTests/CategoryFilterTest.py
@@ -889,3 +889,114 @@ class CategoryFilterAndViewFilterInTreeModeTest(
     CategoryFilterAndViewFilterFixtureAndCommonTestsMixin, test.TestCase
 ):
     treeMode = True
+
+
+class ViewFilterWrappingCategoryFilterFixture(CategoryFilterHelpersMixin):
+    """Test the filter order used in the actual application:
+    TaskList -> CategoryFilter -> ViewFilter
+
+    This is the opposite order of CategoryFilterAndViewFilterFixture.
+    The bug occurs when:
+    1. Parent task has no category
+    2. Child task has category A and is completed
+    3. Category A filter is active
+    4. Completed tasks are hidden
+
+    Without the fix, the parent would still show because:
+    - CategoryFilter adds parent as ancestor of categorized child
+    - ViewFilter removes child (completed) but parent passes (not completed)
+
+    With the fix, ViewFilter's recursive cleanup removes orphan ancestors.
+    """
+    treeMode = True
+
+    def setUp(self):
+        task.Task.settings = config.Settings(load=False)
+        # Parent task with no category
+        self.parent = task.Task("parent task")
+        self.parent.setShouldMarkCompletedWhenAllChildrenCompleted(False)
+        # Child task with category, completed
+        self.child = task.Task("child task")
+        self.child.setCompletionDateTime()
+        self.childCategory = category.Category("child category")
+        self.childCategory.addCategorizable(self.child)
+        self.parent.addChild(self.child)
+        self.tasks = task.TaskList([self.parent, self.child])
+        self.categories = category.CategoryList([self.childCategory])
+        # Filter order: TaskList -> CategoryFilter -> ViewFilter (like the app)
+        self.categoryFilter = category.filter.CategoryFilter(
+            self.tasks, categories=self.categories, treeMode=self.treeMode
+        )
+        self.viewFilter = task.filter.ViewFilter(
+            self.categoryFilter, treeMode=self.treeMode
+        )
+
+    def testParentHiddenWhenCategoryFilteredAndChildCompleted(self):
+        """The main bug scenario: parent should be hidden when its only
+        categorized child is hidden due to completion status."""
+        # First, filter by category
+        self.childCategory.setFiltered(True)
+        # At this point, categoryFilter should have parent (as ancestor) and child
+        self.assertEqual(2, len(self.categoryFilter))
+        # viewFilter should also show both
+        self.assertEqual(2, len(self.viewFilter))
+        # Now hide completed tasks
+        self.viewFilter.hideTaskStatus(task.status.completed)
+        # viewFilter should now be empty - parent has no visible categorized children
+        self.assertEqual(0, len(self.viewFilter))
+
+    def testParentShownWhenChildUnhidden(self):
+        """When we unhide completed tasks, parent should reappear."""
+        self.childCategory.setFiltered(True)
+        self.viewFilter.hideTaskStatus(task.status.completed)
+        self.assertEqual(0, len(self.viewFilter))
+        # Unhide completed tasks
+        self.viewFilter.hideTaskStatus(task.status.completed, False)
+        # Both should be visible again
+        self.assertEqual(2, len(self.viewFilter))
+
+    def testParentShownWhenCategoryUnfiltered(self):
+        """When we remove category filter, parent should reappear."""
+        self.childCategory.setFiltered(True)
+        self.viewFilter.hideTaskStatus(task.status.completed)
+        self.assertEqual(0, len(self.viewFilter))
+        # Remove category filter
+        self.childCategory.setFiltered(False)
+        # Explicitly reset viewFilter (in the app, UI refresh triggers this)
+        # This is needed because categoryFilter items don't change when
+        # removing the filter, so no events fire to trigger viewFilter reset
+        self.viewFilter.reset()
+        # Parent should be visible (no category filter active)
+        self.assertEqual(1, len(self.viewFilter))
+
+
+class ViewFilterWrappingCategoryFilterInTreeModeTest(
+    ViewFilterWrappingCategoryFilterFixture, test.TestCase
+):
+    treeMode = True
+
+
+class ViewFilterWrappingCategoryFilterInListModeTest(
+    ViewFilterWrappingCategoryFilterFixture, test.TestCase
+):
+    treeMode = False
+
+    def testParentHiddenWhenCategoryFilteredAndChildCompleted(self):
+        """In list mode, parent is not shown as ancestor, so behavior differs."""
+        self.childCategory.setFiltered(True)
+        # In list mode, only child is shown (no ancestors)
+        self.assertEqual(1, len(self.categoryFilter))
+        self.assertEqual(1, len(self.viewFilter))
+        # Hide completed tasks
+        self.viewFilter.hideTaskStatus(task.status.completed)
+        # Should be empty
+        self.assertEqual(0, len(self.viewFilter))
+
+    def testParentShownWhenChildUnhidden(self):
+        """In list mode, only child is shown when unhidden."""
+        self.childCategory.setFiltered(True)
+        self.viewFilter.hideTaskStatus(task.status.completed)
+        self.assertEqual(0, len(self.viewFilter))
+        self.viewFilter.hideTaskStatus(task.status.completed, False)
+        # Only child visible in list mode
+        self.assertEqual(1, len(self.viewFilter))


### PR DESCRIPTION
Fix category filter showing uncategorized parent when categorized child is hidden

When filtering by category in tree mode, parent tasks without the filtered category were incorrectly shown if they had a child with that category, even when the child was hidden due to other filters (e.g., hiding completed tasks).

Root cause: The base Filter class adds ancestors in tree mode to maintain tree hierarchy, but each filter operates independently. When CategoryFilter added a parent as an ancestor of a category-matched child, and ViewFilter later hid that child, the parent remained visible as an orphan.

Fix: Implement filter_forced tracking and recursive orphan cleanup:
- Base Filter now tracks which items were added as ancestors vs directly matched (filter_forced set)
- Added getFilterForced() and getAccumulatedFilterForced() methods to propagate this metadata through the filter chain
- ViewFilter performs recursive cleanup after filtering to remove filter_forced items that have no visible children

Also fixes missing 'splash' setting in window defaults.

moved from SF: strange that tasks without a category are shown when filtered to a subtask's category even if subtask is hidden due to state #181