### PR TITLE
Add weekday selector for weekly recurrence and restore prereq status exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.35-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.35-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.35_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.35_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.35_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.35-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.36-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.36-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.36_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.36_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.36_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.36-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.35-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.35-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.35_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.35_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.35-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.35-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.36-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.36-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.36_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.36_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.36-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.36-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.35_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.35_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.36_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.36_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.35-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.35-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.36-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.36-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.35-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.35-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.36-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.36-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.35-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.35-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.36-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.36-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.35-x86_64.AppImage
+./TaskCoach-2.0.1.36-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/taskcoachlib/domain/date/recurrence.py
+++ b/taskcoachlib/domain/date/recurrence.py
@@ -35,6 +35,7 @@ class Recurrence(object):
         count=0,
         stop_datetime=None,
         recurBasedOnCompletion=False,
+        weekdays=None,
     ):
         assert unit in self.units
         assert amount >= 1
@@ -46,6 +47,8 @@ class Recurrence(object):
         self.max = maximum
         self.count = count  # Actual number of recurrences given out so far
         self.recurBasedOnCompletion = recurBasedOnCompletion
+        # Weekdays for weekly recurrence (list of 0-6, where 0=Monday)
+        self.weekdays = weekdays if weekdays is not None else []
 
     def __call__(self, *dateTimes, **kwargs):
         result = [self._nextDateTime(dateTime) for dateTime in dateTimes]
@@ -87,6 +90,21 @@ class Recurrence(object):
             return self._addDays(dateTime)
 
     def _addDays(self, dateTime):
+        if self.unit == "weekly" and self.weekdays:
+            # DateTime.weekday() returns isoweekday (1-7, Mon=1, Sun=7)
+            # self.weekdays uses Python convention (0-6, Mon=0, Sun=6)
+            # Convert stored weekdays to ISO: iso = python + 1
+            current_iso = dateTime.weekday()
+            iso_weekdays = sorted([wd + 1 for wd in self.weekdays])
+            # Find the next weekday in the list after current
+            for wd in iso_weekdays:
+                if wd > current_iso:
+                    days_ahead = wd - current_iso
+                    return dateTime + timedelta.TimeDelta(days=days_ahead)
+            # No weekday found this week, go to first selected day next week
+            first_iso = iso_weekdays[0]
+            days_ahead = 7 - current_iso + first_iso
+            return dateTime + timedelta.TimeDelta(days=days_ahead)
         nrOfDays = dict(daily=1, weekly=7)[self.unit]
         return dateTime + timedelta.TimeDelta(days=nrOfDays)
 
@@ -156,6 +174,7 @@ class Recurrence(object):
             self.max,
             stop_datetime=self.stop_datetime,
             recurBasedOnCompletion=self.recurBasedOnCompletion,
+            weekdays=list(self.weekdays),
         )
 
     def __eq__(self, other):
@@ -167,6 +186,7 @@ class Recurrence(object):
                 and self.max == other.max
                 and self.stop_datetime == other.stop_datetime
                 and self.recurBasedOnCompletion == other.recurBasedOnCompletion
+                and self.weekdays == other.weekdays
             )
         except AttributeError:
             return False

