### PR TITLE
Refactor attachment drag and drop from file explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.29-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.29-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.29_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.29_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.29_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.29-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.30-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.30-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.30_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.30_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.30_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.30-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.29-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.29-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.29_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.29_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.29-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.29-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.30-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.30-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.30_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.30_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.30-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.30-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.29_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.29_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.30_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.30_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.29-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.29-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.30-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.30-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.29-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.29-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.30-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.30-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.29-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.29-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.30-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.30-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.29-x86_64.AppImage
+./TaskCoach-2.0.1.30-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/taskcoachlib/domain/attachment/attachment.py
+++ b/taskcoachlib/domain/attachment/attachment.py
@@ -72,7 +72,9 @@ class Attachment(base.Object, NoteOwner):
 
     def __init__(self, location, *args, **kwargs):
         if "subject" not in kwargs:
-            kwargs["subject"] = location
+            # Use filename without extension as subject, not full path/URL
+            filename = os.path.basename(location)
+            kwargs["subject"] = os.path.splitext(filename)[0] or location
         super().__init__(*args, **kwargs)
         self.__location = location
 

--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -311,14 +311,79 @@ class CategorySubjectPage(SubjectPage):
 
 
 class AttachmentSubjectPage(SubjectPage):
+    # Map type_ values to human-readable names and icons
+    TYPE_INFO = {
+        "file": (_("File"), "document_icon"),
+        "folder": (_("Folder"), "folder_blue_icon"),
+        "uri": (_("Link"), "earth_blue_icon"),
+        "mail": (_("Email"), "envelope_icon"),
+        "unknown": (_("Unknown"), None),
+    }
+
+    def _isFolderUri(self, item):
+        """Check if a URI attachment points to a local folder."""
+        if item.type_ != "uri":
+            return False
+        location = item.location()
+        if location.startswith("file://"):
+            import urllib.request
+            import os
+            try:
+                path = urllib.request.url2pathname(location[7:])
+                return os.path.isdir(path)
+            except Exception:
+                return False
+        return False
+
     def addEntries(self):
-        # Override to insert a location entry between the subject and
-        # description entry
+        # Override to insert type and location entries
         self.addSubjectEntry()
+        self.addTypeEntry()
         self.addLocationEntry()
         self.addDescriptionEntry()
         self.addCreationDateTimeEntry()
         self.addModificationDateTimeEntry()
