### PR TITLE
Update locale monetary format function.

### DIFF
--- a/taskcoachlib/render.py
+++ b/taskcoachlib/render.py
@@ -322,7 +322,7 @@ def monetaryAmount(aFloat):
     return (
         ""
         if round(aFloat, 2) == 0
-        else locale.format("%.2f", aFloat, monetary=True)
+        else locale.format_string("%.2f", aFloat, monetary=True)
     )
 
 


### PR DESCRIPTION
locale.format was deprecated in Python 3.7, using the new format_string as recommended by Python docs.

Partially Fixes #189:
- when an effort has a hourly fee defined and:
- the Revenue column is shown in the main task list
- and when exporting to CSV or HTML