### PR TITLE
Use AppIndicator for system tray on all Linux desktops

### DIFF
--- a/docs/SYSTEM_TRAY.md
+++ b/docs/SYSTEM_TRAY.md
@@ -1,0 +1,212 @@
+# System Tray Icon Implementation
+
+This document describes the system tray (notification area) icon implementation in Task Coach across different platforms and desktop environments.
+
+## Overview
+
+Task Coach displays a system tray icon that allows users to:
+- Show/hide the main window
+- Access common actions (new task, new effort, etc.)
+- Start/stop effort tracking
+- See tracking status via icon animation
+
+## Implementation Architecture
+
+### Platform Detection Flow
+
+```
+create_taskbar_icon()
+    |
+    +-- Linux/GTK? --Yes--> Use AppIndicator (all Linux)
+    |
+    +-- No --> wx.adv.TaskBarIcon (Windows, macOS)
+```
+
+### Classes
+
+| Class | File | Purpose |
+|-------|------|---------|
+| `TaskBarIcon` | `taskbaricon.py` | wx.adv.TaskBarIcon wrapper for Windows/macOS |
+| `AppIndicatorTaskBarIcon` | `taskbaricon.py` | AppIndicator wrapper for Linux |
+| `AppIndicatorIcon` | `appindicator.py` | Low-level AppIndicator/GTK bindings |
+| `TaskBarMenu` | `menu.py` | wx.Menu for Windows/macOS right-click |
+
+## Platform Behavior Matrix
+
+| OS | Distro | Desktop | Session | Implementation | Left-Click | Right-Click | Notes |
+|----|--------|---------|---------|----------------|------------|-------------|-------|
+| Windows | — | — | — | wx.adv.TaskBarIcon | Show/hide | Popup menu | Full support |
+| macOS | — | — | — | wx.adv.TaskBarIcon | Show/hide | Popup menu | Full support |
+| Linux | — | GNOME | X11 | AppIndicator | Menu | Menu | Requires extension [1] |
+| Linux | — | GNOME | Wayland | AppIndicator | Menu | Menu | Requires extension [1] |
+| Linux | Ubuntu | GNOME | X11 | AppIndicator | Menu | Menu | Extension pre-installed |
+| Linux | Ubuntu | GNOME | Wayland | AppIndicator | Menu | Menu | Extension pre-installed |
+| Linux | — | KDE Plasma | X11 | AppIndicator | Menu | Conflict [2] | Use left-click |
+| Linux | — | KDE Plasma | Wayland | AppIndicator | Menu | Menu | |
+| Linux | — | XFCE | X11 | AppIndicator | Menu | Menu | wx may work [3] |
+| Linux | — | LXDE | X11 | AppIndicator | Menu | Menu | wx right-click broken [4] |
+| Linux | — | LXQt | X11 | AppIndicator | Menu | Menu | |
+| Linux | — | LXQt | Wayland | AppIndicator | Menu | Menu | |
+| Linux | — | MATE | X11 | AppIndicator | Menu | Menu | |
+| Linux | — | Cinnamon | X11 | AppIndicator | Menu | Menu | wx may work [3] |
+
+**Notes:**
+
+[1] **GNOME Extension Required**: GNOME Shell removed built-in system tray support. Install the [AppIndicator Support](https://extensions.gnome.org/extension/615/appindicator-support/) extension. Ubuntu pre-installs this extension, so Ubuntu users don't need to install it manually.
+
+[2] **KDE X11 Right-Click Issues**: Known KDE bugs affect right-click behavior on X11. [Bug 449870](https://bugs.kde.org/show_bug.cgi?id=449870) reports tray icons not reacting to right-click, and [Bug 409768](https://bugs.kde.org/show_bug.cgi?id=409768) reports conflicts where right-clicking causes subsequent clicks to misbehave. Users should use left-click instead.
+
+[3] **wx.adv.TaskBarIcon may work**: According to [wxWidgets documentation](https://wxpython.org/Phoenix/docs/html/wx.adv.TaskBarIcon.html) and user reports, XFCE and Cinnamon support the freedesktop.org System Tray Protocol and wx.adv.TaskBarIcon has been confirmed working on these desktops. Currently using AppIndicator for consistency across all Linux.
+
+[4] **LXDE wx broken**: Confirmed that wx.adv.TaskBarIcon does not receive right-click events on LXDE, even though `IsAvailable()` returns True. Left-click works but right-click events are never delivered.
+
+## Tested Configurations
+
+| OS | Distro | Desktop | Session | wx.adv.TaskBarIcon | AppIndicator |
+|----|--------|---------|---------|-------------------|--------------|
+| Windows | — | — | — | Full support | N/A |
+| macOS | — | — | — | Full support | N/A |
+| Linux | Debian | LXDE | X11 | Left-click only | Full support |
+| Linux | Kubuntu | KDE Plasma | X11 | Left-click only | Left-click only (right conflict) |
+| Linux | Kubuntu | KDE Plasma | Wayland | N/A (no XEmbed) | Full support |
+
+## References
+
+- [wxPython TaskBarIcon Documentation](https://wxpython.org/Phoenix/docs/html/wx.adv.TaskBarIcon.html)
+- [GitHub Issue #2080 - TaskBarIcon click events not firing](https://github.com/wxWidgets/Phoenix/issues/2080)
+- [GitHub Issue #754 - TaskBarIcon not working in Ubuntu](https://github.com/wxWidgets/Phoenix/issues/754)
+
+## Why AppIndicator on Linux?
+
+### The Problem with wx.adv.TaskBarIcon on Linux
+
+`wx.adv.TaskBarIcon` uses the X11 XEmbed protocol for system tray icons. Testing revealed:
+
+1. **Right-click events not received**: On LXDE, KDE, and potentially other desktops, `EVT_TASKBAR_RIGHT_UP` events are never delivered to the application, even though the icon appears and left-click works.
+
+2. **Wayland incompatibility**: XEmbed doesn't exist on Wayland, so `wx.adv.TaskBarIcon` cannot work at all.
+
+3. **Inconsistent behavior**: Different desktop environments handle the XEmbed tray differently, leading to unpredictable behavior.
+
+### The AppIndicator Solution
+
+AppIndicator (libayatana-appindicator) implements the StatusNotifierItem (SNI) protocol:
+
+- **Works on Wayland**: SNI is D-Bus based, no X11 dependency
+- **Works on X11**: Has XEmbed fallback for older trays
+- **Consistent menu behavior**: Menu always works via left-click
+- **Modern standard**: Adopted by KDE, Ubuntu, and most modern desktops
+
+### Why No Left-Click/Right-Click Differentiation?
+
+**This is a limitation of the SNI protocol design, not Wayland itself.**
+
+The StatusNotifierItem (SNI) protocol that AppIndicator implements is **menu-centric by design**. In the SNI specification, clicking the tray icon shows the menu - there is no concept of separate left-click and right-click actions in the protocol.
+
+The chain of causation:
+
+1. **wx.adv.TaskBarIcon** uses the **XEmbed** protocol (X11-only) which supports click differentiation
+2. **XEmbed doesn't exist on Wayland** → wx.adv.TaskBarIcon cannot work on Wayland at all
+3. **AppIndicator** (using SNI) works on both X11 and Wayland, but SNI has no click differentiation
+4. We must use AppIndicator on Wayland, and for consistency use it on all Linux
+
+So while Wayland forces us to use AppIndicator (since XEmbed isn't available), the loss of click differentiation is due to the SNI protocol's design philosophy, not a Wayland restriction per se.
+
+### Trade-offs
+
+| Feature | wx.adv.TaskBarIcon | AppIndicator |
+|---------|-------------------|--------------|
+| Left-click action | Custom (show/hide) | Shows menu |
+| Right-click action | Shows menu | Shows menu (or conflict on KDE X11) |
+| Wayland support | No | Yes |
+| X11 support | Partial* | Yes |
+| Menu updates | Dynamic | Rebuild on change |
+
+*Right-click broken on many desktops
+
+## Menu Contents
+
+The AppIndicator menu provides:
+
+1. **Show/Hide Task Coach** - Toggle main window visibility
+2. **New task...** - Create a new task
+3. **New task from template** - Submenu with saved templates
+4. **New effort...** - Create a new effort entry
+5. **New category...** - Create a new category
+6. **New note...** - Create a new note
+7. **Start tracking effort** - Submenu with trackable tasks (hierarchical)
+8. **Stop/Resume tracking** - Dynamic based on state:
+   - When tracking: "Stop tracking [task name]"
+   - When paused: "Resume tracking [last task name]"
+   - When no recent effort: Hidden
+9. **Quit** - Exit the application
+
+The menu rebuilds automatically when:
+- Task list changes (tasks added/removed)
+- Tracking starts or stops
+- Task subjects change
+
+## Dependencies
+
+### Linux
+
+AppIndicator requires GObject Introspection bindings:
+
+**Debian/Ubuntu:**
+```bash
+sudo apt install gir1.2-ayatanaappindicator3-0.1
+```
+
+**Fedora:**
+```bash
+sudo dnf install libayatana-appindicator-gtk3
+```
+
+**Arch Linux:**
+```bash
+sudo pacman -S libayatana-appindicator
+```
+
+### GNOME Shell Note
+
+GNOME Shell removed built-in system tray support. GNOME users need the [AppIndicator Support](https://extensions.gnome.org/extension/615/appindicator-support/) extension. Ubuntu pre-installs this extension.
+
+## Icon Animation
+
+When effort tracking is active, the tray icon blinks between two states:
+- `clock_icon` - Clock face
+- `clock_stopwatch_icon` - Stopwatch
+
+This is controlled by the setting `window.blinktaskbariconwhentrackingeffort`.
+
+## Debugging
+
+Debug logging can be enabled by looking for `[TRAY]` prefix in console output:
+
+```
+[15:21:01.054] [TRAY] create_taskbar_icon called
+[15:21:01.055] [TRAY] Desktop environment: KDE
+[15:21:01.055] [TRAY] wx.adv.TaskBarIcon.IsAvailable() = True
+[15:21:01.055] [TRAY] _APPINDICATOR_AVAILABLE = True
+[15:21:01.055] [TRAY] needs_appindicator = True
+[15:21:01.055] [TRAY] Using AppIndicator (desktop requires it)
+```
+
+Key log messages:
+- `Using AppIndicator (desktop requires it)` - Linux, using AppIndicator
+- `Using wx.adv.TaskBarIcon (native)` - Windows/macOS
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `taskcoachlib/gui/taskbaricon.py` | Main implementation, factory function |
+| `taskcoachlib/gui/appindicator.py` | AppIndicator/GTK bindings |
+| `taskcoachlib/gui/menu.py` | TaskBarMenu class for wx platforms |
+| `taskcoachlib/gui/icons/` | Icon files (PNG at various sizes) |
+
+## History
+
+- **Original**: wx.adv.TaskBarIcon only
+- **2026-01**: Added AppIndicator support for Wayland
+- **2026-01**: Switched to AppIndicator for all Linux due to wx.adv.TaskBarIcon right-click issues

--- a/taskcoachlib/gui/taskbaricon.py
+++ b/taskcoachlib/gui/taskbaricon.py
@@ -23,6 +23,7 @@ import wx
 import os
 import logging
 from taskcoachlib import meta, patterns, operating_system
+from taskcoachlib.meta.debug import log_step
 from taskcoachlib.i18n import _
 from taskcoachlib.domain import date, task
 from pubsub import pub
@@ -30,31 +31,19 @@ import wx.adv
 from . import artprovider
 
 # Check for AppIndicator availability on Linux/GTK
-# AppIndicator is used exclusively on Linux because:
-# - It works on both Wayland (SNI protocol) and X11 (XEmbed fallback)
-# - wx.adv.TaskBarIcon doesn't work on Wayland
-# - Simplifies codebase with single implementation for Linux
-_USE_APPINDICATOR = False
+# AppIndicator is only used when wx.adv.TaskBarIcon is not available (e.g., Wayland).
+# On X11, wx.adv.TaskBarIcon is preferred because it supports left-click events.
 _APPINDICATOR_MODULE = None
+_APPINDICATOR_AVAILABLE = False
 
+# Pre-load AppIndicator module on GTK systems (for potential fallback)
 if operating_system.isGTK():
     try:
         from . import appindicator as _APPINDICATOR_MODULE
-        if _APPINDICATOR_MODULE.APPINDICATOR_AVAILABLE:
-            _USE_APPINDICATOR = True
-            logging.getLogger(__name__).info(
-                "Linux/GTK detected - using AppIndicator for system tray"
-            )
-        else:
-            logging.getLogger(__name__).warning(
-                f"Linux/GTK detected but AppIndicator not available: "
-                f"{_APPINDICATOR_MODULE.APPINDICATOR_ERROR}. "
-                f"Falling back to wx.adv.TaskBarIcon."
-            )
+        _APPINDICATOR_AVAILABLE = _APPINDICATOR_MODULE.APPINDICATOR_AVAILABLE
     except ImportError as e:
-        logging.getLogger(__name__).warning(
-            f"Linux/GTK detected but failed to import appindicator module: {e}. "
-            f"Falling back to wx.adv.TaskBarIcon."
+        logging.getLogger(__name__).debug(
+            f"AppIndicator module not available: {e}"
         )
 
 
@@ -70,6 +59,7 @@ class TaskBarIcon(patterns.Observer, wx.adv.TaskBarIcon):
         *args,
         **kwargs
     ):
+        log_step("TaskBarIcon.__init__ started (wx.adv.TaskBarIcon)", prefix="TRAY")
         super().__init__(*args, **kwargs)
         self.__window = mainwindow
         self.__taskList = taskList
@@ -109,18 +99,23 @@ class TaskBarIcon(patterns.Observer, wx.adv.TaskBarIcon):
         )
         if operating_system.isGTK():
             events = [wx.adv.EVT_TASKBAR_LEFT_DOWN]
+            log_step("GTK: binding EVT_TASKBAR_LEFT_DOWN for left-click", prefix="TRAY")
         elif operating_system.isWindows():
             # See http://msdn.microsoft.com/en-us/library/windows/desktop/aa511448.aspx#interaction
             events = [
                 wx.adv.EVT_TASKBAR_LEFT_DOWN,
                 wx.adv.EVT_TASKBAR_LEFT_DCLICK,
             ]
+            log_step("Windows: binding LEFT_DOWN and LEFT_DCLICK", prefix="TRAY")
         else:
             events = [wx.adv.EVT_TASKBAR_LEFT_DCLICK]
+            log_step("Other OS: binding EVT_TASKBAR_LEFT_DCLICK", prefix="TRAY")
         for event in events:
             self.Bind(event, self.onTaskbarClick)
+            log_step("Bound event", event, "to onTaskbarClick", prefix="TRAY")
         self.__setTooltipText()
         mainwindow.Bind(wx.EVT_IDLE, self.onIdle)
+        log_step("TaskBarIcon.__init__ completed", prefix="TRAY")
 
     # Event handlers:
 
@@ -174,22 +169,31 @@ class TaskBarIcon(patterns.Observer, wx.adv.TaskBarIcon):
             self.__setIcon()
 
     def onTaskbarClick(self, event):
+        log_step("LEFT-CLICK on taskbar icon, event:", event, prefix="TRAY")
         if self.__window.IsIconized() or not self.__window.IsShown():
+            log_step("Window is iconized/hidden, restoring", prefix="TRAY")
             self.__window.restore(event)
         else:
             if operating_system.isMac():
+                log_step("Mac: raising window", prefix="TRAY")
                 self.__window.Raise()
             else:
+                log_step("Iconizing window", prefix="TRAY")
                 self.__window.Iconize()
 
     # Menu:
 
     def setPopupMenu(self, menu):
+        log_step("setPopupMenu called, binding EVT_TASKBAR_RIGHT_UP", prefix="TRAY")
         self.Bind(wx.adv.EVT_TASKBAR_RIGHT_UP, self.popupTaskBarMenu)
         self.popupmenu = menu  # pylint: disable=W0201
+        log_step("setPopupMenu completed, menu:", menu, prefix="TRAY")
 
     def popupTaskBarMenu(self, event):  # pylint: disable=W0613
+        log_step("RIGHT-CLICK on taskbar icon, showing popup menu", prefix="TRAY")
+        log_step("popupmenu object:", self.popupmenu, prefix="TRAY")
         self.PopupMenu(self.popupmenu)
+        log_step("PopupMenu() returned", prefix="TRAY")
 
     # Getters:
 
@@ -356,6 +360,7 @@ class AppIndicatorTaskBarIcon(patterns.Observer):
     def onTaskListChanged(self, event):  # pylint: disable=W0613
         self.__setTooltipText()
         self.__startOrStopTicking()
+        self._rebuildGtkMenu()  # Update menu with new task list
 
     def onTrackingChanged(self, newValue, sender):
         if newValue:
@@ -374,9 +379,11 @@ class AppIndicatorTaskBarIcon(patterns.Observer):
             self.__startTicking()
         else:
             self.__stopTicking()
+        self._rebuildGtkMenu()  # Update menu with tracking state
 
     def onChangeSubject(self, event):  # pylint: disable=W0613
         self.__setTooltipText()
+        self._rebuildGtkMenu()  # Update menu with new task subject
 
     def onChangeDueDateTime(self, newValue, sender):  # pylint: disable=W0613
         self.__setTooltipText()
@@ -409,9 +416,22 @@ class AppIndicatorTaskBarIcon(patterns.Observer):
         self.__popupmenu = menu
         self._buildGtkMenu()
 
+    def _rebuildGtkMenu(self):
+        """Rebuild the GTK menu to reflect current state.
+
+        Called when task list, tracking state, or task subjects change.
+        Uses wx.CallAfter to ensure it runs on the main thread.
+        """
+        if self.__indicator:  # Only rebuild if indicator still exists
+            wx.CallAfter(self._buildGtkMenu)
+
     def _buildGtkMenu(self):
         """Build a GTK menu for the AppIndicator."""
         if not _APPINDICATOR_MODULE:
+            return
+
+        # Check if indicator still exists (may be destroyed during shutdown)
+        if not self.__indicator:
             return
 
         # Import GTK from the appindicator module's cached reference
@@ -433,24 +453,62 @@ class AppIndicatorTaskBarIcon(patterns.Observer):
         new_task_item.connect('activate', self._onNewTask)
         menu.append(new_task_item)
 
+        # New task from template submenu
+        template_submenu = self._buildTemplateSubmenu(Gtk)
+        if template_submenu:
+            template_item = Gtk.MenuItem(label=_("New task from template"))
+            template_item.set_submenu(template_submenu)
+            menu.append(template_item)
+
+        menu.append(Gtk.SeparatorMenuItem())
+
         # New Effort
         new_effort_item = Gtk.MenuItem(label=_("New effort..."))
         new_effort_item.connect('activate', self._onNewEffort)
         menu.append(new_effort_item)
 
+        # New Category
+        new_category_item = Gtk.MenuItem(label=_("New category..."))
+        new_category_item.connect('activate', self._onNewCategory)
+        menu.append(new_category_item)
+
+        # New Note
+        new_note_item = Gtk.MenuItem(label=_("New note..."))
+        new_note_item.connect('activate', self._onNewNote)
+        menu.append(new_note_item)
+
         menu.append(Gtk.SeparatorMenuItem())
 
-        # Stop tracking (if any tasks being tracked)
-        stop_item = Gtk.MenuItem(label=_("Stop tracking"))
-        stop_item.connect('activate', self._onStopTracking)
-        menu.append(stop_item)
+        # Start tracking effort submenu
+        tracking_submenu = self._buildStartTrackingSubmenu(Gtk)
+        if tracking_submenu:
+            tracking_item = Gtk.MenuItem(label=_("Start tracking effort"))
+            tracking_item.set_submenu(tracking_submenu)
+            menu.append(tracking_item)
+
+        # Stop/Resume tracking - dynamic based on state
+        trackedTasks = self.__taskList.tasksBeingTracked()
+        if trackedTasks:
+            # Currently tracking - show Stop
+            if len(trackedTasks) == 1:
+                label = _("Stop tracking %s") % trackedTasks[0].subject()
+            else:
+                label = _("Stop tracking %d tasks") % len(trackedTasks)
+            stop_item = Gtk.MenuItem(label=label)
+            stop_item.connect('activate', self._onStopTracking)
+            menu.append(stop_item)
+        else:
+            # Not tracking - check if we can resume
+            mostRecent = self._getMostRecentTrackedTask()
+            if mostRecent:
+                label = _("Resume tracking %s") % mostRecent.subject()
+                stop_item = Gtk.MenuItem(label=label)
+                stop_item.connect('activate',
+                    lambda w, t=mostRecent: wx.CallAfter(self._doStartTracking, t))
+                menu.append(stop_item)
+            # If no recent task, don't show the item at all
 
         menu.append(Gtk.SeparatorMenuItem())
-
-        # Restore window
-        restore_item = Gtk.MenuItem(label=_("Restore"))
-        restore_item.connect('activate', lambda w: wx.CallAfter(self.__window.restore, None))
-        menu.append(restore_item)
 
         # Quit
         quit_item = Gtk.MenuItem(label=_("Quit"))
@@ -459,6 +517,92 @@ class AppIndicatorTaskBarIcon(patterns.Observer):
 
         menu.show_all()
         self.__indicator.set_gtk_menu(menu)
+
+    def _buildTemplateSubmenu(self, Gtk):
+        """Build submenu for task templates."""
+        from taskcoachlib import persistence
+
+        path = self.__settings.pathToTemplatesDir()
+        try:
+            templateList = persistence.TemplateList(path)
+            templates = list(zip(templateList.tasks(), templateList.names()))
+        except Exception:
+            templates = []
+
+        if not templates:
+            return None
+
+        submenu = Gtk.Menu()
+        # Sort by subject (display name) rather than filename
+        templates.sort(key=lambda t: t[0].subject().lower())
+        for task, filename in templates:
+            template_path = os.path.join(path, filename)
+            subject = task.subject() or filename  # Fallback to filename if no subject
+            item = Gtk.MenuItem(label=subject)
+            # Use default argument to capture template_path in closure
+            item.connect('activate',
+                lambda w, p=template_path: wx.CallAfter(self._doNewTaskFromTemplate, p))
+            submenu.append(item)
+
+        return submenu
+
+    def _buildStartTrackingSubmenu(self, Gtk):
+        """Build submenu for starting effort tracking on tasks."""
+        # Get trackable tasks (not completed, not deleted)
+        trackable_tasks = [
+            t for t in self.__taskList
+            if not t.completed() and not getattr(t, 'isDeleted', lambda: False)()
+        ]
+
+        if not trackable_tasks:
+            return None
+
+        submenu = Gtk.Menu()
+        # Get root tasks (tasks without parent or parent not in list)
+        root_tasks = [
+            t for t in trackable_tasks
+            if t.parent() is None or t.parent() not in trackable_tasks
+        ]
+        root_tasks.sort(key=lambda t: t.subject().lower())
+
+        for task_item in root_tasks:
+            self._addTaskToTrackingMenu(Gtk, submenu, task_item, trackable_tasks)
+
+        return submenu
+
+    def _addTaskToTrackingMenu(self, Gtk, menu, task_item, trackable_tasks):
+        """Add a task (and its children) to the tracking submenu."""
+        # Get trackable children
+        trackable_children = [
+            child for child in task_item.children()
+            if child in trackable_tasks
+        ]
+
+        if trackable_children:
+            # Task has children - create a submenu
+            item = Gtk.MenuItem(label=task_item.subject())
+            child_menu = Gtk.Menu()
+
+            # Add item to start tracking this task
+            start_item = Gtk.MenuItem(label=_("Track this task"))
+            start_item.connect('activate',
+                lambda w, t=task_item: wx.CallAfter(self._doStartTracking, t))
+            child_menu.append(start_item)
+            child_menu.append(Gtk.SeparatorMenuItem())
+
+            # Add children
+            trackable_children.sort(key=lambda t: t.subject().lower())
+            for child in trackable_children:
+                self._addTaskToTrackingMenu(Gtk, child_menu, child, trackable_tasks)
+
+            item.set_submenu(child_menu)
+            menu.append(item)
+        else:
+            # No children - simple menu item
+            item = Gtk.MenuItem(label=task_item.subject())
+            item.connect('activate',
+                lambda w, t=task_item: wx.CallAfter(self._doStartTracking, t))
+            menu.append(item)
 
     def _onNewTask(self, widget):
         """Handle New Task menu item."""
@@ -493,6 +637,69 @@ class AppIndicatorTaskBarIcon(patterns.Observer):
         """Stop tracking all efforts (called from wx main thread)."""
         for trackedTask in self.__taskList.tasksBeingTracked():
             trackedTask.stopTracking()
+
+    def _onNewCategory(self, widget):
+        """Handle New Category menu item."""
+        wx.CallAfter(self._doNewCategory)
+
+    def _doNewCategory(self):
+        """Create a new category (called from wx main thread)."""
+        from taskcoachlib.gui import uicommand
+        categories = self.__window.taskFile.categories()
+        cmd = uicommand.CategoryNew(categories=categories, settings=self.__settings)
+        cmd.doCommand(None)
+
+    def _onNewNote(self, widget):
+        """Handle New Note menu item."""
+        wx.CallAfter(self._doNewNote)
+
+    def _doNewNote(self):
+        """Create a new note (called from wx main thread)."""
+        from taskcoachlib.gui import uicommand
+        notes = self.__window.taskFile.notes()
+        cmd = uicommand.NoteNew(notes=notes, settings=self.__settings)
+        cmd.doCommand(None)
+
+    def _doNewTaskFromTemplate(self, template_path):
+        """Create a new task from template (called from wx main thread)."""
+        from taskcoachlib.gui import uicommand
+        tasks = self.__window.taskFile.tasks()
+        cmd = uicommand.TaskNewFromTemplate(
+            template_path, taskList=tasks, settings=self.__settings
+        )
+        cmd.doCommand(None)
+
+    def _doStartTracking(self, task_to_track):
+        """Start tracking effort for a task (called from wx main thread)."""
+        from taskcoachlib import command
+        tasks = self.__window.taskFile.tasks()
+        cmd = command.StartEffortCommand(tasks, [task_to_track])
+        cmd.do()
+
+    def _getMostRecentTrackedTask(self):
+        """Get the most recently tracked task for resume functionality.
+
+        Returns:
+            The task that was most recently tracked, or None if no efforts exist.
+        """
+        effortList = self.__window.taskFile.efforts()
+        if not effortList:
+            return None
+
+        # Find the effort with the most recent stop time
+        maxStop = None
+        mostRecentTask = None
+        for effort in effortList:
+            stop = effort.getStop()
+            if stop is not None and (maxStop is None or stop > maxStop):
+                maxStop = stop
+                mostRecentTask = effort.task()
+
+        # Only return if task is not completed and not deleted
+        if mostRecentTask and not mostRecentTask.completed():
+            if not getattr(mostRecentTask, 'isDeleted', lambda: False)():
+                return mostRecentTask
+        return None
 
     # Getters:
 
@@ -631,11 +838,37 @@ class AppIndicatorTaskBarIcon(patterns.Observer):
             self.__indicator = None
 
 
+def _get_desktop_environment():
+    """Detect the current desktop environment."""
+    # Check XDG_CURRENT_DESKTOP first (most reliable)
+    xdg_desktop = os.environ.get('XDG_CURRENT_DESKTOP', '').upper()
+    if xdg_desktop:
+        return xdg_desktop
+    # Fall back to DESKTOP_SESSION
+    return os.environ.get('DESKTOP_SESSION', '').upper()
+
+
+def _needs_appindicator():
+    """Check if we need to use AppIndicator instead of wx.adv.TaskBarIcon.
+
+    wx.adv.TaskBarIcon on Linux/GTK doesn't properly receive right-click events
+    on many desktop environments (LXDE, KDE, and possibly others). AppIndicator
+    provides reliable menu functionality across all Linux desktops.
+    """
+    # Use AppIndicator on all Linux/GTK systems when available
+    # because wx.adv.TaskBarIcon right-click is broken on many desktops
+    if operating_system.isGTK():
+        return True
+    return False
+
+
 def create_taskbar_icon(mainwindow, taskList, settings):
     """Factory function to create the appropriate taskbar icon.
 
-    On Linux/GTK with AppIndicator available, returns AppIndicatorTaskBarIcon.
-    On Windows/macOS (or Linux without AppIndicator), returns wx.adv.TaskBarIcon.
+    Uses wx.adv.TaskBarIcon when available (preferred for full click event support).
+    Falls back to AppIndicator on Linux when:
+    - wx.adv.TaskBarIcon is not available (e.g., Wayland)
+    - Desktop environment doesn't properly support right-click (e.g., LXDE)
 
     Args:
         mainwindow: The main application window
@@ -645,9 +878,32 @@ def create_taskbar_icon(mainwindow, taskList, settings):
     Returns:
         TaskBarIcon or AppIndicatorTaskBarIcon instance
     """
-    if _USE_APPINDICATOR:
-        logging.getLogger(__name__).info("Creating AppIndicator-based taskbar icon (Linux)")
+    log_step("create_taskbar_icon called", prefix="TRAY")
+
+    desktop = _get_desktop_environment()
+    needs_appindicator = _needs_appindicator()
+    wx_taskbar_available = wx.adv.TaskBarIcon.IsAvailable()
+
+    log_step("Desktop environment:", desktop, prefix="TRAY")
+    log_step("wx.adv.TaskBarIcon.IsAvailable() =", wx_taskbar_available, prefix="TRAY")
+    log_step("_APPINDICATOR_AVAILABLE =", _APPINDICATOR_AVAILABLE, prefix="TRAY")
+    log_step("needs_appindicator =", needs_appindicator, prefix="TRAY")
+
+    # Use AppIndicator if needed and available
+    if needs_appindicator and _APPINDICATOR_AVAILABLE:
+        log_step("Using AppIndicator (desktop requires it)", prefix="TRAY")
         return AppIndicatorTaskBarIcon(mainwindow, taskList, settings)
-    else:
-        logging.getLogger(__name__).info("Creating wx.adv.TaskBarIcon-based taskbar icon (Windows/macOS)")
+
+    # Use native wx.adv.TaskBarIcon if available
+    if wx_taskbar_available:
+        log_step("Using wx.adv.TaskBarIcon (native)", prefix="TRAY")
         return TaskBarIcon(mainwindow, taskList, settings)
+
+    # Last resort: try AppIndicator on GTK
+    if operating_system.isGTK() and _APPINDICATOR_AVAILABLE:
+        log_step("Using AppIndicator (fallback)", prefix="TRAY")
+        return AppIndicatorTaskBarIcon(mainwindow, taskList, settings)
+
+    # No AppIndicator available, try wx.adv.TaskBarIcon anyway (may not work)
+    log_step("WARNING: No good tray option available, trying wx.adv.TaskBarIcon", prefix="TRAY")
+    return TaskBarIcon(mainwindow, taskList, settings)

--- a/taskcoachlib/i18n/__init__.py
+++ b/taskcoachlib/i18n/__init__.py
@@ -18,12 +18,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import wx, os, locale
 from taskcoachlib import patterns, operating_system
+from taskcoachlib.meta.debug import log_step
 from . import po2dict
 
 
 def _log_i18n(msg):
     """Log i18n-related messages for debugging."""
-    print(f"[i18n] {msg}")
+    log_step(msg, prefix="i18n")
 
 
 # Directory containing .po files


### PR DESCRIPTION
wx.adv.TaskBarIcon right-click events are unreliable on Linux - confirmed broken on LXDE and KDE X11, with known KDE bugs (449870, 409768). AppIndicator (StatusNotifierItem protocol) provides consistent behavior.

System tray changes:
- Use AppIndicator for all Linux/GTK, wx.adv.TaskBarIcon for Windows/macOS
- Add complete GTK menu matching TaskBarMenu functionality
- Dynamic Stop/Resume tracking with task name display
- Menu rebuilds automatically on task list and tracking changes
- Add null checks for safe shutdown
- Add debug logging with [TRAY] prefix

Menu features:
- Show/Hide Task Coach (replaces separate Restore item)
- New task, New task from template (shows subject, not filename)
- New effort, New category, New note
- Start tracking effort (hierarchical task submenu)
- Stop/Resume tracking (context-aware label)
- Quit

Documentation:
- Add docs/SYSTEM_TRAY.md with platform behavior matrix
- Document SNI protocol limitation (no left/right click differentiation)
- Reference KDE bugs for X11 right-click issues

Other:
- Update i18n logging to use log_step function

Tested on: LXDE X11, KDE Plasma X11, KDE Plasma Wayland

system tray menu oddness (right/left click identical, stop effort when already stopped) #236