### PR TITLE
Fix dialog rendering problem on GNOME Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.43-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.43-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.43_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.43_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.43_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.43-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.44-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.44-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.44_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.44_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.44_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.44-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.43-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.43-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.43_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.43_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.43-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.43-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.44-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.44-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.44_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.44_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.44-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.44-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.43_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.43_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.44_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.44_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.43-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.43-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.44-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.44-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.43-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.43-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.44-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.44-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.43-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.43-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.44-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.44-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.43-x86_64.AppImage
+./TaskCoach-2.0.1.44-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "43"  # Patch number - INCREMENT THIS for each release
+patch = "44"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.1.41
 
 release_day = "20"  # Day of the release (1-31)

--- a/taskcoachlib/widgets/dialog.py
+++ b/taskcoachlib/widgets/dialog.py
@@ -79,11 +79,28 @@ class Dialog(sized_controls.SizedDialog):
             wx.CallAfter(self.__safeLayoutRefresh)
 
     def __safeLayoutRefresh(self):
-        """Force layout refresh on Wayland where initial render may be incomplete."""
+        """Force layout refresh on Wayland where initial render may be incomplete.
+
+        GTK3 caches widget best sizes, and when windows are laid out while hidden
+        (as dialogs are during construction), the cached sizes may be wrong.
+        We must invalidate all cached sizes recursively, then re-layout.
+        See: https://github.com/wxWidgets/wxWidgets/issues/19053
+        """
         try:
             if self and self._panel:
+                self.__invalidateBestSizeRecursively(self)
                 self._panel.Layout()
-                self.SendSizeEvent()
+                self.Layout()
+                self.Refresh()
+        except RuntimeError:
+            pass
+
+    def __invalidateBestSizeRecursively(self, window):
+        """Recursively invalidate best size cache for window and all children."""
+        try:
+            window.InvalidateBestSize()
+            for child in window.GetChildren():
+                self.__invalidateBestSizeRecursively(child)
         except RuntimeError:
             pass
 


### PR DESCRIPTION
The previous Wayland rendering fix was insufficient. GTK3 caches widget best sizes when windows are laid out while hidden (during dialog construction). Simply calling Layout() and SendSizeEvent() did not clear these cached values, causing text labels to appear truncated.

This fix recursively calls InvalidateBestSize() on all child widgets before re-layout, which clears GTK3's cached sizes and allows proper text rendering on first display.

Ref: https://github.com/wxWidgets/wxWidgets/issues/19053

major glitches on GNOME+Wayland (Ubuntu), rendering #267