### PR TITLE
Refactor iCalendar export

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.48-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.48-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.48_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.48_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.48_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.48-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.49-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.49-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.49_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.49_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.49_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.49-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.48-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.48-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.48_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.48_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.48-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.48-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.49-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.49-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.49_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.49_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.49-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.49-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.48_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.48_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.49_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.49_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.48-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.48-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.49-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.49-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.48-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.48-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.49-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.49-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.48-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.48-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.49-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.49-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.48-x86_64.AppImage
+./TaskCoach-2.0.1.49-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/taskcoachlib/gui/dialog/export.py
+++ b/taskcoachlib/gui/dialog/export.py
@@ -18,9 +18,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from taskcoachlib.tools import wxhelper
 import wx
+import datetime
 from taskcoachlib.i18n import _
 from wx.lib import sized_controls
+from wx.lib.agw import hypertreelist, customtreectrl
 from taskcoachlib import meta, widgets
+from pubsub import pub
 
 
 class ExportDialog(sized_controls.SizedDialog):
@@ -319,19 +322,402 @@ class ExportAsCSVDialog(ExportDialog):
         )
 
 
+class ICalendarViewerPicker(sized_controls.SizedPanel):
+    """Enhanced viewer picker for iCalendar export with 'All' options and
+    dynamic selection counts."""
+
+    # Special markers for "All" entries
+    ALL_TASKS = "ALL_TASKS"
+    ALL_EFFORTS = "ALL_EFFORTS"
+
+    def __init__(self, parent, mainWindow, activeViewer):
+        super().__init__(parent)
+        self.mainWindow = mainWindow
+        self.SetSizerType("horizontal")
+        self._viewerMap = {}  # Maps display string to viewer or ALL_* constant
+        self._subscriptions = []
+        self.createPicker()
+        self.populatePicker(activeViewer)
+        self._subscribeToSelectionChanges()
+
+    def createPicker(self):
+        label = wx.StaticText(self, label=_("Export items from:"))
+        label.SetSizerProps(valign="center")
+        # Use wx.Choice instead of ComboBox - it's a true dropdown with no editable text field
+        self.viewerComboBox = wx.Choice(self)
+        self.viewerComboBox.Bind(wx.EVT_CHOICE, self.onViewerChanged)
+
+    def _getOpenViewers(self):
+        """Get open Task and Effort viewers."""
+        viewers = list(self.mainWindow.viewer)
+        taskViewers = [v for v in viewers if v.isShowingTasks()]
+        effortViewers = [
+            v for v in viewers
+            if v.isShowingEffort() and not v.isShowingAggregatedEffort()
+        ]
+        return taskViewers, effortViewers
+
+    def _getSelectionCount(self, viewer):
+        """Get selection count for a viewer."""
+        try:
+            return len(viewer.curselection())
+        except (RuntimeError, AttributeError):
+            return 0
+
+    def _buildSortedEntries(self, taskViewers, effortViewers):
+        """Build sorted entries for the dropdown."""
+        entries = []
+
+        # Section 1: "All" entries (alphabetical)
+        allEntries = [
+            (_("Efforts (All)"), self.ALL_EFFORTS),
+            (_("Tasks (All)"), self.ALL_TASKS),
+        ]
+        allEntries.sort(key=lambda x: x[0])
+        entries.extend(allEntries)
+
+        # Separator marker
+        entries.append(("---", None))
+
+        # Section 2: Open viewers
+        # Group by type, alphabetical, then by selection count descending
+        viewerEntries = []
+
+        # Effort viewers
+        for viewer in effortViewers:
+            count = self._getSelectionCount(viewer)
+            title = viewer.title()
+            displayText = _("%s (%d selected)") % (title, count)
+            # Sort key: (type for alpha sort, -count for descending)
+            viewerEntries.append((title, -count, displayText, viewer))
+
+        # Task viewers
+        for viewer in taskViewers:
+            count = self._getSelectionCount(viewer)
+            title = viewer.title()
+            displayText = _("%s (%d selected)") % (title, count)
+            viewerEntries.append((title, -count, displayText, viewer))
+
+        # Sort by title (alphabetical), then by -count (most selected first)
+        viewerEntries.sort(key=lambda x: (x[0], x[1]))
+
+        for title, negCount, displayText, viewer in viewerEntries:
+            entries.append((displayText, viewer))
+
+        return entries
+
+    def populatePicker(self, activeViewer=None):
+        """Populate the dropdown with sorted entries.
+
+        Default selection is always the first item (an "All" choice)."""
+        self.viewerComboBox.Clear()
+        self._viewerMap.clear()
+
+        taskViewers, effortViewers = self._getOpenViewers()
+        entries = self._buildSortedEntries(taskViewers, effortViewers)
+
+        for i, (displayText, viewerOrMarker) in enumerate(entries):
+            if displayText == "---":
+                # Add separator (visual only - wxComboBox doesn't support real separators)
+                self.viewerComboBox.Append("─" * 20)
+            else:
+                self.viewerComboBox.Append(displayText)
+                self._viewerMap[displayText] = viewerOrMarker
+
+        # Default to first item (first "All" choice)
+        if self.viewerComboBox.GetCount() > 0:
+            self.viewerComboBox.SetSelection(0)
+
+    def _subscribeToSelectionChanges(self):
+        """Subscribe to selection change events from all viewers."""
+        pub.subscribe(self._onViewerStatusChanged, "viewer.status")
+
+    def _onViewerStatusChanged(self):
+        """Handle viewer status changes (including selection changes)."""
+        # Refresh the dropdown to update selection counts
+        currentSelection = self.viewerComboBox.GetStringSelection()
+        currentViewer = self._viewerMap.get(currentSelection)
+
+        taskViewers, effortViewers = self._getOpenViewers()
+        entries = self._buildSortedEntries(taskViewers, effortViewers)
+
+        self.viewerComboBox.Clear()
+        self._viewerMap.clear()
+
+        newSelectionIndex = 0
+        for i, (displayText, viewerOrMarker) in enumerate(entries):
+            if displayText == "---":
+                self.viewerComboBox.Append("─" * 20)
+            else:
+                self.viewerComboBox.Append(displayText)
+                self._viewerMap[displayText] = viewerOrMarker
+
+                # Try to keep the same viewer selected
+                if viewerOrMarker == currentViewer:
+                    newSelectionIndex = self.viewerComboBox.GetCount() - 1
+
+        if self.viewerComboBox.GetCount() > 0:
+            self.viewerComboBox.SetSelection(newSelectionIndex)
+
+    def selectedViewer(self):
+        """Return the selected viewer or ALL_* constant."""
+        displayText = self.viewerComboBox.GetStringSelection()
+        return self._viewerMap.get(displayText)
+
+    def isAllSelected(self):
+        """Return True if an 'All' option is selected."""
+        selected = self.selectedViewer()
+        return selected in (self.ALL_TASKS, self.ALL_EFFORTS)
+
+    def isTasksSelected(self):
+        """Return True if Tasks (All) or a Task viewer is selected."""
+        selected = self.selectedViewer()
+        if selected == self.ALL_TASKS:
+            return True
+        if selected and selected != self.ALL_EFFORTS:
+            try:
+                return selected.isShowingTasks()
+            except AttributeError:
+                pass
+        return False
+
+    def options(self):
+        return dict(selectedViewer=self.selectedViewer())
+
+    def onViewerChanged(self, event):
+        event.Skip()
+        # Skip separator selections
+        selection = self.viewerComboBox.GetStringSelection()
+        if selection.startswith("─"):
+            # Move to next valid item
+            idx = self.viewerComboBox.GetSelection()
+            if idx + 1 < self.viewerComboBox.GetCount():
+                self.viewerComboBox.SetSelection(idx + 1)
+            elif idx > 0:
+                self.viewerComboBox.SetSelection(idx - 1)
+        wx.PostEvent(self, ViewerPickedEvent(viewer=self.selectedViewer()))
+
+    def saveSettings(self):
+        pass
+
+    def Destroy(self):
+        try:
+            pub.unsubscribe(self._onViewerStatusChanged, "viewer.status")
+        except Exception:
+            pass
+        return super().Destroy()
+
+
+class ICalendarFieldPicker(sized_controls.SizedPanel):
+    """Control for selecting which fields to export in iCalendar format.
+    Uses HyperTreeList with checkboxes."""
+
+    # Field definitions: (field_key, taskcoach_label, icalendar_field, required, for_tasks, for_efforts)
+    TASK_FIELDS = [
+        ("uid", _("ID"), "UID", True, True, False),
+        ("dtstamp", _("(auto-generated)"), "DTSTAMP", True, True, False),
+        ("summary", _("Subject"), "SUMMARY", False, True, False),
+        ("description", _("Description"), "DESCRIPTION", False, True, False),
+        ("dtstart", _("Planned start date"), "DTSTART", False, True, False),
+        ("due", _("Due date"), "DUE", False, True, False),
+        ("completed", _("Completion date"), "COMPLETED", False, True, False),
+        ("categories", _("Categories"), "CATEGORIES", False, True, False),
+        ("status", _("Status"), "STATUS", False, True, False),
+        ("priority", _("Priority"), "PRIORITY", False, True, False),
+        ("percent", _("Percent complete"), "PERCENT-COMPLETE", False, True, False),
+        ("created", _("Creation date"), "CREATED", False, True, False),
+        ("lastmod", _("Modification date"), "LAST-MODIFIED", False, True, False),
+    ]
+
+    EFFORT_FIELDS = [
+        ("uid", _("ID"), "UID", True, False, True),
+        ("dtstamp", _("(auto-generated)"), "DTSTAMP", True, False, True),
+        ("summary", _("Subject"), "SUMMARY", False, False, True),
+        ("description", _("Description"), "DESCRIPTION", False, False, True),
+        ("dtstart", _("Start"), "DTSTART", False, False, True),
+        ("dtend", _("End"), "DTEND", False, False, True),
+    ]
+
+    def __init__(self, parent, forTasks=True):
+        super().__init__(parent)
+        self.SetSizerType("vertical")
+        self.SetSizerProps(expand=True, proportion=1)
+        self._forTasks = forTasks
+        self._checkedFields = set()
+        self._itemMap = {}  # Maps field_key to tree item
+        self.createFieldPicker()
+        self.populateFields()
+
+    def createFieldPicker(self):
+        label = wx.StaticText(self, label=_("Fields to export:"))
+        label.SetSizerProps(valign="top")
+
+        agwStyle = (
+            wx.TR_DEFAULT_STYLE
+            | wx.TR_HIDE_ROOT
+            | wx.TR_NO_BUTTONS
+            | wx.TR_FULL_ROW_HIGHLIGHT
+            | customtreectrl.TR_AUTO_CHECK_CHILD
+        )
+
+        # Use default border style to match system theme
+        self.tree = hypertreelist.HyperTreeList(
+            self,
+            agwStyle=agwStyle
+        )
+        self.tree.SetSizerProps(expand=True, proportion=1)
+
+        # Add columns - widths will be auto-sized after population
+        self.tree.AddColumn(_("TaskCoach Field"))
+        self.tree.AddColumn(_("iCalendar Field"))
+
+        self.tree.Bind(customtreectrl.EVT_TREE_ITEM_CHECKED, self.onItemChecked)
+
+    def populateFields(self):
+        """Populate the field list based on whether we're exporting tasks or efforts."""
+        self.tree.DeleteAllItems()
+        self._itemMap.clear()
+        self._checkedFields.clear()
+
+        root = self.tree.AddRoot("")
+        fields = self.TASK_FIELDS if self._forTasks else self.EFFORT_FIELDS
+
+        for field_key, tc_label, ical_field, required, for_tasks, for_efforts in fields:
+            # ct_type: 0=normal, 1=checkbox, 2=radiobutton
+            item = self.tree.AppendItem(root, tc_label, ct_type=1)
+            self.tree.SetItemText(item, ical_field, 1)
+            self._itemMap[field_key] = item
+
+            # Check all items by default
+            self.tree.CheckItem(item, True)
+            self._checkedFields.add(field_key)
+
+            # Disable required fields (greyed out but checked)
+            if required:
+                self.tree.EnableItem(item, False)
+
+        # Auto-size columns to fit content
+        self._autoSizeColumns()
+
+    def _autoSizeColumns(self):
+        """Auto-size columns to fit their content."""
+        for col in range(self.tree.GetColumnCount()):
+            self.tree.SetColumnWidth(col, wx.LIST_AUTOSIZE)
+            # Ensure minimum width for readability
+            if self.tree.GetColumnWidth(col) < 100:
+                self.tree.SetColumnWidth(col, 100)
+
+    def setForTasks(self, forTasks):
+        """Switch between task and effort field lists."""
+        if self._forTasks != forTasks:
+            self._forTasks = forTasks
+            self.populateFields()
+
+    def onItemChecked(self, event):
+        """Handle checkbox changes."""
+        item = event.GetItem()
+        # Find the field key for this item
+        for field_key, treeItem in self._itemMap.items():
+            if treeItem == item:
+                if self.tree.IsItemChecked(item):
+                    self._checkedFields.add(field_key)
+                else:
+                    self._checkedFields.discard(field_key)
+                break
+        event.Skip()
+
+    def selectedFields(self):
+        """Return set of selected field keys."""
+        return self._checkedFields.copy()
+
+    def options(self):
+        return dict(selectedFields=self.selectedFields())
+
+    def saveSettings(self):
+        pass
+
+
 class ExportAsICalendarDialog(ExportDialog):
