### PR TITLE
Fix Tab key to exit date/time controls instead of cycling subfields

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.36-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.36-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.36_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.36_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.36_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.36-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.37-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.37-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.37_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.37_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.37_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.37-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.36-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.36-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.36_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.36_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.36-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.36-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.37-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.37-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.37_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.37_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.37-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.37-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.36_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.36_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.37_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.37_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.36-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.36-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.37-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.37-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.36-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.36-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.37-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.37-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.36-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.36-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.37-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.37-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.36-x86_64.AppImage
+./TaskCoach-2.0.1.37-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,8 +41,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "36"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.1.18
+patch = "37"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.1.37
 
 release_day = "18"  # Day of the release (1-31)
 release_month = "January"  # Month of the release

--- a/taskcoachlib/thirdparty/smartdatetimectrl.py
+++ b/taskcoachlib/thirdparty/smartdatetimectrl.py
@@ -670,21 +670,7 @@ class Entry(wx.Panel):
                 event.Skip()
                 return
             self.DismissPopup()
-            # Tab navigates between subfields first, only exits at boundaries
-            fields = self.Fields()
-            if self.__focus is not None and fields:
-                currentIndex = fields.index(self.__focus)
-                if event.ShiftDown():
-                    # Shift+Tab: move to previous field or exit if at first
-                    if currentIndex > 0:
-                        self.__SetFocus(fields[currentIndex - 1])
-                        return
-                else:
-                    # Tab: move to next field or exit if at last
-                    if currentIndex < len(fields) - 1:
-                        self.__SetFocus(fields[currentIndex + 1])
-                        return
-            # At boundary - exit the control
+            # Tab exits the control; use left/right arrows for subfield navigation
             self._Entry__hasFocus = False
             self.Refresh()
             self.Navigate(not event.ShiftDown())

--- a/taskcoachlib/widgets/datectrl.py
+++ b/taskcoachlib/widgets/datectrl.py
@@ -108,6 +108,8 @@ class DateTimeCtrl(wx.Panel):
         self.SetSizer(sizer)
 
         self.__ctrl.Bind(sdtc.EVT_DATETIME_CHANGE, self.__OnChange)
+        # Forward choices change events so external bindings work
+        self.__ctrl.Bind(sdtc.EVT_TIME_CHOICES_CHANGE, self.__OnChoicesChange)
         # Pass focus to child when panel receives focus via Tab
         self.Bind(wx.EVT_SET_FOCUS, self.__OnSetFocus)
 
@@ -132,6 +134,12 @@ class DateTimeCtrl(wx.Panel):
         self.__value = event.GetValue()
         if self.__callback is not None:
             self.__callback()
+
+    def __OnChoicesChange(self, event):
+        """Forward choices change event from internal control to this panel."""
+        # Re-emit event from this panel so external bindings receive it
+        new_event = sdtc.TimeChoicesChangedEvent(self, event.GetValue())
+        self.ProcessEvent(new_event)
 
     def EnableChoices(self, enabled=True):
         self.__ctrl.EnableChoices(enabled=enabled)


### PR DESCRIPTION
Previously, pressing Tab in date/time Entry controls would cycle between subfields (day, month, year, hour, minute) before exiting the control. This was inconsistent with standard form navigation behavior where Tab moves between controls, not within them.

Now Tab immediately exits the control and moves to the next form field. Users can still navigate between subfields using the left/right arrow keys.

Also forwards choices change events from the DateTimeCtrl wrapper panel so external code can bind to preset selection changes.

Version 2.0.1.37

Somehow, the Tab key function changed (and I don't like it) #262