### PR TITLE
Add reset window layout and document AUI Wayland issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.33-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.33-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.33_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.33_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.33_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.33-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.34-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.34-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.34_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.34_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.34_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.34-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.33-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.33-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.33_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.33_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.33-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.33-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.34-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.34-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.34_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.34_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.34-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.34-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.33_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.33_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.34_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.34_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.33-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.33-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.34-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.34-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.33-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.33-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.34-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.34-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.33-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.33-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.34-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.34-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.33-x86_64.AppImage
+./TaskCoach-2.0.1.34-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.
@@ -160,11 +160,6 @@ This tests Python version, dependencies, module imports, and wxPython patch stat
 Task Coach is free software licensed under the [GNU General Public License v3](https://www.gnu.org/licenses/gpl-3.0.html).
 
 Copyright (C) 2004-2025 Task Coach developers
-
-## Recent Changes (2.0.1.33)
-
-- **Auto-expand on hover during drag and drop**: Tree nodes now automatically expand after hovering anywhere on a collapsed row for 500ms while dragging. This modern UX behavior matches Windows Explorer, macOS Finder, and most IDEs - no longer requires targeting the tiny expand button.
-- **Path tab in editors**: All object editors (tasks, notes, categories, attachments) now include a "Path" tab showing the complete hierarchical path from root to the current object. The path displays each ancestor with its type and icon, updates dynamically when any parent changes, and uses lazy loading for performance.
 
 ## Architecture Overview
 

--- a/docs/AUI_WAYLAND_ISSUES.md
+++ b/docs/AUI_WAYLAND_ISSUES.md
@@ -1,0 +1,114 @@
+# AUI Docking Issues on Wayland
+
+This document describes known issues with wxPython/wxWidgets AUI (Advanced User Interface) docking functionality when running on Wayland display servers.
+
+## Problem Summary
+
+AUI docking is unusable on Wayland because users cannot see where panes will dock when dragging. The docking hints (visual preview) don't display due to Wayland's security model.
+
+### What Works on Wayland
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Floating windows | ✅ Works | Can detach panes to floating windows |
+| Resize panes via sash/dividers | ✅ Works | Dividers work normally |
+| Drag floating window around | ✅ Works | Compositor handles movement |
+
+### What's Broken on Wayland
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Docking hints/preview | ❌ Broken | Can't see where pane will dock |
+| Drag pane to rearrange docked layout | ❌ Unusable | Works but no visual feedback |
+| Drag floating window to re-dock | ❌ Broken | App can't detect dock zones |
+
+## Technical Root Cause
+
+On Wayland, `gdk_window_get_origin()` always returns `(0, 0)` and `gtk_window_move()` does nothing because Wayland intentionally hides global screen coordinates from applications for security. AUI's docking hints use separate overlay windows that require global coordinates to position, so they appear broken or squashed at origin. Same-window operations like sash resizing work because mouse coordinates are relative to that window.
+
+## Target Behavior: GIMP-like Docking
+
+GIMP provides a working docking model on Wayland that we should emulate:
+
+- **Floating windows work** - panes can be detached and moved around
+- **Once undocked, panes cannot be re-docked via drag** - this is a Wayland limitation
+- **Explicit menu controls** are needed to toggle windows between docked and floating states
+
+This pattern accepts Wayland's limitations while preserving useful functionality.
+
+## Upstream Bug Reports
+
+| Issue | Status | Description |
+|-------|--------|-------------|
+| [wxWidgets #25722](https://github.com/wxWidgets/wxWidgets/issues/25722) | Open | Main tracking issue for Wayland AUI/miniframe problems |
+| [wxWidgets #22576](https://github.com/wxWidgets/wxWidgets/issues/22576) | Fixed | Docking indicator wrong position - fixed with wxOverlay |
+| [wxWidgets #18372](https://github.com/wxWidgets/wxWidgets/issues/18372) | Closed (dup) | Floating panes cannot be dragged |
+| [wxWidgets #18669](https://github.com/wxWidgets/wxWidgets/issues/18669) | Open | KDE/KWin specific issues |
+
+## Upstream Fix: wxOverlay (Not Yet Available)
+
+wxWidgets C++ fixed docking hints for Wayland in [commit 29c8bfc](https://github.com/wxWidgets/wxWidgets/commit/29c8bfc) (February 9, 2024):
+
+> "Use wxOverlay to show docking hint instead of transparent wxFrame. The main advantage of using wxOverlay over wxFrame, besides reduced code complexity, is that the docking hint now works correctly under Wayland which it didn't work before. wxAUI_MGR_RECTANGLE_HINT now works everywhere (including wxGTK and wxOSX)."
+
+Related commits:
+- [29c8bfc](https://github.com/wxWidgets/wxWidgets/commit/29c8bfc) - wxOverlay fix for docking hints (Feb 2024)
+- [b1442f2](https://github.com/wxWidgets/wxWidgets/commit/b1442f2) - Restore screen coords in ShowHint() for backward compat (Oct 2024)
+
+**Current status**:
+- Fix is in wxWidgets C++ (wx.aui) but requires wxWidgets 3.2.5+
+- Fix is NOT in wxPython's pure Python `wx.lib.agw.aui` (which Task Coach uses)
+- Current wxPython 4.2.0 ships with wxWidgets 3.2.2 (predates the fix)
+
+**Monitoring**: When wxPython AGW AUI is updated with the wxOverlay approach, or when we can switch to wx.aui with a newer wxWidgets, docking hints should work.
+
+## Task Coach Implementation
+
+**Implemented**:
+- `operating_system.isWayland()` detection in `taskcoachlib/operating_system.py`
+- "Reset window layout" menu option in View menu:
+  - Closes ALL viewers
+  - Resets viewer counts to fresh install defaults (1 TaskViewer, 1 CategoryViewer)
+  - Clears saved perspective
+  - Recreates viewers with default layout (TaskViewer in center, CategoryViewer on right)
+
+### Reset Implementation Details
+
+The reset must handle tabbed/notebook configurations where multiple viewers are stacked. Simply closing viewers leaves orphaned AUI notebook controls that break the center pane detection.
+
+**Solution:**
+1. Close all viewers via `closeViewer()`
+2. Call `manager.Update()` to process closures
+3. Use `DetachPane()` then `ClosePane()` on any remaining non-toolbar panes (cleans up notebook controls)
+4. Call `manager.Update()` again
+5. Reset viewer counts and perspective in settings
+6. Recreate viewers with `addViewers()`
+7. **Explicitly set first TaskViewer to `AUI_DOCK_CENTER`** - don't rely on auto-positioning since leftover AUI state can cause `dockedPanes()` to return non-empty, skipping center placement
+
+The explicit CENTER positioning is critical: without a center pane, AUI docking hints disappear entirely and users cannot re-dock floating panes.
+
+**Planned** (GIMP-like pattern):
+- Menu options to explicitly create windows as docked or floating
+- Menu option to toggle a window between docked and floating state
+- This provides explicit control since drag-based docking is unusable on Wayland
+
+## Workaround: Run Under XWayland
+
+XWayland is a compatibility layer that runs an X11 server inside Wayland, allowing legacy X11 applications to run on Wayland systems. Most Wayland compositors (GNOME, KDE Plasma, etc.) include XWayland by default. When an application runs under XWayland, it has access to the X11 APIs that AUI docking requires, including global screen coordinates and window positioning.
+
+To get full AUI docking functionality on a Wayland system, run Task Coach under XWayland by setting the GDK_BACKEND environment variable:
+
+```bash
+GDK_BACKEND=x11 taskcoach
+GDK_BACKEND=x11 python taskcoach.py
+GDK_BACKEND=x11 python3 taskcoach.py
+```
+
+This forces the application to use the X11 backend via XWayland, where AUI docking works correctly.
+
+## References
+
+- [xdg-toplevel-drag protocol](https://wayland.app/protocols/xdg-toplevel-drag-v1) - future solution for floating window docking
+- [GIMP Docking Documentation](https://docs.gimp.org/2.6/en/gimp-concepts-docks.html) - reference for docking behavior
+- [wxWidgets Wayland Support](https://docs.wxwidgets.org/latest/plat_gtk_overview.html)
+- [wxAuiManager Class Reference](https://docs.wxwidgets.org/latest/classwx_aui_manager.html)

--- a/taskcoachlib/gui/mainwindow.py
+++ b/taskcoachlib/gui/mainwindow.py
@@ -334,6 +334,67 @@ If this happens again, please make a copy of your TaskCoach.ini file """
         self.Raise()
         self.Refresh()
 
+    def resetWindowLayout(self):
+        """Reset window layout to default as when freshly installed.
+
+        This closes ALL viewers, resets viewer counts to defaults (1 TaskViewer,
+        1 CategoryViewer), clears the saved perspective, and recreates viewers.
+        """
+        import wx.lib.agw.aui as aui
+
+        # Close ALL viewers (not just floating)
+        viewers_to_close = list(self.viewer.viewers)  # Copy the list
+        for v in viewers_to_close:
+            self.viewer.closeViewer(v)
+            self.viewer.viewers.remove(v)
+
+        # Process closures
+        self.manager.Update()
+
+        # Detach and close any remaining non-toolbar panes (e.g., notebook controls)
+        leftover_panes = [
+            pane for pane in self.manager.GetAllPanes()
+            if not pane.IsToolbar()
+        ]
+        for pane in leftover_panes:
+            if pane.window:
+                self.manager.DetachPane(pane.window)
+            self.manager.ClosePane(pane)
+        self.manager.Update()
+
+        # Reset viewer counts to fresh install defaults
+        self.settings.set("view", "taskviewercount", "1")
+        self.settings.set("view", "categoryviewercount", "1")
+        self.settings.set("view", "noteviewercount", "0")
+        self.settings.set("view", "effortviewercount", "0")
+        self.settings.set("view", "effortviewerforselectedtaskscount", "0")
+        self.settings.set("view", "squaretaskviewercount", "0")
+        self.settings.set("view", "timelineviewercount", "0")
+        self.settings.set("view", "calendarviewercount", "0")
+        self.settings.set("view", "hierarchicalcalendarviewercount", "0")
+        self.settings.set("view", "taskstatsviewercount", "0")
+        self.settings.set("view", "taskinterdepsviewercount", "0")
+
+        # Clear saved perspective
+        self.settings.set("view", "perspective", "")
+
+        # Recreate viewers with default counts
+        viewer.addViewers(self.viewer, self.taskFile, self.settings)
+
+        # Explicitly position the first TaskViewer in center (in case auto-positioning failed)
+        for pane in self.manager.GetAllPanes():
+            if pane.IsToolbar():
+                continue
+            name = pane.name
+            if "taskviewer" in name and "stats" not in name and "interdeps" not in name:
+                pane.dock_direction = aui.AUI_DOCK_CENTER
+                pane.dock_layer = 0
+                pane.dock_row = 0
+                pane.dock_pos = 0
+                break  # Only first taskviewer
+
+        self.manager.Update()
+
     def onIconify(self, event):
         if event.IsIconized() and self.settings.getboolean(
             "window", "hidewheniconized"

--- a/taskcoachlib/gui/menu.py
+++ b/taskcoachlib/gui/menu.py
@@ -529,7 +529,9 @@ class ViewMenu(Menu):
                 menuText=_("Status&bar"),
                 helpText=_("Show/hide status bar"),
                 setting="statusbar",
-            )
+            ),
+            None,
+            uicommand.ResetWindowLayout(),
         )
 
 

--- a/taskcoachlib/gui/uicommand/uicommand.py
+++ b/taskcoachlib/gui/uicommand/uicommand.py
@@ -3043,6 +3043,22 @@ class MainWindowRestore(base_uicommand.UICommand):
         self.mainWindow().restore(event)
 
 
+class ResetWindowLayout(base_uicommand.UICommand):
+    """Reset the window layout (AUI panes) to default positions."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            menuText=_("Reset &window layout"),
+            helpText=_("Reset all panes to their default positions"),
+            bitmap="reset",
+            *args,
+            **kwargs
+        )
+
+    def doCommand(self, event):
+        self.mainWindow().resetWindowLayout()
+
+
 class Search(ViewerCommand, settings_uicommand.SettingsCommand):
     # Search can only be attached to a real viewer, not to a viewercontainer
     def __init__(self, *args, **kwargs):

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "33"  # Patch number - INCREMENT THIS for each release
+patch = "34"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.1.18
 
 release_day = "17"  # Day of the release (1-31)

--- a/taskcoachlib/operating_system.py
+++ b/taskcoachlib/operating_system.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import wx, sys, platform
+import wx, sys, platform, os
 
 # This module is meant to be imported like this:
 #   from taskcoachlib import operating_system
@@ -34,6 +34,16 @@ def isWindows():
 
 def isGTK():
     return isPlatform("GTK")
+
+
+def isWayland():
+    """Detect if running on Wayland display server.
+
+    Note: AUI floating windows are broken on Wayland due to protocol
+    limitations. See docs/AUI_WAYLAND_ISSUES.md for details.
+    """
+    return (os.environ.get('XDG_SESSION_TYPE') == 'wayland' or
+            os.environ.get('WAYLAND_DISPLAY') is not None)
 
 
 def isPlatform(threeLetterPlatformAbbreviation, wxPlatform=wx.Platform):

--- a/taskcoachlib/widgets/frame.py
+++ b/taskcoachlib/widgets/frame.py
@@ -121,6 +121,7 @@ class AuiManagedFrameWithDynamicCenterPane(wx.Frame):
         if floating:
             paneInfo.Float()
         if not self.dockedPanes():
+            # First pane goes to center
             paneInfo = paneInfo.Center()
         self.manager.AddPane(window, paneInfo)
         self.manager.Update()


### PR DESCRIPTION
- Add 'Reset window layout' menu option in View menu
- Resets to fresh install defaults: 1 TaskViewer (center), 1 CategoryViewer (right)
- Properly cleans up tabbed/notebook panes using DetachPane() before ClosePane()
- Explicitly positions TaskViewer to AUI_DOCK_CENTER (required for docking to work)

- Add docs/AUI_WAYLAND_ISSUES.md documenting:
  - What works/broken on Wayland (floating ok, docking hints broken)
  - Technical root cause (Wayland hides global coordinates)
  - Upstream wxOverlay fix (not yet in wxPython AGW AUI)
  - XWayland workaround with GDK_BACKEND=x11
  - Reset implementation details

- Add operating_system.isWayland() detection
- Bump version to 2.0.1.34