--- a/taskcoachlib/domain/task/task.py
+++ b/taskcoachlib/domain/task/task.py
@@ -634,7 +634,19 @@ class Task(
             self.__status = status.completed
         else:
             now = date.Now()
-            if self.dueDateTime() < now:
+            # Don't call prerequisite.completed() because it will lead to infinite
+            # recursion in the case of circular dependencies.
+            # Check prerequisites first - task is inactive if any prereq is uncompleted:
+            if any(
+                [
+                    prerequisite.completionDateTime() == self.maxDateTime
+                    for prerequisite in self.prerequisites(
+                        recursive=True, upwards=True
+                    )
+                ]
+            ):
+                self.__status = status.inactive
+            elif self.dueDateTime() < now:
                 self.__status = status.overdue
             elif 0 <= self.timeLeft().hours() < self.__dueSoonHours:
                 self.__status = status.duesoon
@@ -1398,6 +1410,8 @@ class Task(
         recur = self.recurrence(recursive=True, upwards=True)
 
         currentDueDateTime = self.dueDateTime()
+        currentPlannedStartDateTime = self.plannedStartDateTime()
+
         if currentDueDateTime != date.DateTime():
             basisForRecurrence = (
                 completionDateTime
@@ -1413,7 +1427,6 @@ class Task(
             )
             self.setDueDateTime(nextDueDateTime)
 
-        currentPlannedStartDateTime = self.plannedStartDateTime()
         if currentPlannedStartDateTime != date.DateTime():
             if date.DateTime() not in (
                 currentPlannedStartDateTime,

--- a/taskcoachlib/gui/dialog/entry.py
+++ b/taskcoachlib/gui/dialog/entry.py
@@ -573,6 +573,35 @@ class RecurrenceEntry(wx.Panel):
         recurrenceFrequencyPanel.SetSizerAndFit(panelSizer)
         self._recurrenceSizer = panelSizer
 
+        # Weekday selector panel for weekly recurrence
+        weekdayPanel = wx.Panel(self)
+        weekdayPanelSizer = wx.BoxSizer(wx.HORIZONTAL)
+        weekdayPanelSizer.Add(
+            wx.StaticText(weekdayPanel, label=_("On days:")),
+            flag=wx.ALIGN_CENTER_VERTICAL,
+        )
+        weekdayPanelSizer.Add((6, -1))
+        # Weekday names starting from Monday (0) to Sunday (6)
+        weekdayNames = [
+            _("Mon"),
+            _("Tue"),
+            _("Wed"),
+            _("Thu"),
+            _("Fri"),
+            _("Sat"),
+            _("Sun"),
+        ]
+        self._weekdayCheckBoxes = []
+        for i, dayName in enumerate(weekdayNames):
+            cb = wx.CheckBox(weekdayPanel, label=dayName)
+            cb.Bind(wx.EVT_CHECKBOX, self.onRecurrenceEdited)
+            self._weekdayCheckBoxes.append(cb)
+            weekdayPanelSizer.Add(cb, flag=wx.ALIGN_CENTER_VERTICAL)
+            if i < len(weekdayNames) - 1:
+                weekdayPanelSizer.Add((6, -1))
+        weekdayPanel.SetSizerAndFit(weekdayPanelSizer)
+        self._weekdayPanel = weekdayPanel
+
         # schedulePanel created before maxPanel for correct tab order (top-to-bottom)
         schedulePanel = wx.Panel(self)
         panelSizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -666,6 +695,8 @@ class RecurrenceEntry(wx.Panel):
         panelSizer = wx.BoxSizer(wx.VERTICAL)
         panelSizer.Add(recurrenceFrequencyPanel)
         panelSizer.Add(self.verticalSpace)
+        panelSizer.Add(self._weekdayPanel)
+        panelSizer.Add(self.verticalSpace)
         panelSizer.Add(schedulePanel)
         panelSizer.Add(self.verticalSpace)
         panelSizer.Add(maxPanel)
@@ -686,6 +717,10 @@ class RecurrenceEntry(wx.Panel):
         self._recurrenceSameWeekdayCheckBox.Enable(
             self._recurrencePeriodEntry.Selection in (3, 4)
         )
+        # Enable weekday checkboxes only when weekly is selected (index 2)
+        weeklySelected = self._recurrencePeriodEntry.Selection == 2
+        for cb in self._weekdayCheckBoxes:
+            cb.Enable(weeklySelected)
         self._recurrenceSizer.Layout()
 
     def onRecurrencePeriodEdited(self, event):
@@ -733,6 +768,9 @@ class RecurrenceEntry(wx.Panel):
             if recurrence.unit in ("monthly", "yearly")
             else False
         )
+        # Set weekday checkboxes
+        for i, cb in enumerate(self._weekdayCheckBoxes):
+            cb.SetValue(i in recurrence.weekdays)
         self._scheduleChoice.Selection = (
             1 if recurrence.recurBasedOnCompletion else 0
         )
@@ -767,4 +805,8 @@ class RecurrenceEntry(wx.Panel):
             kwargs["stop_datetime"] = (
                 self._recurrenceStopDateTimeEntry.GetValue()
             )
+        # Get selected weekdays (0-6 for Mon-Sun)
+        kwargs["weekdays"] = [
+            i for i, cb in enumerate(self._weekdayCheckBoxes) if cb.IsChecked()
+        ]
         return date.Recurrence(**kwargs)  # pylint: disable=W0142

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,10 +41,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "35"  # Patch number - INCREMENT THIS for each release
+patch = "36"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.1.18
 
-release_day = "17"  # Day of the release (1-31)
+release_day = "18"  # Day of the release (1-31)
 release_month = "January"  # Month of the release
 release_year = "2026"  # Year of the release
 

--- a/taskcoachlib/persistence/xml/reader.py
+++ b/taskcoachlib/persistence/xml/reader.py
@@ -514,9 +514,16 @@ class XMLReader(object):
             maximum=0,
             stop_datetime=None,
             sameWeekday=False,
+            weekdays=[],
         )
         node = task_node.find("recurrence")
         if node is not None:
+            weekdays_str = node.attrib.get("weekdays", "")
+            weekdays = (
+                [int(d) for d in weekdays_str.split(",") if d]
+                if weekdays_str
+                else []
+            )
             kwargs = dict(
                 unit=node.attrib.get("unit", ""),
                 amount=int(node.attrib.get("amount", "1")),
@@ -531,6 +538,7 @@ class XMLReader(object):
                 recurBasedOnCompletion=self.__parse_boolean(
                     node.attrib.get("recurBasedOnCompletion", "False")
                 ),
+                weekdays=weekdays,
             )
         return kwargs
 

--- a/taskcoachlib/persistence/xml/writer.py
+++ b/taskcoachlib/persistence/xml/writer.py
@@ -212,6 +212,8 @@ class XMLWriter(object):
             attrs["sameWeekday"] = "True"
         if recurrence.recurBasedOnCompletion:
             attrs["recurBasedOnCompletion"] = "True"
+        if recurrence.weekdays:
+            attrs["weekdays"] = ",".join(str(d) for d in recurrence.weekdays)
         return ET.SubElement(parentNode, "recurrence", attrs)
 
     def effortNode(self, parentNode, effort):

--- a/taskcoachlib/render.py
+++ b/taskcoachlib/render.py
@@ -114,7 +114,21 @@ def recurrence(recurrence):
     else:
         labels = [_("Daily"), _("Weekly"), _("Monthly"), _("Yearly")]
     mapping = dict(list(zip(["daily", "weekly", "monthly", "yearly"], labels)))
-    return mapping.get(recurrence.unit) % dict(frequency=recurrence.amount)
+    result = mapping.get(recurrence.unit) % dict(frequency=recurrence.amount)
+    # Append weekday names for weekly recurrence if specific days are selected
+    if recurrence.unit == "weekly" and recurrence.weekdays:
+        weekday_names = [
+            _("Mon"),
+            _("Tue"),
+            _("Wed"),
+            _("Thu"),
+            _("Fri"),
+            _("Sat"),
+            _("Sun"),
+        ]
+        selected_days = [weekday_names[d] for d in sorted(recurrence.weekdays)]
+        result += " (" + ", ".join(selected_days) + ")"
+    return result
 
 
 def budget(aBudget):


### PR DESCRIPTION
- Add weekday selector UI (Mon-Sun checkboxes) for weekly recurrence
- Checkboxes only enabled when "Weekly" is selected
- Recurrence moves to next selected weekday instead of just +7 days
- Handle ISO weekday (1-7) vs Python weekday (0-6) conversion
- Display selected weekdays in recurrence column: "Weekly (Mon, Fri)"
- Persist weekdays in XML as comma-separated integers
- Restore prerequisite check: tasks with uncompleted prereqs show as inactive
- Prerequisite check now runs before overdue check (takes priority)

moved from UV: request for recurrence selecting multiple days of week #228