### PR TITLE
Add Time Spent display to Edit Effort dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.44-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.44-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.44_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.44_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.44_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.44-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.45-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.45-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.45_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.45_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.45_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.45-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.44-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.44-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.44_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.44_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.44-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.44-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.45-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.45-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.45_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.45_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.45-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.45-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.44_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.44_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.45_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.45_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.44-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.44-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.45-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.45-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.44-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.44-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.45-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.45-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.44-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.44-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.45-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.45-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.44-x86_64.AppImage
+./TaskCoach-2.0.1.45-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -3193,8 +3193,55 @@ class EffortEditBook(Page):
             flags=[None, None, wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL],
         )
 
-        # --- Duration row ---
+        # --- Time Spent row (display only) ---
+        # Get stop time early - needed for timer decision and duration calculation
         current_stop_date_time = self.items[0].getStop()
+
+        # Calculate initial time spent
+        if current_stop_date_time is not None:
+            time_spent_duration = current_stop_date_time - current_start_date_time
+            time_spent_seconds = max(0, int(time_spent_duration.total_seconds()))
+        else:
+            # Tracking - calculate from start to now
+            now = date.DateTime.now()
+            if current_start_date_time and now > current_start_date_time:
+                time_spent_duration = now - current_start_date_time
+                time_spent_seconds = int(time_spent_duration.total_seconds())
+            else:
+                time_spent_seconds = 0
+
+        ts_hours = time_spent_seconds // 3600
+        ts_minutes = (time_spent_seconds % 3600) // 60
+        ts_seconds = time_spent_seconds % 60
+
+        self._timeSpentCtrl = widgets.MaskedDurationCtrl(
+            self,
+            days=0, hours=ts_hours, minutes=ts_minutes, seconds=ts_seconds,
+            showSeconds=True
+        )
+        # Deactivate when stop time exists, read-only (but not disabled) when tracking
+        if current_stop_date_time is not None:
+            self._timeSpentCtrl.Enable(False)
+        else:
+            self._timeSpentCtrl.SetReadOnly(True)
+
+        self._timeSpentLabel = wx.StaticText(self, label=_("Calculated time spent until now"))
+
+        self._timeSpentTimer = None
+        # Start timer only if effort is being tracked (no stop time)
+        if current_stop_date_time is None:
+            self._timeSpentTimer = wx.Timer(self)
+            self.Bind(wx.EVT_TIMER, self.__onTimeSpentTimer, self._timeSpentTimer)
+            self._timeSpentTimer.Start(1000)  # Update every second
+
+        self.addEntry(
+            _("Time spent"),
+            self._timeSpentCtrl,
+            self._timeSpentLabel,
+            flags=[None, None, wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL],
+        )
+
+        # --- Duration row ---
         if current_stop_date_time is not None:
             duration = current_stop_date_time - current_start_date_time
             total_seconds = int(duration.total_seconds())
@@ -3387,12 +3434,22 @@ class EffortEditBook(Page):
                 command.EditEffortStopDateTimeCommand(
                     None, self.items, newValue=self._stopDateTimeCombo.GetValue()
                 ).do()
+                # Stop timer - effort is no longer being tracked
+                self.__stopTimeSpentTimer()
+                # Deactivate time spent control
+                self._timeSpentCtrl.Enable(False)
             else:
                 # Disabling stop - duration stays enabled
                 for item in self.items:
                     item.setStop(date.DateTime.max)
                 self.__updateEffortPresetSelection()
                 self.__update_invalid_period_message()
+                self.__updateTimeSpentDisplay()
+                # Start timer - effort is now being tracked
+                self.__startTimeSpentTimer()
+                # Enable time spent control but make it read-only (not editable)
+                self._timeSpentCtrl.Enable(True)
+                self._timeSpentCtrl.SetReadOnly(True)
         finally:
             self._updatingControls = False
         event.Skip()
@@ -3542,6 +3599,7 @@ class EffortEditBook(Page):
 
         self.__updateEffortPresetSelection()
         self.__update_invalid_period_message()
+        self.__updateTimeSpentDisplay()
 
     def __populateEffortDurationPresets(self):
         """Populate the effort duration presets dropdown from settings."""
@@ -3603,13 +3661,14 @@ class EffortEditBook(Page):
         duration = self._effortDurationCtrl.GetDuration()
         current_seconds = int(duration.total_seconds())
 