+
+    def addTypeEntry(self):
+        """Add a read-only type field with icon."""
+        import os
+        if len(self.items) == 1:
+            item = self.items[0]
+            if self._isFolderUri(item):
+                type_name, icon_name = self.TYPE_INFO.get("folder")
+            else:
+                item_type = item.type_
+                type_name, icon_name = self.TYPE_INFO.get(
+                    item_type, (item_type, None)
+                )
+                # Check if file exists for file attachments
+                if item_type == "file":
+                    attachmentBase = self._settings.get("file", "attachmentbase")
+                    if not os.path.exists(item.normalizedLocation(attachmentBase)):
+                        icon_name = "fileopen_red"
+        else:
+            # Multiple items - show type if all same, otherwise "Mixed"
+            types = set(item.type_ for item in self.items)
+            if len(types) == 1:
+                item_type = types.pop()
+                type_name, icon_name = self.TYPE_INFO.get(
+                    item_type, (_("Unknown"), None)
+                )
+            else:
+                type_name = _("Mixed")
+                icon_name = None
+
+        panel = wx.Panel(self)
+        sizer = wx.BoxSizer(wx.HORIZONTAL)
+        if icon_name:
+            bitmap = wx.ArtProvider.GetBitmap(icon_name, wx.ART_MENU, (16, 16))
+            if bitmap.IsOk():
+                icon = wx.StaticBitmap(panel, bitmap=bitmap)
+                sizer.Add(icon, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        type_label = wx.StaticText(panel, label=type_name)
+        sizer.Add(type_label, 0, wx.ALIGN_CENTER_VERTICAL)
+        panel.SetSizer(sizer)
+        self.addEntry(_("Type"), panel, flags=[wx.ALIGN_RIGHT, wx.ALIGN_CENTER_VERTICAL])
 
     def addLocationEntry(self):
         panel = wx.Panel(self)

--- a/taskcoachlib/gui/viewer/attachment.py
+++ b/taskcoachlib/gui/viewer/attachment.py
@@ -38,12 +38,55 @@ class AttachmentViewer(
     base.ListViewer,
 ):
     SorterClass = attachment.AttachmentSorter
-    viewerImages = base.ListViewer.viewerImages + ["fileopen", "fileopen_red"]
+    viewerImages = base.ListViewer.viewerImages + [
+        "document_icon", "fileopen_red", "folder_blue_icon"
+    ]
+
+    # Map type_ values to human-readable names
+    TYPE_NAMES = {
+        "file": _("File"),
+        "folder": _("Folder"),
+        "uri": _("Link"),
+        "mail": _("Email"),
+        "unknown": _("Unknown"),
+    }
 
     def __init__(self, *args, **kwargs):
         self.attachments = kwargs.pop("attachmentsToShow")
         kwargs.setdefault("settingssection", "attachmentviewer")
         super().__init__(*args, **kwargs)
+
+    def _isFolderUri(self, anAttachment):
+        """Check if a URI attachment points to a local folder."""
+        if anAttachment.type_ != "uri":
+            return False
+        location = anAttachment.location()
+        if location.startswith("file://"):
+            import urllib.request
+            try:
+                path = urllib.request.url2pathname(location[7:])
+                return os.path.isdir(path)
+            except Exception:
+                return False
+        return False
+
+    def getTypeName(self, anAttachment):
+        """Return human-readable type name for an attachment."""
+        if self._isFolderUri(anAttachment):
+            return self.TYPE_NAMES.get("folder", _("Folder"))
+        return self.TYPE_NAMES.get(anAttachment.type_, anAttachment.type_)
+
+    def getItemTooltipData(self, item):
+        """Return tooltip data showing type and location."""
+        result = [
+            (None, [self.getTypeName(item)]),
+            (None, [item.location()]),
+        ]
+        if item.description():
+            lines = [line.rstrip("\r") for line in item.description().split("\n")]
+            if lines and lines != [""]:
+                result.append((None, lines))
+        return result
 
     def _addAttachments(self, attachments, item, **itemDialogKwargs):
         # Don't try to add attachments to attachments.
@@ -91,7 +134,7 @@ class AttachmentViewer(
                 "",
                 width=self.getColumnWidth("type"),
                 imageIndicesCallback=self.typeImageIndices,
-                renderCallback=lambda item: "",
+                renderCallback=self.getTypeName,
                 resizeCallback=self.onResizeColumn,
             ),
             widgets.Column(
@@ -224,9 +267,12 @@ class AttachmentViewer(
         if anAttachment.type_ == "file":
             attachmentBase = self.settings.get("file", "attachmentbase")
             if exists(anAttachment.normalizedLocation(attachmentBase)):
-                index = self.imageIndex["fileopen"]
+                index = self.imageIndex["document_icon"]
             else:
                 index = self.imageIndex["fileopen_red"]
+        elif self._isFolderUri(anAttachment):
+            # Folder URI - use folder icon
+            index = self.imageIndex["folder_blue_icon"]
         else:
             try:
                 index = self.imageIndex[

--- a/taskcoachlib/gui/viewer/mixin.py
+++ b/taskcoachlib/gui/viewer/mixin.py
@@ -671,11 +671,90 @@ class AttachmentDropTargetMixin(object):
                 bitmap="new", attachments=attachments, **itemDialogKwargs
             )
             newItemDialog.Show()
+            # Use CallAfter to ensure proper focus after drop completes
+            wx.CallAfter(newItemDialog.Raise)
+            wx.CallAfter(newItemDialog.SetFocus)
         else:
             addAttachment = command.AddAttachmentCommand(
                 self.presentation(), [item], attachments=attachments
             )
             addAttachment.do()
+            # Open the item's editor on attachments tab, then open attachment editor
+            self._openItemEditorOnAttachmentsTab(item, attachments)
+
+    def _openItemEditorOnAttachmentsTab(self, item, newAttachments=None):
+        """Open the item's editor on the attachments tab.
+
+        If an editor for this item is already open, bring it to front and
+        switch to the attachments tab. Otherwise, create a new editor.
+        If newAttachments is provided, also open the AttachmentEditor for them.
+        """
+        from taskcoachlib.gui.dialog import editor
+        from taskcoachlib.domain import note
+
+        # Determine editor class based on item type
+        if isinstance(item, task.Task):
+            EditorClass = editor.TaskEditor
+            container = self.taskFile.tasks()
+        elif isinstance(item, category.Category):
+            EditorClass = editor.CategoryEditor
+            container = self.taskFile.categories()
+        elif isinstance(item, note.Note):
+            EditorClass = editor.NoteEditor
+            container = self.taskFile.notes()
+        else:
+            return
+
+        # Search for an existing open editor for this item
+        existingEditor = None
+        for window in wx.GetTopLevelWindows():
+            if isinstance(window, EditorClass):
+                # Check if this editor is editing our item
+                if hasattr(window, '_items') and item in window._items:
+                    existingEditor = window
+                    break
+
+        if existingEditor:
+            # Bring to front and switch to attachments tab
+            existingEditor.Raise()
+            existingEditor.SetFocus()
+            if hasattr(existingEditor, '_interior'):
+                existingEditor._interior.setFocus("attachments")
+            itemEditor = existingEditor
+        else:
+            # Create a new editor with columnName="attachments"
+            itemEditor = EditorClass(
+                wx.GetTopLevelParent(self),
+                [item],
+                self.settings,
+                container,
+                self.taskFile,
+                bitmap="edit",
+                columnName="attachments",
+            )
+            itemEditor.Show()
+            wx.CallAfter(itemEditor.Raise)
+            wx.CallAfter(itemEditor.SetFocus)
+
+        # Also open the AttachmentEditor for the new attachments
+        if newAttachments:
+            # Use CallAfter to ensure item editor is fully shown first
+            def openAttachmentEditor():
+                # Wrap attachments in AttachmentList container for Editor
+                # (item.attachments() returns a plain list)
+                attachmentContainer = attachment.AttachmentList(item.attachments())
+                attachmentEditor = editor.AttachmentEditor(
+                    itemEditor,  # Parent to the item editor
+                    newAttachments,
+                    self.settings,
+                    attachmentContainer,
+                    self.taskFile,
+                    bitmap="edit",
+                )
+                attachmentEditor.Show()
+                attachmentEditor.Raise()
+                attachmentEditor.SetFocus()
+            wx.CallAfter(openAttachmentEditor)
 
     def onDropURL(self, item, url, **kwargs):
         """This method is called by the widget when a URL is dropped on an
@@ -686,15 +765,20 @@ class AttachmentDropTargetMixin(object):
     def onDropFiles(self, item, filenames, **kwargs):
         """This method is called by the widget when one or more files
         are dropped on an item."""
+        import os
+        import urllib.request
         attachmentBase = self.settings.get("file", "attachmentbase")
-        if attachmentBase:
-            filenames = [
-                attachment.getRelativePath(filename, attachmentBase)
-                for filename in filenames
-            ]
-        attachments = [
-            attachment.FileAttachment(filename) for filename in filenames
-        ]
+        attachments = []
+        for filename in filenames:
+            if os.path.isdir(filename):
+                # Folders become URI attachments that open in file explorer
+                folder_url = "file://" + urllib.request.pathname2url(filename)
+                attachments.append(attachment.URIAttachment(folder_url))
+            else:
+                # Regular files become file attachments
+                if attachmentBase:
+                    filename = attachment.getRelativePath(filename, attachmentBase)
+                attachments.append(attachment.FileAttachment(filename))
         self._addAttachments(attachments, item, **kwargs)
 
     def onDropMail(self, item, mail, **kwargs):

--- a/taskcoachlib/gui/viewer/task.py
+++ b/taskcoachlib/gui/viewer/task.py
@@ -391,15 +391,7 @@ class BaseTaskTreeViewer(BaseTaskViewer):  # pylint: disable=W0223
                     sorted([note.subject() for note in task.notes()]),
                 )
             )
-        if task.attachments():
-            result.append(
-                (
-                    "paperclip_icon",
-                    sorted(
-                        [str(attachment) for attachment in task.attachments()]
-                    ),
-                )
-            )
+        # Note: attachments are handled by WithAttachmentsViewerMixin
         return result + super().getItemTooltipData(task)
 
     def label(self, task):  # pylint: disable=W0621

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,10 +41,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "29"  # Patch number - INCREMENT THIS for each release
+patch = "30"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.1.18
 
-release_day = "16"  # Day of the release (1-31)
+release_day = "17"  # Day of the release (1-31)
 release_month = "January"  # Month of the release
 release_year = "2026"  # Year of the release
 

--- a/taskcoachlib/patches/hypertreelist.py
+++ b/taskcoachlib/patches/hypertreelist.py
@@ -2973,7 +2973,7 @@ class TreeListMainWindow(CustomTreeCtrl):
 
         colText = wx.Colour(*dc.GetTextForeground())
 
-        if item.IsSelected():
+        if item.IsSelected() or item == self._dragItem:
             colTextHilight = wx.SystemSettings.GetColour(wx.SYS_COLOUR_HIGHLIGHTTEXT)
 
         else:
@@ -3016,10 +3016,14 @@ class TreeListMainWindow(CustomTreeCtrl):
             itemrect = wx.Rect(0, item.GetY() + off_h, total_w-1, total_h - off_h)
 
             if item == self._dragItem:
-                dc.SetBrush(self._hilightBrush)
-                if wx.Platform == "__WXMAC__":
-                    dc.SetPen((item == self._dragItem) and [wx.BLACK_PEN] or [wx.TRANSPARENT_PEN])[0]
-
+                # Draw highlight for drag item (same as selected item)
+                if wx.Platform in ["__WXGTK2__", "__WXMAC__"]:
+                    flags = wx.CONTROL_SELECTED | wx.CONTROL_FOCUSED
+                    wx.RendererNative.Get().DrawItemSelectionRect(self._owner, dc, itemrect, flags)
+                else:
+                    dc.SetBrush(self._hilightBrush)
+                    dc.SetPen(self._borderPen)
+                    dc.DrawRectangle(itemrect)
                 dc.SetTextForeground(colTextHilight)
 
             elif item.IsSelected():
@@ -3137,9 +3141,13 @@ class TreeListMainWindow(CustomTreeCtrl):
                 dc.SetPen((self._hasFocus and [self._borderPen] or [wx.TRANSPARENT_PEN])[0])
                 if i == self.GetMainColumn():
                     if item == self._dragItem:
-                        if wx.Platform == "__WXMAC__":  # don't draw rect outline if we already have the background colour
-                            dc.SetPen((item == self._dragItem and [wx.BLACK_PEN] or [wx.TRANSPARENT_PEN])[0])
-
+                        # Draw highlight for drag item (same as selected item)
+                        itemrect = wx.Rect(text_x-2, item.GetY() + off_h, text_w+2*_MARGIN, total_h - off_h)
+                        if wx.Platform in ["__WXGTK2__", "__WXMAC__"]:
+                            flags = wx.CONTROL_SELECTED | wx.CONTROL_FOCUSED
+                            wx.RendererNative.Get().DrawItemSelectionRect(self._owner, dc, itemrect, flags)
+                        else:
+                            dc.DrawRectangle(itemrect)
                         dc.SetTextForeground(colTextHilight)
 
                     elif item.IsSelected():

--- a/taskcoachlib/widgets/draganddrop.py
+++ b/taskcoachlib/widgets/draganddrop.py
@@ -194,7 +194,13 @@ class DropTarget(wx.DropTarget):
         if formatId == "text/x-moz-message":
             self.onThunderbirdDrop(x, y)
         elif formatId == "text/uri-list" and formatType == wx.DF_FILENAME:
-            urls = self.__urilistDataObject.GetData().strip().split("\n")
+            # GetData() returns memoryview in wxPython 4, convert to string
+            data = self.__urilistDataObject.GetData()
+            if isinstance(data, memoryview):
+                data = bytes(data).decode("utf-8", errors="replace")
+            elif isinstance(data, bytes):
+                data = data.decode("utf-8", errors="replace")
+            urls = data.strip().split("\n")
             for url in urls:
                 url = url.strip()
                 if url.startswith("#"):
@@ -202,14 +208,23 @@ class DropTarget(wx.DropTarget):
                 if self.__tmp_mail_file_url(url) and self.__onDropMailCallback:
                     filename = urllib.parse.unquote(url[len("file://") :])
                     self.__onDropMailCallback(x, y, filename)
+                elif url.startswith("file://") and self.__onDropFileCallback:
+                    # file:// URLs should be treated as files, not links
+                    filename = urllib.request.url2pathname(
+                        urllib.parse.unquote(url[7:])
+                    )
+                    self.__onDropFileCallback(x, y, [filename])
                 elif self.__onDropURLCallback:
-                    if url.startswith("file://"):
-                        url = urllib.request.url2pathname(url[7:])
                     self.__onDropURLCallback(x, y, url)
         elif formatId == "Object Descriptor":
             self.onOutlookDrop(x, y)
         elif formatId == "public.url":
+            # GetData() returns memoryview in wxPython 4, convert to string
             url = self.__macMailObject.GetData()
+            if isinstance(url, memoryview):
+                url = bytes(url).decode("utf-8", errors="replace")
+            elif isinstance(url, bytes):
+                url = url.decode("utf-8", errors="replace")
             if (
                 url.startswith("imap:") or url.startswith("mailbox:")
             ) and self.__onDropMailCallback:
@@ -284,9 +299,8 @@ class DropTarget(wx.DropTarget):
 
     def onFileDrop(self, x, y):
         if self.__onDropFileCallback:
-            self.__onDropFileCallback(
-                x, y, self.__fileDataObject.GetFilenames()
-            )
+            filenames = self.__fileDataObject.GetFilenames()
+            self.__onDropFileCallback(x, y, filenames)
 
 
 class TreeHelperMixin(object):

--- a/taskcoachlib/widgets/itemctrl.py
+++ b/taskcoachlib/widgets/itemctrl.py
@@ -248,6 +248,7 @@ class _CtrlWithDropTargetMixin(_CtrlWithItemsMixin):
         self.__onDropURLCallback = kwargs.pop("onDropURL", None)
         self.__onDropFilesCallback = kwargs.pop("onDropFiles", None)
         self.__onDropMailCallback = kwargs.pop("onDropMail", None)
+        self.__dropHighlightItem = None  # Track highlighted item during drag
         super().__init__(*args, **kwargs)
         if (
             self.__onDropURLCallback
@@ -263,18 +264,19 @@ class _CtrlWithDropTargetMixin(_CtrlWithItemsMixin):
             self.GetMainWindow().SetDropTarget(dropTarget)
 
     def onDropURL(self, x, y, url):
+        self._clearDropHighlight()  # Clear highlight on drop
         item = self.HitTest((x, y))[0]
         if self.__onDropURLCallback:
             self.__onDropURLCallback(self._objectBelongingTo(item), url)
 
     def onDropFiles(self, x, y, filenames):
+        self._clearDropHighlight()  # Clear highlight on drop
         item = self.HitTest((x, y))[0]
         if self.__onDropFilesCallback:
-            self.__onDropFilesCallback(
-                self._objectBelongingTo(item), filenames
-            )
+            self.__onDropFilesCallback(self._objectBelongingTo(item), filenames)
 
     def onDropMail(self, x, y, mail):
+        self._clearDropHighlight()  # Clear highlight on drop
         item = self.HitTest((x, y))[0]
         if self.__onDropMailCallback:
             self.__onDropMailCallback(self._objectBelongingTo(item), mail)
@@ -284,7 +286,29 @@ class _CtrlWithDropTargetMixin(_CtrlWithItemsMixin):
         if self._itemIsOk(item):
             if flags & wx.TREE_HITTEST_ONITEMBUTTON:
                 self.Expand(item)
+            # Highlight the row being hovered over
+            self._setDropHighlight(item)
+        else:
+            self._clearDropHighlight()
         return defaultResult
+
+    def _setDropHighlight(self, item):
+        """Set visual highlight on item during drag-over."""
+        if item != self.__dropHighlightItem:
+            self.__dropHighlightItem = item
+            # Use SetDragItem which is used by internal DnD for highlighting
+            if hasattr(self, 'SetDragItem'):
+                self.SetDragItem(item)
+
+    def _clearDropHighlight(self):
+        """Clear any existing drop highlight."""
+        if self.__dropHighlightItem is not None:
+            self.__dropHighlightItem = None
+            if hasattr(self, 'SetDragItem'):
+                try:
+                    self.SetDragItem(None)
+                except Exception:
+                    pass  # Item may have been deleted
 
     def GetMainWindow(self):
         try:

--- a/taskcoachlib/widgets/listctrl.py
+++ b/taskcoachlib/widgets/listctrl.py
@@ -72,6 +72,12 @@ class VirtualListCtrl(
         wx.PostEvent(self, wx.ChildFocusEvent(self))
         event.Skip()
 
+    def GetMainWindow(self):
+        # Override to return self for drop target support.
+        # wx.ListCtrl.GetMainWindow() returns an internal Window that
+        # doesn't properly receive drag/drop events.
+        return self
+
     def getItemWithIndex(self, rowIndex):
         return self.__parent.getItemWithIndex(rowIndex)
 


### PR DESCRIPTION
Drag and drop behavior:
- Open item editor on attachments tab when dropping files on tree items
- Also open AttachmentEditor for newly dropped attachments
- Add blue row highlighting during drag-over using SetDragItem
- Support dropping folders as URI attachments that open in file explorer
- Fix file:// URLs incorrectly treated as web links instead of files
- Fix memoryview handling for wxPython 4 in drop target data

Attachment display improvements:
- Use filename without extension as default subject instead of full path
- Add type field with icon to AttachmentEditor (File/Folder/Link/Email)
- Show type name in attachment list column instead of blank
- Add tooltips to attachment list showing type and location
- Change file icon from fileopen to document_icon
- Use folder_blue_icon for folder URI attachments

Bug fixes:
- Fix double attachment entries in task hover popup tooltip
- Fix drag highlight showing white instead of blue selection color
- Fix GetMainWindow for ListCtrl drop target support

Bump version to 2.0.1.30

drag-drop attachments not working #232
moved from UV: attaching a folder (directory) rather than single files only #231
moved from SF: hover pop-over shows double-entries for attachments #168