### PR TITLE
Auto-expand tree nodes when hovering during drag and drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.32-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.32-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.32_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.32_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.32_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.32-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.33-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.33-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.33_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.33_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.33_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.33-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.32-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.32-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.32_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.32_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.32-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.32-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.33-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.33-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.33_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.33_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.33-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.33-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.32_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.32_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.33_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.33_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.32-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.32-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.33-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.33-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.32-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.32-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.33-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.33-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.32-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.32-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.33-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.33-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.32-x86_64.AppImage
+./TaskCoach-2.0.1.33-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.
@@ -161,8 +161,9 @@ Task Coach is free software licensed under the [GNU General Public License v3](h
 
 Copyright (C) 2004-2025 Task Coach developers
 
-## Recent Changes (2.0.1.32)
+## Recent Changes (2.0.1.33)
 
+- **Auto-expand on hover during drag and drop**: Tree nodes now automatically expand after hovering anywhere on a collapsed row for 500ms while dragging. This modern UX behavior matches Windows Explorer, macOS Finder, and most IDEs - no longer requires targeting the tiny expand button.
 - **Path tab in editors**: All object editors (tasks, notes, categories, attachments) now include a "Path" tab showing the complete hierarchical path from root to the current object. The path displays each ancestor with its type and icon, updates dynamically when any parent changes, and uses lazy loading for performance.
 
 ## Architecture Overview

--- a/taskcoachlib/gui/viewer/mixin.py
+++ b/taskcoachlib/gui/viewer/mixin.py
@@ -750,6 +750,7 @@ class AttachmentDropTargetMixin(object):
                     attachmentContainer,
                     self.taskFile,
                     bitmap="edit",
+                    columnName="subject",  # Open on Description tab, not Notes
                 )
                 attachmentEditor.Show()
                 attachmentEditor.Raise()

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "32"  # Patch number - INCREMENT THIS for each release
+patch = "33"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.1.18
 
 release_day = "17"  # Day of the release (1-31)

--- a/taskcoachlib/widgets/draganddrop.py
+++ b/taskcoachlib/widgets/draganddrop.py
@@ -364,6 +364,11 @@ class TreeCtrlDragAndDropMixin(TreeHelperMixin):
         self._dragStartPos = None
         self.GetMainWindow().Bind(wx.EVT_LEFT_DOWN, self._OnLeftDown)
         self._dragItems = []