+    """Non-modal export dialog for iCalendar format.
+
+    This dialog is non-modal to allow users to change selections in the
+    main window while the export dialog is open."""
+
     title = _("Export as iCalendar")
 
+    def __init__(self, *args, **kwargs):
+        self._exportCallback = kwargs.pop("exportCallback", None)
+        # Use non-modal style (no DIALOG_MODAL)
+        super().__init__(*args, **kwargs)
+        # Bind cancel button and close event
+        self.Bind(wx.EVT_CLOSE, self.onClose)
+        cancelBtn = self.FindWindowById(wx.ID_CANCEL)
+        if cancelBtn:
+            cancelBtn.Bind(wx.EVT_BUTTON, self.onCancel)
+
     def createInterior(self, pane):
-        viewerPicker = ViewerPicker(
-            pane, self.exportableViewers(), self.activeViewer()
+        self.viewerPicker = ICalendarViewerPicker(
+            pane, self.window, self.activeViewer()
         )
-        selectionOnlyCheckBox = SelectionOnlyCheckBox(
-            pane, self.settings, self.section, "ical_selectiononly"
-        )
-        return viewerPicker, selectionOnlyCheckBox
+        self.viewerPicker.Bind(EVT_VIEWERPICKED, self.onViewerChanged)
+
+        # Determine initial field type based on active viewer
+        forTasks = self._isTasksSelected()
+        self.fieldPicker = ICalendarFieldPicker(pane, forTasks=forTasks)
+
+        # Note: "Selection only" checkbox removed - behavior is now implicit:
+        # - "All" choices export all items
+        # - Viewer choices export only selected items from that viewer
+
+        return self.viewerPicker, self.fieldPicker
+
+    def onOk(self, event):
+        """Handle OK button - perform export and close dialog."""
+        # Save settings
+        for component in self.components:
+            component.saveSettings()
+
+        # Perform export if callback is set
+        if self._exportCallback:
+            exportOptions = self.options()
+            selectedViewer = exportOptions.pop("selectedViewer")
+            # Selection behavior is implicit based on dropdown choice:
+            # - "All" choices: selectionOnly=False (handled by writer)
+            # - Viewer choices: selectionOnly=True (export selected items)
+            isAllChoice = self.viewerPicker.isAllSelected()
+            exportOptions["selectionOnly"] = not isAllChoice
+
+            # Generate default filename: Tasks-YYYYMMDD or Effort-YYYYMMDD
+            dateStr = datetime.date.today().strftime("%Y%m%d")
+            if self._isTasksSelected():
+                exportOptions["defaultFilename"] = "Tasks-%s" % dateStr
+            else:
+                exportOptions["defaultFilename"] = "Effort-%s" % dateStr
+
+            self._exportCallback(selectedViewer, **exportOptions)
+
+        self.Destroy()
+
+    def onCancel(self, event):
+        """Handle Cancel button."""
+        self.Destroy()
+
+    def onClose(self, event):
+        """Handle window close (X button)."""
+        self.Destroy()
+
+    def _isTasksSelected(self):
+        """Check if Tasks are selected (All or viewer)."""
+        return self.viewerPicker.isTasksSelected()
+
+    def onViewerChanged(self, event):
+        event.Skip()
+        # Update field picker based on task/effort selection
+        forTasks = self._isTasksSelected()
+        self.fieldPicker.setForTasks(forTasks)
 
     def exportableViewers(self):
+        """Not used for iCalendar - we use ICalendarViewerPicker instead."""
         viewers = super().exportableViewers()
         return [
             viewer

--- a/taskcoachlib/gui/iocontroller.py
+++ b/taskcoachlib/gui/iocontroller.py
@@ -445,15 +445,22 @@ class IOController(object):
         )
 
     def exportAsICalendar(
-        self, viewer, selectionOnly=False, fileExists=os.path.exists
+        self, viewer, selectionOnly=False, selectedFields=None,
+        defaultFilename=None, fileExists=os.path.exists
     ):
+        # Use default filename if provided
+        fileOpts = self.__icsFileDialogOpts.copy()
+        if defaultFilename:
+            fileOpts["default_filename"] = defaultFilename
         return self.export(
             _("Export as iCalendar"),
-            self.__icsFileDialogOpts,
+            fileOpts,
             persistence.iCalendarWriter,
             viewer,
             selectionOnly,
             fileExists=fileExists,
+            selectedFields=selectedFields,
+            taskFile=self.__taskFile,
         )
 
     def exportAsTodoTxt(

--- a/taskcoachlib/gui/uicommand/uicommand.py
+++ b/taskcoachlib/gui/uicommand/uicommand.py
@@ -496,7 +496,10 @@ class FileExportAsCSV(FileExportCommand):
 
 
 class FileExportAsICalendar(FileExportCommand):
-    """Action for exporting the contents of a viewer to iCalendar format."""
+    """Action for exporting the contents of a viewer to iCalendar format.
+
+    Uses a non-modal dialog to allow users to change selections while
+    the export dialog is open."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(
@@ -506,15 +509,39 @@ class FileExportAsICalendar(FileExportCommand):
             *args,
             **kwargs
         )
+        self._exportDialog = None
+
+    def doCommand(self, event):
+        """Show non-modal export dialog."""
+        # If dialog already open, just raise it
+        if self._exportDialog:
+            self._exportDialog.Raise()
+            return
+
+        self._exportDialog = self.getExportDialogClass()(
+            self.mainWindow(),
+            settings=self.settings,
+            exportCallback=self.exportFunction()
+        )
+        # Use Show() for non-modal dialog
+        self._exportDialog.Show()
+        # Clear reference when dialog is destroyed
+        self._exportDialog.Bind(
+            wx.EVT_WINDOW_DESTROY,
+            self._onDialogDestroyed
+        )
+
+    def _onDialogDestroyed(self, event):
+        """Clear dialog reference when destroyed."""
+        self._exportDialog = None
+        event.Skip()
 
     def exportFunction(self):
         return self.iocontroller.exportAsICalendar
 
     def enabled(self, event):
-        return any(
-            self.exportableViewer(viewer)
-            for viewer in self.mainWindow().viewer
-        )
+        # Always enabled since we have "Tasks (All)" and "Efforts (All)" options
+        return True
 
     @staticmethod
     def getExportDialogClass():

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,10 +41,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "48"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.1.45
+patch = "49"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.1.49
 
-release_day = "21"  # Day of the release (1-31)
+release_day = "22"  # Day of the release (1-31)
 release_month = "January"  # Month of the release
 release_year = "2026"  # Year of the release
 

--- a/taskcoachlib/persistence/icalendar/ical.py
+++ b/taskcoachlib/persistence/icalendar/ical.py
@@ -369,79 +369,132 @@ class VNoteParser(VCalendarParser):
 # { Generating iCalendar files.
 
 
-def VCalFromTask(task, encoding=True, doFold=True):
+def VCalFromTask(task, encoding=True, doFold=True, selectedFields=None):
     """This function returns a string representing the task in
-    iCalendar format."""
+    iCalendar format.
 
-    encoding = ";ENCODING=QUOTED-PRINTABLE;CHARSET=UTF-8" if encoding else ""
+    Args:
+        task: The task to export
+        encoding: Whether to use quoted-printable encoding
+        doFold: Whether to fold long lines
+        selectedFields: Set of field keys to export. If None, export all fields.
+                       Required fields (uid, dtstamp) are always exported.
+    """
+    # Default to all fields if not specified
+    if selectedFields is None:
+        selectedFields = {
+            "uid", "dtstamp", "summary", "description", "dtstart", "due",
+            "completed", "categories", "status", "priority", "percent",
+            "created", "lastmod"
+        }
+
+    encoding_str = ";ENCODING=QUOTED-PRINTABLE;CHARSET=UTF-8" if encoding else ""
     quote = quoteString if encoding else lambda s: s
 
     components = []
     components.append("BEGIN:VTODO")  # pylint: disable=W0511
-    components.append("UID:%s" % task.id().encode("UTF-8"))
 
-    if task.creationDateTime() > date.DateTime.min:
+    # Required fields (always exported)
+    components.append("UID:%s" % task.id().encode("UTF-8"))
+    components.append("DTSTAMP:%s" % fmtDateTime(date.Now()))
+
+    if "created" in selectedFields and task.creationDateTime() > date.DateTime.min:
         components.append("CREATED:%s" % fmtDateTime(task.creationDateTime()))
 
-    if task.modificationDateTime() > date.DateTime.min:
+    if "lastmod" in selectedFields and task.modificationDateTime() > date.DateTime.min:
         components.append(
             "LAST-MODIFIED:%s" % fmtDateTime(task.modificationDateTime())
         )
 
-    if task.plannedStartDateTime() != date.DateTime():
+    if "dtstart" in selectedFields and task.plannedStartDateTime() != date.DateTime():
         components.append(
             "DTSTART:%s" % fmtDateTime(task.plannedStartDateTime())
         )
 
-    if task.dueDateTime() != date.DateTime():
+    if "due" in selectedFields and task.dueDateTime() != date.DateTime():
         components.append("DUE:%s" % fmtDateTime(task.dueDateTime()))
 
-    if task.completionDateTime() != date.DateTime():
+    if "completed" in selectedFields and task.completionDateTime() != date.DateTime():
         components.append(
             "COMPLETED:%s" % fmtDateTime(task.completionDateTime())
         )
 
-    if task.categories(recursive=True, upwards=True):
+    if "categories" in selectedFields and task.categories(recursive=True, upwards=True):
         categories = ",".join(
             [
                 quote(str(c))
                 for c in task.categories(recursive=True, upwards=True)
             ]
         )
-        components.append("CATEGORIES%s:%s" % (encoding, categories))
+        components.append("CATEGORIES%s:%s" % (encoding_str, categories))
 
-    if task.completed():
-        components.append("STATUS:COMPLETED")
-    elif task.active():
-        components.append("STATUS:NEEDS-ACTION")
-    else:
-        components.append("STATUS:CANCELLED")  # Hum...
+    if "status" in selectedFields:
+        if task.completed():
+            components.append("STATUS:COMPLETED")
+        elif task.active():
+            components.append("STATUS:NEEDS-ACTION")
+        else:
+            components.append("STATUS:CANCELLED")  # Hum...
 
-    components.append(
-        "DESCRIPTION%s:%s" % (encoding, quote(task.description()))
-    )
-    components.append("PRIORITY:%d" % min(3, task.priority() + 1))
-    components.append("PERCENT-COMPLETE:%d" % task.percentageComplete())
-    components.append("SUMMARY%s:%s" % (encoding, quote(task.subject())))
+    if "description" in selectedFields:
+        components.append(
+            "DESCRIPTION%s:%s" % (encoding_str, quote(task.description()))
+        )
+
+    if "priority" in selectedFields:
+        components.append("PRIORITY:%d" % min(3, task.priority() + 1))
+
+    if "percent" in selectedFields:
+        components.append("PERCENT-COMPLETE:%d" % task.percentageComplete())
+
+    if "summary" in selectedFields:
+        components.append("SUMMARY%s:%s" % (encoding_str, quote(task.subject())))
+
     components.append("END:VTODO")  # pylint: disable=W0511
     if doFold:
         return fold(components)
     return "\r\n".join(components) + "\r\n"
 
 
-def VCalFromEffort(effort, encoding=True, doFold=True):
-    encoding = ";ENCODING=QUOTED-PRINTABLE;CHARSET=UTF-8" if encoding else ""
+def VCalFromEffort(effort, encoding=True, doFold=True, selectedFields=None):
+    """This function returns a string representing the effort in
+    iCalendar VEVENT format.
+
+    Args:
+        effort: The effort to export
+        encoding: Whether to use quoted-printable encoding
+        doFold: Whether to fold long lines
+        selectedFields: Set of field keys to export. If None, export all fields.
+                       Required fields (uid, dtstamp) are always exported.
+    """
+    # Default to all fields if not specified
+    if selectedFields is None:
+        selectedFields = {"uid", "dtstamp", "summary", "description", "dtstart", "dtend"}
+
+    encoding_str = ";ENCODING=QUOTED-PRINTABLE;CHARSET=UTF-8" if encoding else ""
     quote = quoteString if encoding else lambda s: s
+
     components = []
     components.append("BEGIN:VEVENT")
+
+    # Required fields (always exported)
     components.append("UID:%s" % effort.id().encode("UTF-8"))
-    components.append("SUMMARY%s:%s" % (encoding, quote(effort.subject())))
-    components.append(
-        "DESCRIPTION%s:%s" % (encoding, quote(effort.description()))
-    )
-    components.append("DTSTART:%s" % fmtDateTime(effort.getStart()))
-    if effort.getStop():
+    components.append("DTSTAMP:%s" % fmtDateTime(date.Now()))
+
+    if "summary" in selectedFields:
+        components.append("SUMMARY%s:%s" % (encoding_str, quote(effort.subject())))
+
+    if "description" in selectedFields:
+        components.append(
+            "DESCRIPTION%s:%s" % (encoding_str, quote(effort.description()))
+        )
+
+    if "dtstart" in selectedFields:
+        components.append("DTSTART:%s" % fmtDateTime(effort.getStart()))
+
+    if "dtend" in selectedFields and effort.getStop():
         components.append("DTEND:%s" % fmtDateTime(effort.getStop()))
+
     components.append("END:VEVENT")
     if doFold:
         return fold(components)

--- a/taskcoachlib/persistence/icalendar/writer.py
+++ b/taskcoachlib/persistence/icalendar/writer.py
@@ -31,31 +31,65 @@ def extendedWithAncestors(selection):
 
 
 class iCalendarWriter(object):
+    # Constants for "All" export options (must match export.py)
+    ALL_TASKS = "ALL_TASKS"
+    ALL_EFFORTS = "ALL_EFFORTS"
+
     def __init__(self, fd, filename=None):
         self.__fd = fd
 
     def write(
-        self, viewer, settings, selectionOnly=False
+        self, viewer, settings, selectionOnly=False, selectedFields=None,
+        taskFile=None
     ):  # pylint: disable=W0613
-        items = viewer.visibleItems()
-        if selectionOnly:
-            selection = viewer.curselection()
-            if viewer.isTreeViewer():
-                selection = extendedWithAncestors(selection)
-            items = [item for item in items if item in selection]
-        return self.writeItems(items)
+        """Write items to iCalendar format.
 
-    def writeItems(self, items):
+        Args:
+            viewer: The viewer to export from, or ALL_TASKS/ALL_EFFORTS constant
+            settings: Application settings
+            selectionOnly: If True, only export selected items (ignored for ALL_*)
+            selectedFields: Set of field keys to export
+            taskFile: The task file (required for ALL_* export)
+        """
+        # Handle "All" export options
+        if viewer == self.ALL_TASKS:
+            if taskFile is None:
+                return 0
+            items = list(taskFile.tasks())
+        elif viewer == self.ALL_EFFORTS:
+            if taskFile is None:
+                return 0
+            items = list(taskFile.efforts())
+        else:
+            # Normal viewer-based export
+            items = viewer.visibleItems()
+            if selectionOnly:
+                selection = viewer.curselection()
+                if viewer.isTreeViewer():
+                    selection = extendedWithAncestors(selection)
+                items = [item for item in items if item in selection]
+
+        return self.writeItems(items, selectedFields=selectedFields)
+
+    def writeItems(self, items, selectedFields=None):
+        """Write a list of items to iCalendar format.
+
+        Args:
+            items: List of tasks or efforts to export
+            selectedFields: Set of field keys to export
+        """
         self.__fd.write("BEGIN:VCALENDAR\r\n")
         self._writeMetaData()
         count = 0
         for item in items:
-            transform = (
-                ical.VCalFromTask
-                if isinstance(item, task.Task)
-                else ical.VCalFromEffort
-            )
-            self.__fd.write(transform(item, encoding=False))
+            if isinstance(item, task.Task):
+                self.__fd.write(
+                    ical.VCalFromTask(item, encoding=False, selectedFields=selectedFields)
+                )
+            else:
+                self.__fd.write(
+                    ical.VCalFromEffort(item, encoding=False, selectedFields=selectedFields)
+                )
             count += 1
         self.__fd.write("END:VCALENDAR\r\n")
         return count


### PR DESCRIPTION
- Add field picker control using HyperTreeList with checkboxes
  - Shows TaskCoach field and corresponding iCalendar field columns
  - Required fields (UID, DTSTAMP) are checked and greyed out
  - Auto-sizes columns to fit content

- Improve viewer picker dropdown
  - Always show "Tasks (All)" and "Efforts (All)" options
  - Show open viewers with selection count: "Tasks (3 selected)"
  - Sort alphabetically by type, then by selection count descending
  - Use wx.Choice for proper read-only dropdown appearance

- Make export dialog non-modal
  - Users can change selections in main window while dialog is open
  - Selection counts update dynamically via pubsub

- Add selective field export support
  - Writer accepts selectedFields parameter to control which fields are exported
  - DTSTAMP field now properly included per RFC 5545

- UX improvements
  - Remove redundant "Selection only" checkbox (behavior is implicit)
  - Default selection to first "All" choice
  - Default filename: Tasks-YYYYMMDD.ics or Effort-YYYYMMDD.ics

- Bump version to 2.0.1.49

moved from SF: strangeness with status and iCal export #281