### PR TITLE
Refactor Linux system tray to use AppIndicator exclusively

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,25 @@ To launch the AppImage, open the file or run:
 
 To remove: simply delete the AppImage file.
 
+#### Linux System Tray
+
+Task Coach uses libayatana-appindicator for the system tray icon on Linux. This provides consistent behavior across all desktop environments (KDE, XFCE, MATE, LXQt, LXDE, Cinnamon) and works on both X11 and Wayland.
+
+The package is installed automatically with the .deb/.rpm packages. For manual installation:
+
+```bash
+# Debian/Ubuntu
+sudo apt install gir1.2-ayatanaappindicator3-0.1
+
+# Fedora
+sudo dnf install libayatana-appindicator-gtk3
+
+# Arch Linux
+sudo pacman -S libayatana-appindicator
+```
+
+**Note:** GNOME Shell removed built-in system tray support. GNOME users need the [AppIndicator Support](https://extensions.gnome.org/extension/615/appindicator-support/) extension to see tray icons. Ubuntu pre-installs this extension.
+
 ### macOS
 
 Download the `.dmg` for your Mac (Apple Silicon for M1/M2/M3/M4, Intel for older Macs). Open the DMG and drag Task Coach to Applications.

--- a/build.in/arch/PKGBUILD
+++ b/build.in/arch/PKGBUILD
@@ -22,6 +22,7 @@ depends=(
     'python-keyring'
     'python-numpy'
     'python-fasteners>=0.19'
+    'libayatana-appindicator'
     'libxss'
     'xdg-utils'
 )

--- a/build.in/fedora/taskcoach.spec
+++ b/build.in/fedora/taskcoach.spec
@@ -47,6 +47,7 @@ Requires:       python3-pyxdg
 Requires:       python3-keyring
 Requires:       python3-numpy
 Requires:       python3-fasteners
+Requires:       libayatana-appindicator-gtk3
 Requires:       libXScrnSaver
 Requires:       xdg-utils
 

--- a/debian/control
+++ b/debian/control
@@ -27,6 +27,7 @@ Depends: ${python3:Depends},
          python3-keyring,
          python3-numpy,
          python3-fasteners,
+         gir1.2-ayatanaappindicator3-0.1,
          libxss1,
          xdg-utils
 Recommends: python3-squaremap

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -53,6 +53,7 @@ This table shows how dependencies are handled in **built packages** and **setup 
 | keyring | distro | distro | distro | distro | distro | distro | bundled | pip | pip |
 | pyxdg | distro | distro | distro | distro | distro | distro | bundled | — | — |
 | fasteners | distro | distro | distro | distro | distro | distro | bundled | pip | pip |
+| ayatana-appindicator | distro | distro | distro | distro | distro | distro | host | — | — |
 | hypertreelist | **patch** | **patch** | **patch** | **patch** | **patch** | **patch** | bundled | **patch** | **patch** |
 | WMI | — | — | — | — | — | — | — | pip | — |
 
@@ -61,6 +62,7 @@ This table shows how dependencies are handled in **built packages** and **setup 
 - `pip` = Bundled via pip in package build (version too old or not in repos)
 - `patch` = Bundled patch in `taskcoachlib/patches/` (wxPython hypertreelist fix)
 - `bundled` = Bundled in package (thirdparty/ for .deb/.rpm, or inside AppImage)
+- `host` = Uses host system library (AppImage); install on host for Wayland tray support
 - `AUR` = Arch User Repository (rolling release)
 - `—` = Not applicable for this platform
 

--- a/setup.sh
+++ b/setup.sh
@@ -136,6 +136,7 @@ get_system_packages() {
     SYSTEM_PACKAGES="python3-wxgtk4.0 python3-six python3-lxml python3-numpy"
     SYSTEM_PACKAGES="$SYSTEM_PACKAGES python3-dateutil python3-chardet python3-keyring"
     SYSTEM_PACKAGES="$SYSTEM_PACKAGES python3-pyparsing python3-pyxdg python3-venv"
+    SYSTEM_PACKAGES="$SYSTEM_PACKAGES gir1.2-ayatanaappindicator3-0.1"
 
     # Distribution-specific additions
     case "$DISTRO_CODENAME" in

--- a/setup_arch.sh
+++ b/setup_arch.sh
@@ -81,6 +81,7 @@ if command -v sudo &> /dev/null; then
         python-pyxdg \
         python-watchdog \
         python-fasteners \
+        libayatana-appindicator \
         libxss \
         xdg-utils
 

--- a/setup_fedora.sh
+++ b/setup_fedora.sh
@@ -85,6 +85,7 @@ if command -v sudo &> /dev/null; then
         python3-fasteners \
         python3-watchdog \
         python3-pypubsub \
+        libayatana-appindicator-gtk3 \
         libXScrnSaver \
         xdg-utils
     echo -e "${GREEN}✓ System packages installed${NC}"

--- a/taskcoachlib/application/application.py
+++ b/taskcoachlib/application/application.py
@@ -779,7 +779,9 @@ Break the lock?"""
         if self.__can_create_task_bar_icon():
             from taskcoachlib.gui import taskbaricon, menu
 
-            self.taskBarIcon = taskbaricon.TaskBarIcon(
+            # Use factory function to get the appropriate icon type
+            # (AppIndicator on Wayland, wx.adv.TaskBarIcon otherwise)
+            self.taskBarIcon = taskbaricon.create_taskbar_icon(
                 self.mainwindow,  # pylint: disable=W0201
                 self.taskFile.tasks(),
                 self.settings,

--- a/taskcoachlib/gui/appindicator.py
+++ b/taskcoachlib/gui/appindicator.py
@@ -1,0 +1,346 @@
+# -*- coding: utf-8 -*-
+
+"""
+Task Coach - Your friendly task manager
+Copyright (C) 2004-2016 Task Coach developers <developers@taskcoach.org>
+
+Task Coach is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Task Coach is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+AppIndicator/StatusNotifierItem support for Wayland.
+
+This module provides system tray icon support on Wayland using the
+libayatana-appindicator library (StatusNotifierItem protocol), which
+is required because wx.adv.TaskBarIcon relies on X11's XEmbed protocol
+that doesn't work on Wayland.
+
+References:
+- https://github.com/AyatanaIndicators/libayatana-appindicator
+- https://lazka.github.io/pgi-docs/AyatanaAppIndicator3-0.1/
+"""
+
+import os
+import sys
+
+# Try to import AppIndicator (Ayatana version preferred, fallback to legacy)
+_appindicator = None
+_gi = None
+_Gtk = None
+_GLib = None
+APPINDICATOR_AVAILABLE = False
+APPINDICATOR_ERROR = None
+
+try:
+    import gi
+    _gi = gi
+    gi.require_version('Gtk', '3.0')
+    from gi.repository import Gtk, GLib
+    _Gtk = Gtk
+    _GLib = GLib
+
+    # Try Ayatana first (actively maintained)
+    try:
+        gi.require_version('AyatanaAppIndicator3', '0.1')
+        from gi.repository import AyatanaAppIndicator3 as appindicator
+        _appindicator = appindicator
+        APPINDICATOR_AVAILABLE = True
+    except (ValueError, ImportError):
+        # Fallback to legacy AppIndicator3
+        try:
+            gi.require_version('AppIndicator3', '0.1')
+            from gi.repository import AppIndicator3 as appindicator
+            _appindicator = appindicator
+            APPINDICATOR_AVAILABLE = True
+        except (ValueError, ImportError):
+            APPINDICATOR_ERROR = "Neither AyatanaAppIndicator3 nor AppIndicator3 available"
+except ImportError as e:
+    APPINDICATOR_ERROR = f"GObject introspection not available: {e}"
+except Exception as e:
+    APPINDICATOR_ERROR = f"Failed to initialize AppIndicator: {e}"
+
+
+def is_wayland():
+    """Check if running on Wayland."""
+    return (os.environ.get('XDG_SESSION_TYPE') == 'wayland' or
+            os.environ.get('WAYLAND_DISPLAY') is not None)
+
+
+def get_icon_path(icon_name, size=48):
+    """Get the path to an icon file.
+
+    Args:
+        icon_name: Base name of the icon (e.g., 'taskcoach', 'clock_icon')
+        size: Icon size (default 48 for good visibility)
+
+    Returns:
+        Absolute path to the icon PNG file, or None if not found
+    """
+    # Determine base path for icons
+    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+        base_path = sys._MEIPASS
+    else:
+        base_path = os.path.dirname(__file__)
+
+    icon_filename = f"{icon_name}{size}x{size}.png"
+    icon_path = os.path.join(base_path, 'icons', icon_filename)
+
+    if os.path.exists(icon_path):
+        return icon_path
+
+    # Try other sizes as fallback
+    for fallback_size in [48, 32, 22, 16, 64, 128]:
+        if fallback_size == size:
+            continue
+        icon_filename = f"{icon_name}{fallback_size}x{fallback_size}.png"
+        icon_path = os.path.join(base_path, 'icons', icon_filename)
+        if os.path.exists(icon_path):
+            return icon_path
+
+    return None
+
+
+class AppIndicatorIcon:
+    """System tray icon using AppIndicator/StatusNotifierItem.
+
+    This class provides a similar interface to wx.adv.TaskBarIcon but uses
+    the AppIndicator library for Wayland compatibility.
+    """
+
+    def __init__(self, app_id="taskcoach", icon_name="taskcoach",
+                 category=None, tooltip="Task Coach"):
+        """Initialize the AppIndicator icon.
+
+        Args:
+            app_id: Unique identifier for the indicator
+            icon_name: Name of the icon (will be looked up in icons folder)
+            category: AppIndicator category (defaults to APPLICATION_STATUS)
+            tooltip: Tooltip text (used as title since AppIndicator has limited tooltip support)
+        """
+        if not APPINDICATOR_AVAILABLE:
+            raise ImportError(f"AppIndicator not available: {APPINDICATOR_ERROR}")
+
+        self._app_id = app_id
+        self._icon_name = icon_name
+        self._tooltip = tooltip
+        self._menu = None
+        self._menu_items = {}
+        self._click_callback = None
+
+        # Determine category
+        if category is None:
+            category = _appindicator.IndicatorCategory.APPLICATION_STATUS
+
+        # Get icon path
+        icon_path = get_icon_path(icon_name)
+        if icon_path:
+            # AppIndicator needs icon path without extension for theme lookup,
+            # or full path for custom icons
+            self._indicator = _appindicator.Indicator.new(
+                app_id,
+                icon_path,  # Full path to icon
+                category
+            )
+        else:
+            # Fallback to system icon
+            self._indicator = _appindicator.Indicator.new(
+                app_id,
+                "application-default-icon",
+                category
+            )
+
+        # Set title (shown in some environments)
+        self._indicator.set_title(tooltip)
+
+        # Create initial empty menu (required for indicator to show)
+        self._create_empty_menu()
+
+        # Activate the indicator
+        self._indicator.set_status(_appindicator.IndicatorStatus.ACTIVE)
+
+    def _create_empty_menu(self):
+        """Create an empty GTK menu (required for indicator to display)."""
+        self._menu = _Gtk.Menu()
+        # Add at least one item (invisible indicators may not show)
+        item = _Gtk.MenuItem(label="Loading...")
+        item.set_sensitive(False)
+        self._menu.append(item)
+        self._menu.show_all()
+        self._indicator.set_menu(self._menu)
+
+    def SetIcon(self, icon_name, tooltip=""):
+        """Set the indicator icon and tooltip.
+
+        Args:
+            icon_name: Name of the icon (or wx.Icon which will be ignored,
+                      use the string name instead)
+            tooltip: Tooltip text
+        """
+        # Handle both string icon names and wx.Icon objects
+        if isinstance(icon_name, str):
+            self._icon_name = icon_name
+            icon_path = get_icon_path(icon_name)
+            if icon_path:
+                self._indicator.set_icon_full(icon_path, tooltip or self._tooltip)
+
+        if tooltip:
+            self._tooltip = tooltip
+            self._indicator.set_title(tooltip)
+
+    def set_icon_by_name(self, icon_name, tooltip=""):
+        """Set icon by name (string).
+
+        This is the preferred method when you have the icon name as a string.
+        """
+        self._icon_name = icon_name
+        icon_path = get_icon_path(icon_name)
+        if icon_path:
+            self._indicator.set_icon_full(icon_path, tooltip or self._tooltip)
+        if tooltip:
+            self._tooltip = tooltip
+            self._indicator.set_title(tooltip)
+
+    def set_tooltip(self, tooltip):
+        """Set the tooltip/title text."""
+        self._tooltip = tooltip
+        self._indicator.set_title(tooltip)
+
+    def set_click_callback(self, callback):
+        """Set callback for left-click on indicator.
+
+        Note: AppIndicator doesn't support direct left-click handling in the
+        same way as wx.TaskBarIcon. The callback will be triggered via a
+        menu item instead.
+        """
+        self._click_callback = callback
+
+    def set_menu(self, menu_builder_callback):
+        """Set the menu using a builder callback.
+
+        Args:
+            menu_builder_callback: A function that takes (Gtk, menu, click_callback)
+                                  and populates the menu with items
+        """
+        self._menu = _Gtk.Menu()
+        menu_builder_callback(_Gtk, self._menu, self._click_callback)
+        self._menu.show_all()
+        self._indicator.set_menu(self._menu)
+
+    def set_gtk_menu(self, menu):
+        """Set a pre-built GTK menu."""
+        self._menu = menu
+        self._menu.show_all()
+        self._indicator.set_menu(self._menu)
+
+    def update_menu(self):
+        """Trigger menu update (re-show all items)."""
+        if self._menu:
+            self._menu.show_all()
+
+    def RemoveIcon(self):
+        """Remove/hide the indicator."""
+        self._indicator.set_status(_appindicator.IndicatorStatus.PASSIVE)
+
+    def Destroy(self):
+        """Clean up the indicator."""
+        self.RemoveIcon()
+        self._menu = None
+        self._indicator = None
+
+    def IsAvailable(self):
+        """Check if the indicator is available and active."""
+        return (self._indicator is not None and
+                self._indicator.get_status() == _appindicator.IndicatorStatus.ACTIVE)
+
+    @property
+    def indicator(self):
+        """Access the underlying AppIndicator object."""
+        return self._indicator
+
+
+def build_taskcoach_menu(Gtk, menu, mainwindow, taskFile, settings,
+                         on_click_callback=None):
+    """Build the Task Coach tray menu using GTK.
+
+    This creates a GTK menu with similar items to TaskBarMenu.
+
+    Args:
+        Gtk: The Gtk module from gi.repository
+        menu: The Gtk.Menu to populate
+        mainwindow: The main application window
+        taskFile: The task file object
+        settings: Application settings
+        on_click_callback: Callback for restore/iconize action
+    """
+    from taskcoachlib.i18n import _
+    from taskcoachlib import meta
+
+    # Show/Hide main window
+    def on_show_hide(widget):
+        if on_click_callback:
+            on_click_callback(None)
+
+    show_item = Gtk.MenuItem(label=_("Show/Hide Main Window"))
+    show_item.connect('activate', on_show_hide)
+    menu.append(show_item)
+
+    menu.append(Gtk.SeparatorMenuItem())
+
+    # New Task
+    def on_new_task(widget):
+        # Use wx.CallAfter to safely call wx code from GTK callback
+        import wx
+        wx.CallAfter(mainwindow.createNewTask)
+
+    new_task_item = Gtk.MenuItem(label=_("New task"))
+    new_task_item.connect('activate', on_new_task)
+    menu.append(new_task_item)
+
+    menu.append(Gtk.SeparatorMenuItem())
+
+    # Quit
+    def on_quit(widget):
+        import wx
+        wx.CallAfter(mainwindow.Close)
+
+    quit_item = Gtk.MenuItem(label=_("Quit"))
+    quit_item.connect('activate', on_quit)
+    menu.append(quit_item)
+
+
+def create_indicator_for_taskcoach(mainwindow, taskList, settings):
+    """Factory function to create an AppIndicator for Task Coach.
+
+    Args:
+        mainwindow: The main application window
+        taskList: The task list
+        settings: Application settings
+
+    Returns:
+        AppIndicatorIcon instance, or None if not available
+    """
+    if not APPINDICATOR_AVAILABLE:
+        return None
+
+    try:
+        indicator = AppIndicatorIcon(
+            app_id="taskcoach",
+            icon_name="taskcoach",
+            tooltip="Task Coach"
+        )
+        return indicator
+    except Exception as e:
+        import logging
+        logging.getLogger(__name__).warning(
+            f"Failed to create AppIndicator: {e}"
+        )
+        return None

--- a/taskcoachlib/gui/taskbaricon.py
+++ b/taskcoachlib/gui/taskbaricon.py
@@ -21,12 +21,41 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import wx
 import os
+import logging
 from taskcoachlib import meta, patterns, operating_system
 from taskcoachlib.i18n import _
 from taskcoachlib.domain import date, task
 from pubsub import pub
 import wx.adv
 from . import artprovider
+
+# Check for AppIndicator availability on Linux/GTK
+# AppIndicator is used exclusively on Linux because:
+# - It works on both Wayland (SNI protocol) and X11 (XEmbed fallback)
+# - wx.adv.TaskBarIcon doesn't work on Wayland
+# - Simplifies codebase with single implementation for Linux
+_USE_APPINDICATOR = False
+_APPINDICATOR_MODULE = None
+
+if operating_system.isGTK():
+    try:
+        from . import appindicator as _APPINDICATOR_MODULE
+        if _APPINDICATOR_MODULE.APPINDICATOR_AVAILABLE:
+            _USE_APPINDICATOR = True
+            logging.getLogger(__name__).info(
+                "Linux/GTK detected - using AppIndicator for system tray"
+            )
+        else:
+            logging.getLogger(__name__).warning(
+                f"Linux/GTK detected but AppIndicator not available: "
+                f"{_APPINDICATOR_MODULE.APPINDICATOR_ERROR}. "
+                f"Falling back to wx.adv.TaskBarIcon."
+            )
+    except ImportError as e:
+        logging.getLogger(__name__).warning(
+            f"Linux/GTK detected but failed to import appindicator module: {e}. "
+            f"Falling back to wx.adv.TaskBarIcon."
+        )
 
 
 class TaskBarIcon(patterns.Observer, wx.adv.TaskBarIcon):
@@ -254,3 +283,371 @@ class TaskBarIcon(patterns.Observer, wx.adv.TaskBarIcon):
         except Exception:
             # wx assert errors on macOS but the icon still gets set... Whatever
             pass
+
+
+class AppIndicatorTaskBarIcon(patterns.Observer):
+    """TaskBarIcon implementation using AppIndicator for Linux.
+
+    This class provides the same interface as TaskBarIcon but uses the
+    libayatana-appindicator library instead of wx.adv.TaskBarIcon.
+
+    AppIndicator is used exclusively on Linux because:
+    - Works on Wayland via StatusNotifierItem (SNI) protocol
+    - Works on X11 via automatic XEmbed fallback
+    - Provides consistent behavior across all Linux desktop environments
+    """
+
+    def __init__(
+        self,
+        mainwindow,
+        taskList,
+        settings,
+        defaultBitmap="taskcoach",
+        tickBitmap="clock_icon",
+        tackBitmap="clock_stopwatch_icon",
+        *args,
+        **kwargs
+    ):
+        super().__init__()
+        self.__window = mainwindow
+        self.__taskList = taskList
+        self.__settings = settings
+        self.__bitmap = self.__defaultBitmap = defaultBitmap
+        self.__tooltipText = ""
+        self.__tickBitmap = tickBitmap
+        self.__tackBitmap = tackBitmap
+        self.__popupmenu = None
+        self._clockRunning = False
+
+        # Create the AppIndicator
+        self.__indicator = _APPINDICATOR_MODULE.AppIndicatorIcon(
+            app_id="taskcoach",
+            icon_name=defaultBitmap,
+            tooltip=meta.name
+        )
+
+        # Set up observers
+        self.registerObserver(
+            self.onTaskListChanged,
+            eventType=taskList.addItemEventType(),
+            eventSource=taskList,
+        )
+        self.registerObserver(
+            self.onTaskListChanged,
+            eventType=taskList.removeItemEventType(),
+            eventSource=taskList,
+        )
+        pub.subscribe(
+            self.onTrackingChanged, task.Task.trackingChangedEventType()
+        )
+        pub.subscribe(
+            self.onChangeDueDateTime, task.Task.dueDateTimeChangedEventType()
+        )
+        self.registerObserver(
+            self.onChangeDueDateTime_Deprecated,
+            eventType=task.Task.appearanceChangedEventType(),
+        )
+
+        self.__setTooltipText()
+        self.__setIcon()
+
+    # Event handlers:
+
+    def onTaskListChanged(self, event):  # pylint: disable=W0613
+        self.__setTooltipText()
+        self.__startOrStopTicking()
+
+    def onTrackingChanged(self, newValue, sender):
+        if newValue:
+            self.registerObserver(
+                self.onChangeSubject,
+                eventType=sender.subjectChangedEventType(),
+                eventSource=sender,
+            )
+        else:
+            self.removeObserver(
+                self.onChangeSubject,
+                eventType=sender.subjectChangedEventType(),
+            )
+        self.__setTooltipText()
+        if newValue:
+            self.__startTicking()
+        else:
+            self.__stopTicking()
+
+    def onChangeSubject(self, event):  # pylint: disable=W0613
+        self.__setTooltipText()
+
+    def onChangeDueDateTime(self, newValue, sender):  # pylint: disable=W0613
+        self.__setTooltipText()
+
+    def onChangeDueDateTime_Deprecated(self, event):
+        self.__setTooltipText()
+
+    def onEverySecond(self):
+        if self.__settings.getboolean(
+            "window", "blinktaskbariconwhentrackingeffort"
+        ):
+            self.__toggleTrackingBitmap()
+            self.__setIcon()
+
+    def onTaskbarClick(self, event=None):
+        """Handle click on indicator - show/hide main window."""
+        if self.__window.IsIconized() or not self.__window.IsShown():
+            self.__window.restore(event)
+        else:
+            self.__window.Iconize()
+
+    # Menu:
+
+    def setPopupMenu(self, menu):
+        """Set the popup menu.
+
+        For AppIndicator, we need to build a GTK menu instead of using
+        the wx.Menu directly.
+        """
+        self.__popupmenu = menu
+        self._buildGtkMenu()
+
+    def _buildGtkMenu(self):
+        """Build a GTK menu for the AppIndicator."""
+        if not _APPINDICATOR_MODULE:
+            return
+
+        # Import GTK from the appindicator module's cached reference
+        Gtk = _APPINDICATOR_MODULE._Gtk
+        if not Gtk:
+            return
+
+        menu = Gtk.Menu()
+
+        # Show/Hide main window (acts as left-click replacement)
+        show_item = Gtk.MenuItem(label=_("Show/Hide Task Coach"))
+        show_item.connect('activate', lambda w: wx.CallAfter(self.onTaskbarClick))
+        menu.append(show_item)
+
+        menu.append(Gtk.SeparatorMenuItem())
+
+        # New Task
+        new_task_item = Gtk.MenuItem(label=_("New task..."))
+        new_task_item.connect('activate', self._onNewTask)
+        menu.append(new_task_item)
+
+        # New Effort
+        new_effort_item = Gtk.MenuItem(label=_("New effort..."))
+        new_effort_item.connect('activate', self._onNewEffort)
+        menu.append(new_effort_item)
+
+        menu.append(Gtk.SeparatorMenuItem())
+
+        # Stop tracking (if any tasks being tracked)
+        stop_item = Gtk.MenuItem(label=_("Stop tracking"))
+        stop_item.connect('activate', self._onStopTracking)
+        menu.append(stop_item)
+
+        menu.append(Gtk.SeparatorMenuItem())
+
+        # Restore window
+        restore_item = Gtk.MenuItem(label=_("Restore"))
+        restore_item.connect('activate', lambda w: wx.CallAfter(self.__window.restore, None))
+        menu.append(restore_item)
+
+        # Quit
+        quit_item = Gtk.MenuItem(label=_("Quit"))
+        quit_item.connect('activate', lambda w: wx.CallAfter(self.__window.Close))
+        menu.append(quit_item)
+
+        menu.show_all()
+        self.__indicator.set_gtk_menu(menu)
+
+    def _onNewTask(self, widget):
+        """Handle New Task menu item."""
+        wx.CallAfter(self._doNewTask)
+
+    def _doNewTask(self):
+        """Create a new task (called from wx main thread)."""
+        from taskcoachlib.gui import uicommand
+        tasks = self.__window.taskFile.tasks()
+        cmd = uicommand.TaskNew(taskList=tasks, settings=self.__settings)
+        cmd.doCommand(None)
+
+    def _onNewEffort(self, widget):
+        """Handle New Effort menu item."""
+        wx.CallAfter(self._doNewEffort)
+
+    def _doNewEffort(self):
+        """Create a new effort (called from wx main thread)."""
+        from taskcoachlib.gui import uicommand
+        efforts = self.__window.taskFile.efforts()
+        tasks = self.__window.taskFile.tasks()
+        cmd = uicommand.EffortNew(
+            effortList=efforts, taskList=tasks, settings=self.__settings
+        )
+        cmd.doCommand(None)
+
+    def _onStopTracking(self, widget):
+        """Handle Stop Tracking menu item."""
+        wx.CallAfter(self._doStopTracking)
+
+    def _doStopTracking(self):
+        """Stop tracking all efforts (called from wx main thread)."""
+        for trackedTask in self.__taskList.tasksBeingTracked():
+            trackedTask.stopTracking()
+
+    # Getters:
+
+    def tooltip(self):
+        return self.__tooltipText
+
+    def bitmap(self):
+        return self.__bitmap
+
+    def defaultBitmap(self):
+        return self.__defaultBitmap
+
+    # Private methods:
+
+    def __startOrStopTicking(self):
+        self.__startTicking()
+        self.__stopTicking()
+
+    def __startTicking(self):
+        if self.__taskList.nrBeingTracked() > 0:
+            self.startClock()
+            self.__toggleTrackingBitmap()
+            self.__setIcon()
+
+    def startClock(self):
+        if not self._clockRunning:
+            pub.subscribe(self._onTimerSecond, 'timer.second')
+            self._clockRunning = True
+
+    def __stopTicking(self):
+        if self.__taskList.nrBeingTracked() == 0:
+            self.stopClock()
+            self.__setDefaultBitmap()
+            self.__setIcon()
+
+    def stopClock(self):
+        if self._clockRunning:
+            pub.unsubscribe(self._onTimerSecond, 'timer.second')
+            self._clockRunning = False
+
+    def _onTimerSecond(self, timestamp):
+        """Handle second tick from global timer."""
+        self.onEverySecond()
+
+    toolTipMessages = [
+        (task.status.overdue, _("one task overdue"), _("%d tasks overdue")),
+        (task.status.duesoon, _("one task due soon"), _("%d tasks due soon")),
+    ]
+
+    def __setTooltipText(self):
+        """Update the tooltip text based on current task status."""
+        textParts = []
+        trackedTasks = self.__taskList.tasksBeingTracked()
+        if trackedTasks:
+            count = len(trackedTasks)
+            if count == 1:
+                tracking = _('tracking "%s"') % trackedTasks[0].subject()
+            else:
+                tracking = _("tracking effort for %d tasks") % count
+            textParts.append(tracking)
+        else:
+            counts = self.__taskList.nrOfTasksPerStatus()
+            for status, singular, plural in self.toolTipMessages:
+                count = counts[status]
+                if count == 1:
+                    textParts.append(singular)
+                elif count > 1:
+                    textParts.append(plural % count)
+
+        textPart = ", ".join(textParts)
+        filename = os.path.basename(self.__window.taskFile.filename())
+        namePart = "%s - %s" % (meta.name, filename) if filename else meta.name
+        text = "%s\n%s" % (namePart, textPart) if textPart else namePart
+
+        if text != self.__tooltipText:
+            self.__tooltipText = text
+            if self.__indicator:
+                self.__indicator.set_tooltip(text)
+
+    def __setDefaultBitmap(self):
+        self.__bitmap = self.__defaultBitmap
+
+    def __toggleTrackingBitmap(self):
+        tick, tack = self.__tickBitmap, self.__tackBitmap
+        self.__bitmap = tack if self.__bitmap == tick else tick
+
+    def __setIcon(self):
+        """Update the indicator icon."""
+        if self.__indicator:
+            self.__indicator.set_icon_by_name(self.__bitmap, self.__tooltipText)
+
+    # wx.adv.TaskBarIcon compatibility methods:
+
+    def Bind(self, event, handler, source=None, id=wx.ID_ANY, id2=wx.ID_ANY):
+        """Stub for wx.EvtHandler.Bind compatibility.
+
+        AppIndicator uses its own GTK menu, so wx event bindings are ignored.
+        This method exists only to prevent AttributeError when TaskBarMenu
+        tries to bind events to its parent.
+        """
+        pass
+
+    def Unbind(self, event, source=None, id=wx.ID_ANY, id2=wx.ID_ANY, handler=None):
+        """Stub for wx.EvtHandler.Unbind compatibility.
+
+        AppIndicator uses its own GTK menu, so wx event unbindings are ignored.
+        """
+        return True
+
+    def ProcessEvent(self, event):
+        """Stub for wx.EvtHandler.ProcessEvent compatibility.
+
+        AppIndicator uses its own GTK menu, so wx event processing is ignored.
+        This method is called by Menu.invokeMenuItem() and Menu.openMenu().
+        """
+        return False
+
+    def UpdateWindowUI(self, flags=wx.UPDATE_UI_NONE):
+        """Stub for wx.Window.UpdateWindowUI compatibility.
+
+        AppIndicator uses its own GTK menu, so UI updates are ignored.
+        This method is called by Menu.openMenu() before processing menu events.
+        """
+        pass
+
+    def RemoveIcon(self):
+        """Remove the indicator icon."""
+        if self.__indicator:
+            self.__indicator.RemoveIcon()
+
+    def Destroy(self):
+        """Clean up the indicator."""
+        self.stopClock()
+        if self.__indicator:
+            self.__indicator.Destroy()
+            self.__indicator = None
+
+
+def create_taskbar_icon(mainwindow, taskList, settings):
+    """Factory function to create the appropriate taskbar icon.
+
+    On Linux/GTK with AppIndicator available, returns AppIndicatorTaskBarIcon.
+    On Windows/macOS (or Linux without AppIndicator), returns wx.adv.TaskBarIcon.
+
+    Args:
+        mainwindow: The main application window
+        taskList: The task list
+        settings: Application settings
+
+    Returns:
+        TaskBarIcon or AppIndicatorTaskBarIcon instance
+    """
+    if _USE_APPINDICATOR:
+        logging.getLogger(__name__).info("Creating AppIndicator-based taskbar icon (Linux)")
+        return AppIndicatorTaskBarIcon(mainwindow, taskList, settings)
+    else:
+        logging.getLogger(__name__).info("Creating wx.adv.TaskBarIcon-based taskbar icon (Windows/macOS)")
+        return TaskBarIcon(mainwindow, taskList, settings)

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,10 +41,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "27"  # Patch number - INCREMENT THIS for each release
+patch = "28"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.1.18
 
-release_day = "15"  # Day of the release (1-31)
+release_day = "16"  # Day of the release (1-31)
 release_month = "January"  # Month of the release
 release_year = "2026"  # Year of the release
 


### PR DESCRIPTION
## Summary

Replaces `wx.adv.TaskBarIcon` with libayatana-appindicator for all Linux systems. AppIndicator provides consistent system tray behavior across all desktop environments and display servers.

### Why this change?

- `wx.adv.TaskBarIcon` uses X11's XEmbed protocol which doesn't work on Wayland
- AppIndicator works on both Wayland (SNI protocol) and X11 (automatic XEmbed fallback)
- Single implementation simplifies maintenance
- Better desktop environment integration

### Desktop environment support

| Desktop | Protocol | Status |
|---------|----------|--------|
| KDE Plasma | SNI | ✅ Native |
| XFCE | SNI | ✅ Native |
| LXQt | SNI | ✅ Native |
| MATE | SNI | ✅ Native (1.18+) |
| Cinnamon | SNI | ✅ Native |
| LXDE | XEmbed | ✅ Fallback |
| GNOME | SNI | ⚠️ Requires extension |

### Changes

- Add `taskcoachlib/gui/appindicator.py` - AppIndicator wrapper
- Add `AppIndicatorTaskBarIcon` class to `taskbaricon.py`
- Use AppIndicator for all Linux/GTK (not just Wayland)
- Keep `wx.adv.TaskBarIcon` for Windows/macOS only
- Add libayatana-appindicator dependency to all Linux packages
- Update setup scripts and documentation

### New dependency

| Distro | Package |
|--------|---------|
| Debian/Ubuntu | `gir1.2-ayatanaappindicator3-0.1` |
| Fedora | `libayatana-appindicator-gtk3` |
| Arch | `libayatana-appindicator` |


### References
system tray icon not working #233