+        # Hover-expand timer: auto-expand collapsed items after hover delay
+        self._hoverExpandTimerId = wx.NewIdRef()
+        self._hoverExpandTimer = wx.Timer(self, self._hoverExpandTimerId)
+        self._hoverExpandItem = None  # Item currently being hovered for expansion
+        self.Bind(wx.EVT_TIMER, self._onHoverExpandTimer, id=self._hoverExpandTimerId)
 
     def OnDrop(self, dropItem, dragItems, part, column):
         """This function must be overloaded in the derived class. dragItems
@@ -488,13 +493,55 @@ class TreeCtrlDragAndDropMixin(TreeHelperMixin):
         else:
             self.SetCursorToDroppingImpossible()
             self._ClearDropFeedback()
-        if flags & wx.TREE_HITTEST_ONITEMBUTTON:
-            self.Expand(item)
+        # Auto-expand collapsed items on hover (modern UX behavior)
+        self._handleHoverExpand(item, flags)
         if self.GetSelections() != [item]:
             self.UnselectAll()
             if item != self.GetRootItem():
                 self.SelectItem(item)
         event.Skip()
+
+    def _handleHoverExpand(self, item, flags):
+        """Handle auto-expand of collapsed items during drag hover.
+
+        Expands collapsed items after a brief hover delay (500ms) for better UX.
+        Immediate expand when hovering directly on the expand button.
+        """
+        # Immediate expand when on the expand/collapse button
+        if flags & wx.TREE_HITTEST_ONITEMBUTTON:
+            self._hoverExpandTimer.Stop()
+            self._hoverExpandItem = None
+            self.Expand(item)
+            return
+
+        # Check if item is expandable (has children and is collapsed)
+        if item and item != self.GetRootItem():
+            try:
+                isExpandable = self.ItemHasChildren(item) and not self.IsExpanded(item)
+            except RuntimeError:
+                isExpandable = False
+        else:
+            isExpandable = False
+
+        if isExpandable:
+            # Start or continue timer for this item
+            if item != self._hoverExpandItem:
+                self._hoverExpandItem = item
+                self._hoverExpandTimer.Start(500, oneShot=True)
+        else:
+            # Not over an expandable item, cancel any pending expand
+            self._hoverExpandTimer.Stop()
+            self._hoverExpandItem = None
+
+    def _onHoverExpandTimer(self, event):
+        """Timer fired - expand the hovered item."""
+        if self._hoverExpandItem:
+            try:
+                if self.ItemHasChildren(self._hoverExpandItem) and not self.IsExpanded(self._hoverExpandItem):
+                    self.Expand(self._hoverExpandItem)
+            except RuntimeError:
+                pass  # Item may have been deleted
+        self._hoverExpandItem = None
 
     def _UpdateDropFeedback(self, item, flags, column, point):
         """Update visual feedback during drag based on drop position."""
@@ -537,6 +584,9 @@ class TreeCtrlDragAndDropMixin(TreeHelperMixin):
         if headerWin:
             headerWin.Unbind(wx.EVT_MOTION)
             headerWin.Unbind(wx.EVT_LEFT_UP)
+        # Cancel any pending hover-expand
+        self._hoverExpandTimer.Stop()
+        self._hoverExpandItem = None
         # Clean up HyperTreeList's internal drag state
         mainWin = self.GetMainWindow()
         if hasattr(mainWin, '_dragImage') and mainWin._dragImage:

--- a/taskcoachlib/widgets/itemctrl.py
+++ b/taskcoachlib/widgets/itemctrl.py
@@ -249,6 +249,10 @@ class _CtrlWithDropTargetMixin(_CtrlWithItemsMixin):
         self.__onDropFilesCallback = kwargs.pop("onDropFiles", None)
         self.__onDropMailCallback = kwargs.pop("onDropMail", None)
         self.__dropHighlightItem = None  # Track highlighted item during drag
+        # Hover-expand timer: auto-expand collapsed items after hover delay
+        self.__hoverExpandTimerId = wx.NewIdRef()
+        self.__hoverExpandTimer = None  # Created lazily when drop target is set
+        self.__hoverExpandItem = None  # Item currently being hovered for expansion
         super().__init__(*args, **kwargs)
         if (
             self.__onDropURLCallback
@@ -262,21 +266,27 @@ class _CtrlWithDropTargetMixin(_CtrlWithItemsMixin):
                 self.onDragOver,
             )
             self.GetMainWindow().SetDropTarget(dropTarget)
+            # Initialize hover-expand timer
+            self.__hoverExpandTimer = wx.Timer(self, self.__hoverExpandTimerId)
+            self.Bind(wx.EVT_TIMER, self.__onHoverExpandTimer, id=self.__hoverExpandTimerId)
 
     def onDropURL(self, x, y, url):
         self._clearDropHighlight()  # Clear highlight on drop
+        self.__stopHoverExpandTimer()  # Cancel any pending expand
         item = self.HitTest((x, y))[0]
         if self.__onDropURLCallback:
             self.__onDropURLCallback(self._objectBelongingTo(item), url)
 
     def onDropFiles(self, x, y, filenames):
         self._clearDropHighlight()  # Clear highlight on drop
+        self.__stopHoverExpandTimer()  # Cancel any pending expand
         item = self.HitTest((x, y))[0]
         if self.__onDropFilesCallback:
             self.__onDropFilesCallback(self._objectBelongingTo(item), filenames)
 
     def onDropMail(self, x, y, mail):
         self._clearDropHighlight()  # Clear highlight on drop
+        self.__stopHoverExpandTimer()  # Cancel any pending expand
         item = self.HitTest((x, y))[0]
         if self.__onDropMailCallback:
             self.__onDropMailCallback(self._objectBelongingTo(item), mail)
@@ -284,13 +294,58 @@ class _CtrlWithDropTargetMixin(_CtrlWithItemsMixin):
     def onDragOver(self, x, y, defaultResult):
         item, flags = self.HitTest((x, y))[:2]
         if self._itemIsOk(item):
-            if flags & wx.TREE_HITTEST_ONITEMBUTTON:
-                self.Expand(item)
+            # Auto-expand collapsed items on hover (modern UX behavior)
+            self.__handleHoverExpand(item, flags)
             # Highlight the row being hovered over
             self._setDropHighlight(item)
         else:
             self._clearDropHighlight()
+            self.__stopHoverExpandTimer()
         return defaultResult
+
+    def __handleHoverExpand(self, item, flags):
+        """Handle auto-expand of collapsed items during drag hover.
+
+        Expands collapsed items after a brief hover delay (500ms) for better UX.
+        Immediate expand when hovering directly on the expand button.
+        """
+        # Immediate expand when on the expand/collapse button
+        if flags & wx.TREE_HITTEST_ONITEMBUTTON:
+            self.__stopHoverExpandTimer()
+            self.Expand(item)
+            return
+
+        # Check if item is expandable (has children and is collapsed)
+        try:
+            isExpandable = self.ItemHasChildren(item) and not self.IsExpanded(item)
+        except (RuntimeError, AttributeError):
+            isExpandable = False
+
+        if isExpandable:
+            # Start or continue timer for this item
+            if item != self.__hoverExpandItem:
+                self.__hoverExpandItem = item
+                if self.__hoverExpandTimer:
+                    self.__hoverExpandTimer.Start(500, oneShot=True)
+        else:
+            # Not over an expandable item, cancel any pending expand
+            self.__stopHoverExpandTimer()
+
+    def __stopHoverExpandTimer(self):
+        """Stop the hover-expand timer and clear state."""
+        if self.__hoverExpandTimer:
+            self.__hoverExpandTimer.Stop()
+        self.__hoverExpandItem = None
+
+    def __onHoverExpandTimer(self, event):
+        """Timer fired - expand the hovered item."""
+        if self.__hoverExpandItem:
+            try:
+                if self.ItemHasChildren(self.__hoverExpandItem) and not self.IsExpanded(self.__hoverExpandItem):
+                    self.Expand(self.__hoverExpandItem)
+            except (RuntimeError, AttributeError):
+                pass  # Item may have been deleted
+        self.__hoverExpandItem = None
 
     def _setDropHighlight(self, item):
         """Set visual highlight on item during drag-over."""


### PR DESCRIPTION
Implement modern UX behavior where collapsed tree nodes automatically expand after hovering anywhere on the row for 500ms during drag operations. This matches the behavior of Windows Explorer, macOS Finder, and most modern IDEs.

Previously, nodes only expanded when hovering directly over the tiny expand/collapse button, which was difficult to target while dragging.

Changes:
- Add timer-based hover-expand to internal tree drag (draganddrop.py)
- Add timer-based hover-expand to external file drops (itemctrl.py)
- Immediate expand when hovering on expand button (no delay)
- Cancel pending expand when moving to different item or dropping
- Fix attachment editor opening on Notes tab instead of Description tab when dropping files (mixin.py)

Bump version to 2.0.1.33