-        # Search for matching preset (start at 1 to skip placeholder, include "Reset to zero")
-        for i in range(1, self._effortDurationPresetsChoice.GetCount()):
+        # Search for matching preset (start at 1 to skip placeholder, stop before last "Reset to zero")
+        for i in range(1, self._effortDurationPresetsChoice.GetCount() - 1):
             preset_seconds = self._effortDurationPresetsChoice.GetClientData(i)
             if preset_seconds == current_seconds:
                 self._effortDurationPresetsChoice.SetSelection(i)
                 return
 
+        # No match - reset to placeholder "Presets..."
         self._effortDurationPresetsChoice.SetSelection(0)
 
     def __onEffortDurationPresetSelected(self, event):
@@ -3636,6 +3695,8 @@ class EffortEditBook(Page):
                 for item in self.items:
                     item.setStop(date.DateTime.max)
                 self.__update_invalid_period_message()
+                # Reset dropdown back to "Presets..." (don't show "Reset to zero" as selected)
+                self._effortDurationPresetsChoice.SetSelection(0)
                 return
 
             if self._effortEntryMode == 1:  # Retroactive mode
@@ -3671,6 +3732,54 @@ class EffortEditBook(Page):
     def __onEffortPresetsConfigChanged(self):
         """Handle changes to effort preset configuration."""
         self.__populateEffortDurationPresets()
+
+    def __updateTimeSpentDisplay(self):
+        """Update the Time Spent display control based on current start/stop times."""
+        if not hasattr(self, '_timeSpentCtrl'):
+            return
+        if not hasattr(self, '_stopDateTimeCombo'):
+            return
+
+        start = self._startDateTimeCombo.GetDateTime()
+        if start is None:
+            self._timeSpentCtrl.SetDuration(datetime.timedelta(seconds=0), quiet=True)
+            return
+
+        # Get stop time, or use current time if effort is being tracked
+        if self._stopDateTimeCombo.IsChecked():
+            stop = self._stopDateTimeCombo.GetDateTime()
+        else:
+            stop = date.DateTime.now()
+
+        if stop is None or start is None:
+            self._timeSpentCtrl.SetDuration(datetime.timedelta(seconds=0), quiet=True)
+            return
+
+        # Calculate duration
+        if stop > start:
+            duration = stop - start
+            total_seconds = int(duration.total_seconds())
+        else:
+            total_seconds = 0
+
+        self._timeSpentCtrl.SetDuration(datetime.timedelta(seconds=total_seconds), quiet=True)
+
+    def __onTimeSpentTimer(self, event):
+        """Timer handler to update time spent display for tracking efforts."""
+        self.__updateTimeSpentDisplay()
+
+    def __startTimeSpentTimer(self):
+        """Start the timer for updating time spent display."""
+        if self._timeSpentTimer is None:
+            self._timeSpentTimer = wx.Timer(self)
+            self.Bind(wx.EVT_TIMER, self.__onTimeSpentTimer, self._timeSpentTimer)
+            self._timeSpentTimer.Start(1000)
+
+    def __stopTimeSpentTimer(self):
+        """Stop the timer for updating time spent display."""
+        if self._timeSpentTimer is not None:
+            self._timeSpentTimer.Stop()
+            self._timeSpentTimer = None
 
     def __create_start_from_last_effort_button(self, parent=None):
         if parent is None:
@@ -3832,6 +3941,8 @@ class EffortEditBook(Page):
             pub.unsubscribe(self.__onEffortPresetsConfigChanged, "settings.feature.sdtcspans_effort")
         except Exception:
             pass
+        # Stop the time spent timer
+        self.__stopTimeSpentTimer()
 
 
 class Editor(BalloonTipManager, widgets.Dialog):

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,10 +41,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "44"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.1.41
+patch = "45"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.1.45
 
-release_day = "20"  # Day of the release (1-31)
+release_day = "21"  # Day of the release (1-31)
 release_month = "January"  # Month of the release
 release_year = "2026"  # Year of the release
 


### PR DESCRIPTION
- Add Time Spent row to Edit Effort dialog showing elapsed time between start and current time (when tracking) or start and stop (when stopped)
- Live timer updates the display every second during effort tracking
- Time Spent control is read-only when tracking, disabled when stopped
- Fix duration presets dropdown incorrectly matching "Reset to zero" option
- Reset presets dropdown to "Presets..." after selecting "Reset to zero"
- Update README.md version references to 2.0.1.45

Infer Duration related calculations based on actions #285