### PR TITLE
Refactor budget tab durations, fix effort sync, add CurrencyCtrl

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -250,7 +250,7 @@ jobs:
         shell: pwsh
         run: |
           # Create a simple batch launcher (for command-line use with console output)
-          $launcherContent = "@echo off`r`ncd /d `"%~dp0`"`r`nstart `"`" `"python\pythonw.exe`" `"launcher.pyw`" %*"
+          $launcherContent = "@echo off`r`ncd /d `"%~dp0`"`r`npython\python.exe launcher.pyw %*"
           Set-Content -Path "build\TaskCoach\TaskCoach.bat" -Value $launcherContent -Encoding ASCII
 
           # Also create a VBS launcher for silent execution (no console window)

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.55-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.55-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.55_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.55_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.55_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.55-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.56-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.56-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.56_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.56_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.56_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.56-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.55-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.55-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.55_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.55_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.55-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.55-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.56-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.56-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.56_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.56_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.56-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.56-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.55_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.55_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.56_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.56_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.55-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.55-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.56-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.56-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.55-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.55-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.56-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.56-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.55-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.55-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.56-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.56-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.55-x86_64.AppImage
+./TaskCoach-2.0.1.56-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/docs/DATETIME_CONTROLS.md
+++ b/docs/DATETIME_CONTROLS.md
@@ -412,8 +412,17 @@ ctrl = DurationCtrl(parent, days=0, hours=2, minutes=30, seconds=15,
 ctrl = DurationCtrl(parent, days=1, hours=2, minutes=30,
     dayChoices=False, hourChoices=False, minuteChoices=False)
 
-duration = ctrl.GetDuration()  # timedelta
-ctrl.SetDuration(timedelta(days=1, hours=2))
+duration = ctrl.GetDuration()  # date.TimeDelta
+ctrl.SetDuration(date.TimeDelta(days=1, hours=2))
+
+# AttributeSync compatibility aliases
+value = ctrl.GetValue()         # same as GetDuration()
+ctrl.SetValue(duration)         # same as SetDuration()
+ctrl.SetValue(duration, quiet=True)  # suppress events
+
+# Negative durations (display only, e.g. budget left = -1:30:00)
+ctrl.SetDuration(date.TimeDelta(hours=-1, minutes=-30))
+# Day field shows "-" prefix, GetDuration() returns negative TimeDelta
 ```
 
 ### DurationCtrlVerbose
@@ -458,8 +467,8 @@ ctrl = DurationCtrlVerbose(parent, days=0, hours=2, minutes=30, seconds=15,
 ctrl = DurationCtrlVerbose(parent, days=0, hours=0, minutes=0,
     dayChoices=False, hourChoices=False, minuteChoices=False)
 
-duration = ctrl.GetDuration()  # datetime.timedelta
-ctrl.SetDuration(datetime.timedelta(hours=1, minutes=30))
+duration = ctrl.GetDuration()  # date.TimeDelta
+ctrl.SetDuration(date.TimeDelta(hours=1, minutes=30))
 ```
 
 ### TimeCtrl
@@ -651,7 +660,7 @@ class MyDurationCtrl(FieldsCtrl):
         super().__init__(parent, elements)
 
     def GetDuration(self):
-        return datetime.timedelta(
+        return date.TimeDelta(
             days=self.GetFieldValue('day'),
             hours=self.GetFieldValue('hour'),
             minutes=self.GetFieldValue('minute')
@@ -659,7 +668,7 @@ class MyDurationCtrl(FieldsCtrl):
 
     def SetDuration(self, duration):
         if duration is None:
-            duration = datetime.timedelta()
+            duration = date.TimeDelta()
         total = int(duration.total_seconds())
         days, remainder = divmod(total, 86400)
         hours, remainder = divmod(remainder, 3600)

--- a/docs/DURATION_CALCULATIONS.md
+++ b/docs/DURATION_CALCULATIONS.md
@@ -4,6 +4,8 @@ Duration calculations for Edit Task Dates and Edit Effort windows.
 
 ## Index
 
+- [TODO](#todo)
+- [Preconditions and Global Logic](#preconditions-and-global-logic)
 - [Edit Task Dates Window](#edit-task-dates-window)
   - [Duration Modes](#duration-modes)
   - [Logic Flow](#logic-flow)
@@ -15,6 +17,53 @@ Duration calculations for Edit Task Dates and Edit Effort windows.
   - [Field Change Effects](#field-change-effects)
   - [Action Sequence](#action-sequence-1)
 - [Persistence](#persistence)
+
+---
+
+## TODO
+
+1. Task logic: Add explicit autoheal logic for switching from Implicit to
+   other modes when duration is negative.
+2. Task logic: Clean up to NOT rely on Presets as a separate trigger, as
+   Presets is a proxy for Duration. Efforts is cleaned up already — presets
+   route through duration change. Task section should do the same.
+3. Effort: Add Presets to "Called on" line in Implements block.
+4. User-action detection: Currently using source_field as a proxy for
+   user-action since we cannot technically differentiate user actions
+   (clicks/keypresses) from system-triggered changes. If change-only
+   rule (0.2) is insufficient to prevent loops, add global logic to
+   track physical user clicks/keypresses to segregate user actions
+   versus system actions.
+
+---
+
+## Preconditions and Global Logic
+
+All logic flows share these preconditions and rules.
+
+The logic flow is triggered by ONE user-initiated change at a time. The user makes
+a single change (checkbox, field value, or dropdown), then the logic processes
+(including loops) until it stabilizes and exits. Only then is the system ready
+for the next user change.
+
+```
+0. Preconditions and global logic.
+   0.1 User actions. Store last user action and skip any step that changes
+       the user's explicitly set value.
+       0.1.1 User explicitly changed Start-Date
+       0.1.2 User explicitly changed Stop-Date / Due-Date
+       0.1.3 User explicitly changed Duration
+       0.1.4 User explicitly changed Mode
+   0.2 Change-only rule. Only set or change a value if required (i.e., the
+       new value differs from the current value). This is also looping
+       protection.
+   0.3 Recursive safety.
+       0.3.1 Any recursive call assumes starting at depth 0 if no depth
+             received and passes depth+1 to the next call.
+       0.3.2 depth == 1 should never receive a user action, log error,
+             continue.
+       0.3.3 Depth > 1 should never occur, log error, exit.
+```
 
 ---
 
@@ -33,65 +82,60 @@ Duration calculations for Edit Task Dates and Edit Effort windows.
 
 ### Logic Flow
 
-The logic flow is triggered by ONE user-initiated change at a time. The user makes
-a single change (checkbox, field value, or dropdown), then the logic processes
-(including loops) until it stabilizes and exits. Only then is the system ready
-for the next user change.
-
 ```
-Start: Automatic, all fields empty
+Start: Automatic mode, all fields empty
 
-0. Store last user action and skip any step that changes the user's explicitly set value.
-   0.1 User unchecked Start-Date
-   0.2 User unchecked Due-Date
+0. See Preconditions and Global Logic section above.
 
 1. If Mode Automatic
-   1.1 If Start-Date set, Then set Adj-Due mode, Loop
-   1.2 If Due-Date set, Then set Adj-Start mode, Loop
+   1.1 If Start-Date exists, Then set Adj-Due mode, Loop
+   1.2 If Due-Date exists, Then set Adj-Start mode, Loop
    1.3 If Implicit chosen, Then set Implicit mode, Loop
    1.4 If Adj-Due chosen, Then set Adj-Due mode, Loop
    1.5 If Adj-Start chosen, Then set Adj-Start mode, Loop
 
 2. If Mode Adj-Due
-   2.1 Activate Start-Date, If not unchecked by user [Ref2, 0.1]
+   2.1 Activate Start-Date, If not Unset-Action [Ref2, 0.1.1]
    2.2 Activate Due-Date (Read-Only) [Ref2]
    2.3 Disable Automatic mode option in dropdown [Ref1]
    2.4 If Duration changed, Then adj Due-Date
-   2.5 If Start-Date changed, Then adj Due-Date
-   2.6 If Start-Date disabled, Then
-       2.6.1 Deactivate Due-Date
-       2.6.2 Reactivate Automatic mode option in dropdown
-       2.6.3 Set Automatic mode, Loop
+   2.5 If Start-Date Unset-Action, Then
+       2.5.1 Deactivate Due-Date
+       2.5.2 Reactivate Automatic mode option in dropdown
+       2.5.3 Set Automatic mode, Loop
+   2.6 If Start-Date changed, Then adj Due-Date
 
 3. If Mode Adj-Start
-   3.1 Activate Due-Date, If not unchecked by user [Ref2, 0.2]
+   3.1 Activate Due-Date, If not Unset-Action [Ref2, 0.1.2]
    3.2 Activate Start-Date (Read-Only) [Ref2]
    3.3 Disable Automatic mode option in dropdown [Ref1]
    3.4 If Duration changed, Then adj Start-Date
-   3.5 If Due-Date changed, Then adj Start-Date
-   3.6 If Due-Date disabled, Then
-       3.6.1 Deactivate Start-Date
-       3.6.2 Reactivate Automatic mode option in dropdown
-       3.6.3 Set Automatic mode, Loop
+   3.5 If Due-Date Unset-Action, Then
+       3.5.1 Deactivate Start-Date
+       3.5.2 Reactivate Automatic mode option in dropdown
+       3.5.3 Set Automatic mode, Loop
+   3.6 If Due-Date changed, Then adj Start-Date
 
 4. If Mode Implicit
    4.1 Disable Automatic mode option in dropdown [Ref1]
-   4.2 If Start-Date enabled
-       4.2.1 If Due-Date enabled
+   4.2 If Start-Date exists
+       4.2.1 If Due-Date exists
            4.2.1.1 Enable Duration (Read-Only)
            4.2.1.2 Adj Duration
-           4.2.1.3 If Start-Date changed, Then adj Duration
-           4.2.1.4 If Due-Date changed, Then adj Duration
-       4.2.2 If Due-Date disabled, Then disable Duration
-   4.3 If Start-Date disabled, Then disable Duration
+           4.2.1.3 Negative Durations permitted
+       4.2.2 If Due-Date Unset-Action, Then disable Duration
+   4.3 If Start-Date Unset-Action, Then disable Duration
 
 5. Update Field States (See: UI Field States section)
 
 Glossary:
-   Adj-Due    = Adjust Due Date mode
-   Adj-Start  = Adjust Planned Start Date mode
-   Start-Date = Planned Start Date-Time Combo Control with Checkbox
-   Due-Date   = Due Date-Time Combo Control with Checkbox
+   adj          = recalculate/adjust
+   Adj-Due      = Adjust Due Date mode
+   Adj-Start    = Adjust Planned Start Date mode
+   Set-Action   = explicit user change from no value or zero value to a value
+   Unset-Action = explicit user change from a value to no value or zero value
+   Start-Date   = Planned Start Date-Time Combo Control with Checkbox
+   Due-Date     = Due Date-Time Combo Control with Checkbox
 
 References:
    [Ref1] Covered by "Calculation Mode Dropdown Build Logic" section
@@ -101,6 +145,8 @@ References:
 ```
 Implements: __syncDurationState()
 Called on: Every change of Start-Date, Due-Date, Duration, Presets, or Mode dropdown.
+Note: UI-only — updates control values (SetDateTime, SetDuration, SetChecked).
+      No persistence commands. Saving happens when the dialog is closed/saved.
 ```
 
 ### Calculation Mode Dropdown Build Logic
@@ -185,54 +231,85 @@ Called on: Every change of Start-Date, Due-Date, Duration, or Presets fields (af
 ### Logic Flow
 
 ```
-Start: Standard mode, Stop-Date disabled
+Start: Standard mode, Duration 0, Stop-Date disabled
+
+0. See Preconditions and Global Logic section above.
 
 1. If Mode Standard
    1.1 If Retroactive mode chosen, Loop
-   1.2 Set Start-Date editable
-   1.3 If Start-Date changed, Then
-       1.3.1 If Duration > 0, Then adj Stop-Date
-   1.4 If Duration changed, Then
-       1.4.1 If Duration > 0, Then
-           1.4.1.1 Enable Stop-Date
-           1.4.1.2 Adj Stop-Date
-       1.4.2 If Duration = 0, Then disable Stop-Date
-   1.5 If Stop-Date changed, Then
-       1.5.1 If Stop-Date <= Start-Date, Then
-           1.5.1.1 Set Stop-Date = Start-Date + 1s
-           1.5.1.2 Adj Duration to 1s
-       1.5.2 If Stop-Date > Start-Date, Then adj Duration
+   1.2 If Implicit mode chosen, Loop
+   1.3 Set Start-Date editable
+   1.4 Set Duration editable
+   1.5 If Duration Unset-Action, Then disable Stop-Date
+   1.6 If Start-Date changed, Then
+       1.6.1 If Duration > 0, Then adj Stop-Date
+       1.6.2 If Duration = 0, Then do nothing
+   1.7 If Duration changed, Then
+       1.7.1 If Duration > 0, Then
+           1.7.1.1 Enable Stop-Date
+           1.7.1.2 Adj Stop-Date
+       1.7.2 If Duration = 0, Then disable Stop-Date
+   1.8 If Stop-Date changed, Then
+       1.8.1 If Stop-Date Set-Action, Then
+           1.8.1.1 If Duration = 0, Then set Implicit mode, Loop
+           1.8.1.2 If Duration > 0, Then adj Duration
+       1.8.2 If Stop-Date <= Start-Date, Then
+           1.8.2.1 Incoherent state, Autoheal, Thus
+           1.8.2.2 Set Stop-Date = Start-Date + 1s
+           1.8.2.3 Adj Duration to 1s
+       1.8.3 If Stop-Date > Start-Date, Then adj Duration
+   1.9 If Duration <= 0, Then Autoheal, Thus
+       1.9.1 Set Duration to 0
+       1.9.2 Disable Stop-Date
+   1.10 If Duration > 0, Then Autoheal, Thus
+       1.10.1 Enable Stop-Date
+       1.10.2 Adj Stop-Date
 
 2. If Mode Retroactive
    2.1 If Standard mode chosen, Loop
-   2.2 Set Start-Date read-only
-   2.3 If Duration changed, Then
-       2.3.1 If Duration > 0, Then
-           2.3.1.1 Enable Stop-Date
-           2.3.1.2 Adj Start-Date
-       2.3.2 If Duration = 0, Then disable Stop-Date
-   2.4 If Stop-Date changed, Then
-       2.4.1 If Duration <= 0, Then
-           2.4.1.1 Set Duration to 1s
-           2.4.1.2 Set Start-Date = Stop-Date - 1s
-       2.4.2 If Duration > 0, Then adj Start-Date
+   2.2 If Implicit mode chosen, Loop
+   2.3 Set Start-Date read-only
+   2.4 Set Duration editable
+   2.5 If Duration Unset-Action, Then disable Stop-Date
+   2.6 If Stop-Date changed, Then
+       2.6.1 If Duration <= 0, Then
+           2.6.1.1 Incoherent state, Autoheal, Thus
+           2.6.1.2 Set Duration to 1s
+           2.6.1.3 Set Start-Date = Stop-Date - 1s
+       2.6.2 If Duration > 0, Then adj Start-Date
+   2.7 If Duration changed, Then
+       2.7.1 If Duration > 0, Then
+           2.7.1.1 Enable Stop-Date
+           2.7.1.2 Adj Start-Date
+       2.7.2 If Duration = 0, Then disable Stop-Date
+   2.8 If Duration <= 0, Then Autoheal, Thus
+       2.8.1 Set Duration to 0
+       2.8.2 Disable Stop-Date
+   2.9 If Duration > 0, Then Autoheal, Thus
+       2.9.1 Enable Stop-Date
+       2.9.2 Adj Start-Date
 
 3. If Mode Implicit
-   3.1 Set Start-Date editable
-   3.2 Set Duration read-only
-   3.3 If Start-Date changed or Stop-Date changed or Mode changed, Then
-       3.3.1 If Stop-Date enabled and Stop > Start, Then adj Duration = Stop - Start
-       3.3.2 If Stop-Date enabled and Stop <= Start, Then Duration = 0
-
-Auto-Switch Logic (in __syncEffortState, same pattern as Time Spent state check):
-   A1. If Mode = Standard AND Stop-Date active (IsChecked) AND Duration = 0, Then switch to Implicit
-   A2. If Duration preset selected AND Mode = Implicit, Then switch to Standard
+   3.1 If Standard mode chosen, Loop
+   3.2 If Retroactive mode chosen, Loop
+   3.3 If Duration changed, Then
+       3.3.1 Only possible via Presets change
+       3.3.2 Leave Duration as set by preset, do NOT adj
+       3.3.3 Set Standard Mode, Loop
+   3.4 Set Start-Date editable
+   3.5 If Stop-Date does not exist, Disable Duration
+   3.6 If Stop-Date exists, Then
+       3.6.1 Enable Duration (Read-Only)
+       3.6.2 Adj Duration
+       3.6.3 Negative Durations permitted
 
 Glossary:
-   adj        = recalculate/adjust
-   Start-Date = Start Date-Time Combo Control with Checkbox
-   Stop-Date  = Stop Date-Time Combo Control with Checkbox
-   Duration   = Effort Duration Control
+   adj          = recalculate/adjust
+   Set-Action   = explicit user change from no value or zero value to a value
+   Unset-Action = explicit user change from a value to no value or zero value
+   Start-Date   = Start Date-Time Combo Control with Checkbox
+   Stop-Date    = Stop Date-Time Combo Control with Checkbox
+   Duration     = Effort Duration Control
 ```
 
 ```
@@ -241,6 +318,13 @@ Called on: Every change of Start-Date, Stop-Date, Duration, or Mode dropdown.
 Note: UI-only — updates control values (SetDateTime, SetDuration, SetChecked).
       No persistence commands. Saving happens when the dialog is closed/saved.
 ```
+
+### Time Spent
+
+Display-only field showing Now - Start, activated when tracking (no Stop-Date).
+Deactivated when Stop-Date exists.
+
+---
 
 ### Field Change Effects
 
@@ -260,7 +344,7 @@ Note: UI-only — updates control values (SetDateTime, SetDuration, SetChecked).
 |-----------|----------|------|--------|--------|
 | Standard | ❌ | ❌ | Enter Duration | Stop auto-enabled, Stop = Start + Duration |
 | Standard | ❌ | ❌ | Change Start | No effect (no Stop to calculate from) |
-| Standard | ❌ | ❌ | Check Stop | Auto-switch → Implicit, Duration = Stop - Start (read-only) |
+| Standard | ❌ | ❌ | Check Stop | Set Implicit Mode, Loop |
 | Standard | ❌ | ❌ | Set Retroactive | Start read-only |
 | Standard | ✅ | ✅ | Change Duration | Stop recalculated |
 | Standard | ✅ | ✅ | Change Start | Stop recalculated, Duration unchanged |
@@ -270,7 +354,7 @@ Note: UI-only — updates control values (SetDateTime, SetDuration, SetChecked).
 | Standard | ✅ | ✅ | Set Retroactive | Start read-only, Start = Stop - Duration |
 | Standard | ✅ | ✅ | Set Implicit | Duration read-only, Duration = Stop - Start |
 | Standard | ❌ | ❌ | Set Implicit | Duration read-only |
-| Retroactive | ❌ | ❌ | Enter Duration | Stop auto-enabled, Start = Stop - Duration |
+| Retroactive | ❌ | ❌ | Enter Duration | Set Stop enabled, Loop |
 | Retroactive | ❌ | ❌ | Check Stop | Start = Stop - Duration |
 | Retroactive | ❌ | ❌ | Set Standard | Start editable |
 | Retroactive | ✅ | ✅ | Change Duration | Start recalculated, Stop unchanged |
@@ -282,7 +366,7 @@ Note: UI-only — updates control values (SetDateTime, SetDuration, SetChecked).
 | Retroactive | ❌ | ❌ | Set Implicit | Duration read-only |
 | Implicit | ✅ | ✅ | Change Start | Duration recalculated, Stop unchanged |
 | Implicit | ✅ | ✅ | Change Stop | Duration recalculated, Start unchanged |
-| Implicit | ✅ | ✅ | Select duration preset | Auto-switch → Standard, Stop = Start + Duration |
+| Implicit | ✅ | ✅ | Select duration preset | Set Standard Mode, Loop |
 | Implicit | ✅ | ✅ | Uncheck Stop | Duration disabled |
 | Implicit | ✅ | ✅ | Set Standard | Duration editable |
 | Implicit | ✅ | ✅ | Set Retroactive | Start read-only, Duration editable |
@@ -291,5 +375,21 @@ Note: UI-only — updates control values (SetDateTime, SetDuration, SetChecked).
 
 ## Persistence
 
+### Mode Attributes
 - **Task Dates**: Mode stored in task's `plannedDurationMode` attribute
 - **Effort**: Mode stored in effort's `entryMode` attribute (values: `"standard"`, `"retroactive"`, `"implicit"`)
+
+### XML Format (locale-independent)
+
+All values are stored in hardcoded formats — no locale involvement. Locale formatting is display-only. Files are portable across locales.
+
+| Data type | XML format | Example | Writer code |
+|-----------|-----------|---------|-------------|
+| DateTime | `%Y-%m-%d %H:%M:%S` | `2026-01-29 15:30:00` | `writer.py:formatDateTime()` |
+| Duration (budget, plannedDuration) | `H:MM:SS` (days folded into hours) | `74:30:00` (= 3d 2h 30m) | `writer.py:budgetAsAttribute()` via `TimeDelta.hoursMinutesSeconds()` |
+| Float (hourlyFee, fixedFee) | `str(float)` | `25.5` | `writer.py:taskNode()` |
+
+### Internal Types
+- Durations use `date.TimeDelta` (extends `datetime.timedelta`, adds `hoursMinutesSeconds()`)
+- DateTimes use `date.DateTime` (extends `datetime.datetime`)
+- UI controls (`DurationCtrl`, `DateTimeCombo`) return these domain types directly for `AttributeSync` compatibility

--- a/docs/MONETARY_CONTROLS.md
+++ b/docs/MONETARY_CONTROLS.md
@@ -1,0 +1,109 @@
+# Monetary Controls
+
+This document describes the monetary (currency/amount) input controls used in Task Coach, the legacy control's known issues, and the replacement.
+
+## Table of Contents
+
+- [Background](#background)
+- [Current Control — AmountCtrl (masked.NumCtrl)](#current-control--amountctrl-maskednumctrl)
+  - [Architecture](#architecture)
+  - [Known Bugs in wxPython Phoenix](#known-bugs-in-wxpython-phoenix)
+- [Replacement — CurrencyCtrl](#replacement--currencyctrl)
+  - [Design](#design)
+  - [Locale Handling](#locale-handling)
+  - [Future Considerations](#future-considerations)
+- [Usage Sites](#usage-sites)
+- [Files](#files)
+
+## Background
+
+Task Coach uses monetary amount fields in the Budget tab of the task editor for hourly fee, fixed fee, and revenue. These fields require locale-aware decimal input with two decimal places.
+
+wxPython does not provide a built-in currency input control. The C++ `wxFloatingPointValidator` is intentionally excluded from the Python binding. The wxPython community has long noted this gap — a [wxPython forum discussion on money controls](https://discuss.wxpython.org/t/money-control/24654) confirms that developers typically build custom solutions.
+
+## Current Control — AmountCtrl (masked.NumCtrl)
+
+### Architecture
+
+`AmountCtrl` (`taskcoachlib/widgets/masked.py`) is a thin wrapper around `wx.lib.masked.NumCtrl`, a **standard wxPython widget** — it is not custom to Task Coach. The wrapper configures locale-aware parameters:
+
+```python
+class AmountCtrl(FixOverwriteSelectionMixin, masked.NumCtrl):
+    def __init__(self, parent, value=0, locale_conventions=None):
+        locale_conventions = locale_conventions or locale.localeconv()
+        # ... extracts decimalChar, groupChar from locale ...
+        super().__init__(
+            parent, value=value,
+            allowNegative=False, fractionWidth=2,
+            selectOnEntry=True,
+            decimalChar=decimalChar, groupChar=groupChar,
+            groupDigits=groupDigits,
+        )
+```
+
+`AmountEntry` (`taskcoachlib/gui/dialog/entry.py`) wraps `AmountCtrl` in a `PanelWithBoxSizer`, adding read-only support (disable + grey background) and `NavigateBook()` for notebook tab traversal.
+
+### Known Bugs in wxPython Phoenix
+
+`wx.lib.masked.NumCtrl` has **open, unfixed bugs** in wxPython Phoenix that cause crashes during normal typing. These are fundamental event-handling bugs in the masked edit framework, not Task Coach configuration problems.
+
+**Issue [#2587](https://github.com/wxWidgets/Phoenix/issues/2587)** (open, reported Dec 2024, wxPython 4.2.1+):
+
+Three distinct crashes:
+1. **`_adjustFloat` ValueError** — Deleting the initial value then typing triggers `ValueError: not enough values to unpack` when `_adjustFloat` splits on the decimal character. The value string no longer contains the expected decimal point.
+2. **`_insertKey` IndexError** — Deletion and re-entry triggers `IndexError: string index out of range` in the character validation logic.
+3. **Fatal crash on macOS** — Moving cursor then typing a decimal point causes `NSTextRange` assertion failure and `PyGILState_Release: thread state must be current when releasing` — a fatal Python crash.
+
+**Issue [#1179](https://github.com/wxWidgets/Phoenix/issues/1179)** (open, wxPython 4.0.4+):
+
+- **Select-and-type IndexError** — Selecting multiple characters with mouse and pressing a number key causes `IndexError: string index out of range`.
+- **Root cause**: Phoenix changed event ordering between `EVT_KEY_DOWN` and `EVT_CHAR`. After `_OnKeyDown`, the TextCtrl contents are already changed, but `_OnChar` still expects the original unmodified value. This event ordering worked correctly in Classic wxPython but broke in Phoenix.
+- A tentative workaround (overriding `_OnKeyDown` to call `_OnChar` directly) was suggested but never officially implemented.
+
+**No fix has been merged** for either issue as of January 2026.
+
+## Replacement — CurrencyCtrl
+
+### Design
+
+`CurrencyCtrl` (`taskcoachlib/widgets/currencyctrl.py`) replaces `AmountCtrl` using `wx.TextCtrl` + custom `wx.Validator`. This is the approach recommended by the wxPython community (including the reporter of issue #2587) as the standard pattern for currency input.
+
+Implementation:
+- `wx.TextCtrl` with `wx.TE_RIGHT` (right-aligned, standard for monetary amounts)
+- `CurrencyValidator` (`wx.Validator` subclass): filters keystrokes to digits, single decimal point, and navigation keys
+- On focus-loss: auto-formats to 2 decimal places (e.g., `5` becomes `5.00`)
+- `GetValue()` returns `float`, `SetValue(float)` sets formatted text
+- Read-only support handled by `AmountEntry` wrapper (disable + grey background)
+- Locale-aware decimal point from `locale.localeconv()`
+
+`AmountEntry` (`taskcoachlib/gui/dialog/entry.py`) wraps `CurrencyCtrl` in a `PanelWithBoxSizer`, providing read-only support and `NavigateBook()` for notebook tab traversal. `AttributeSync` uses `wx.EVT_KILL_FOCUS` to trigger persistence, which aligns with the focus-loss formatting.
+
+### Locale Handling
+
+Locale handling (preserved from the legacy control):
+- **Decimal point**: `locale.localeconv()["decimal_point"]` (e.g., `.` in en_US, `,` in de_DE)
+- **Formatting**: `"%.2f" % value` with locale decimal char substitution
+
+### Future Considerations
+
+- **Currency symbols**: Currently not displayed in controls (the label provides context). Could add optional prefix/suffix rendering.
+- **Negative amounts**: Currently `allowNegative=False`. Could be added if budget scenarios require it.
+- **Thousands grouping during input**: Current control groups digits; the TextCtrl replacement could add this on focus-loss formatting.
+- **Alternative: `wx.SpinCtrlDouble`**: A native wxPython widget that enforces numeric input with configurable decimal places. However, the spinner UI (up/down arrows) is inappropriate for dollar amount fields.
+
+## Usage Sites
+
+| File | Widget | Field | Editable |
+|------|--------|-------|----------|
+| `taskcoachlib/gui/dialog/editor.py` | `AmountEntry` → `CurrencyCtrl` | Hourly fee | Yes |
+| `taskcoachlib/gui/dialog/editor.py` | `AmountEntry` → `CurrencyCtrl` | Fixed fee | Yes |
+| `taskcoachlib/gui/dialog/editor.py` | `AmountEntry` → `CurrencyCtrl` | Revenue | No (read-only) |
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `taskcoachlib/widgets/currencyctrl.py` | `CurrencyCtrl` + `CurrencyValidator` (replacement) |
+| `taskcoachlib/widgets/masked.py` | Legacy `AmountCtrl` (wraps `wx.lib.masked.NumCtrl`) — no longer used by AmountEntry |
+| `taskcoachlib/gui/dialog/entry.py` | `AmountEntry` (wraps `CurrencyCtrl` in panel) |
+| `taskcoachlib/gui/dialog/editor.py` | Budget tab uses `AmountEntry` for fee/revenue fields |

--- a/launcher.pyw
+++ b/launcher.pyw
@@ -31,16 +31,22 @@ def get_log_path():
     return os.path.join(log_dir, 'TaskCoach', 'startup.log')
 
 def log_message(msg, log_file=None):
-    """Write a message to the log file."""
+    """Write a message to the log file and stdout if available."""
     if log_file is None:
         log_file = get_log_path()
+    timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    formatted = f"[{timestamp}] {msg}"
     try:
         os.makedirs(os.path.dirname(log_file), exist_ok=True)
         with open(log_file, 'a', encoding='utf-8') as f:
-            timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-            f.write(f"[{timestamp}] {msg}\n")
+            f.write(formatted + "\n")
     except Exception:
         pass  # Can't log if we can't write
+    try:
+        if sys.stdout and sys.stdout.name != os.devnull:
+            print(formatted)
+    except Exception:
+        pass
 
 def show_error_dialog(title, message):
     """Show a Windows message box with error details."""

--- a/taskcoachlib/domain/date/timedelta.py
+++ b/taskcoachlib/domain/date/timedelta.py
@@ -96,6 +96,12 @@ class TimeDelta(datetime.timedelta):
             timeDelta.days, timeDelta.seconds, timeDelta.microseconds
         )
 
+    def __neg__(self):
+        timeDelta = super().__neg__()
+        return self.__class__(
+            timeDelta.days, timeDelta.seconds, timeDelta.microseconds
+        )
+
 
 ONE_SECOND = TimeDelta(seconds=1)
 ONE_MINUTE = TimeDelta(minutes=1)

--- a/taskcoachlib/domain/task/task.py
+++ b/taskcoachlib/domain/task/task.py
@@ -1001,7 +1001,7 @@ class Task(
 
     def budgetLeft(self, recursive=False):
         budget = self.budget(recursive)
-        return budget - self.timeSpent(recursive) if budget else budget
+        return budget - self.timeSpent(recursive)
 
     def sendBudgetLeftChangedMessage(self):
         pub.sendMessage(

--- a/taskcoachlib/gui/artprovider.py
+++ b/taskcoachlib/gui/artprovider.py
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from taskcoachlib import patterns, operating_system
 from taskcoachlib.i18n import _
+from taskcoachlib.meta.debug import log_step
 from taskcoachlib.tools import wxhelper
 import wx
 import os
@@ -121,12 +122,14 @@ class ArtProvider(wx.ArtProvider):
         if os.path.exists(icon_path):
             image = wx.Image(icon_path)
             if not image.IsOk():
+                log_step("ERROR! Icon file exists but failed to load:", icon_path, prefix="ICON")
                 return wx.NullBitmap
             bitmap = image.ConvertToBitmap()
             if artClient == wx.ART_FRAME_ICON:
                 bitmap = self.convertAlphaToMask(bitmap)
             return bitmap
         else:
+            log_step("ERROR! Icon not found:", repr(artId), "(tried", new_icon_path, "and", legacy_icon_path + ")", prefix="ICON")
             return wx.NullBitmap
 
     @staticmethod

--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -416,7 +416,7 @@ class CategorySubjectPage(SubjectPage):
             self.items[0].stylePriority() if len(self.items) == 1 else 0
         )
         self._stylePriorityEntry = widgets.SpinCtrl(
-            self, size=(100, -1), value=currentPriority, min=0, max=99
+            self, size=(100, -1), value=currentPriority, min=-999, max=999
         )
         self._stylePrioritySync = attributesync.AttributeSync(
             "stylePriority",
@@ -1745,7 +1745,7 @@ class DatesPage(Page):
         """Handle planned start checkbox toggle."""
         # Commit value to model immediately (checkbox toggle = focus loss)
         self._plannedStartDateTimeSync.commit()
-        # 0.1 User unchecked Start-Date
+        # 0.1 User Unset-Action Start-Date
         userAction = "start_unchecked" if not self._plannedStartDateTimeCombo.IsChecked() else None
         self.__syncDurationState(userAction=userAction)
         event.Skip()
@@ -1754,7 +1754,7 @@ class DatesPage(Page):
         """Handle due date checkbox toggle."""
         # Commit value to model immediately (checkbox toggle = focus loss)
         self._dueDateTimeSync.commit()
-        # 0.2 User unchecked Due-Date
+        # 0.2 User Unset-Action Due-Date
         userAction = "due_unchecked" if not self._dueDateTimeCombo.IsChecked() else None
         self.__syncDurationState(userAction=userAction)
         event.Skip()
@@ -1777,9 +1777,9 @@ class DatesPage(Page):
         See docs/DURATION_CALCULATIONS.md "Logic Flow" section.
 
         Args:
-            userAction: The user action that triggered this sync (step 0):
-                       - "start_unchecked": User unchecked Start-Date (0.1)
-                       - "due_unchecked": User unchecked Due-Date (0.2)
+            userAction: The user action that triggered this sync (section 0):
+                       - "start_unchecked": User Unset-Action Start-Date (0.1)
+                       - "due_unchecked": User Unset-Action Due-Date (0.2)
                        - None: Other action (mode selected, value changed, etc.)
             liveUpdate: If True, only update display (no commands executed).
                        If False, execute commands to persist changes.
@@ -1791,17 +1791,17 @@ class DatesPage(Page):
         # === Logic Flow: Mode Transitions and Calculations ===
 
         if mode == "automatic":
-            # 1.1 If Start-Date set, Then set Adj-Due mode, Loop
+            # 1.1 If Start-Date exists, Then set Adj-Due mode, Loop
             if startChecked:
                 self.__setDurationMode("adjdue")
                 return self.__syncDurationState(userAction, liveUpdate)  # Loop
-            # 1.2 If Due-Date set, Then set Adj-Start mode, Loop
+            # 1.2 If Due-Date exists, Then set Adj-Start mode, Loop
             if dueChecked:
                 self.__setDurationMode("adjstart")
                 return self.__syncDurationState(userAction, liveUpdate)  # Loop
 
         elif mode == "adjdue":
-            # 2.1 Activate Start-Date, If not unchecked by user [Ref2, 0.1]
+            # 2.1 Activate Start-Date, If not Unset-Action [Ref2, 0.1]
             if userAction != "start_unchecked" and not startChecked:
                 self._plannedStartDateTimeCombo.SetChecked(True)
                 startChecked = True
@@ -1809,19 +1809,19 @@ class DatesPage(Page):
             if not dueChecked:
                 self._dueDateTimeCombo.SetChecked(True)
                 dueChecked = True
-            # 2.6 If Start-Date disabled, Then deactivate Due-Date, set Automatic mode, Loop
+            # 2.5 If Start-Date Unset-Action, Then deactivate Due-Date, set Automatic mode, Loop
             if not startChecked:
                 self._dueDateTimeCombo.SetChecked(False)
                 self.__setDurationMode("automatic")
                 return self.__syncDurationState(userAction, liveUpdate)  # Loop
-            # 2.4/2.5 Adj Due-Date (on Duration or Start-Date change)
+            # 2.4/2.6 Adj Due-Date (on Duration or Start-Date change)
             if liveUpdate:
                 self.__updateDueDateLive()
             else:
                 self.__updateDueDateFromDuration()
 
         elif mode == "adjstart":
-            # 3.1 Activate Due-Date, If not unchecked by user [Ref2, 0.2]
+            # 3.1 Activate Due-Date, If not Unset-Action [Ref2, 0.2]
             if userAction != "due_unchecked" and not dueChecked:
                 self._dueDateTimeCombo.SetChecked(True)
                 dueChecked = True
@@ -1829,25 +1829,26 @@ class DatesPage(Page):
             if not startChecked:
                 self._plannedStartDateTimeCombo.SetChecked(True)
                 startChecked = True
-            # 3.6 If Due-Date disabled, Then deactivate Start-Date, set Automatic mode, Loop
+            # 3.5 If Due-Date Unset-Action, Then deactivate Start-Date, set Automatic mode, Loop
             if not dueChecked:
                 self._plannedStartDateTimeCombo.SetChecked(False)
                 self.__setDurationMode("automatic")
                 return self.__syncDurationState(userAction, liveUpdate)  # Loop
-            # 3.4/3.5 Adj Start-Date (on Duration or Due-Date change)
+            # 3.4/3.6 Adj Start-Date (on Duration or Due-Date change)
             if liveUpdate:
                 self.__updatePlannedStartLive()
             else:
                 self.__updatePlannedStartFromDuration()
 
         elif mode == "implicit":
-            # 4.2/4.3 Based on which dates are enabled
+            # 4.1 Disable Automatic mode option in dropdown [Ref1]
+            # 4.2/4.3 Based on which dates exist
             startChecked = self._plannedStartDateTimeCombo.IsChecked()
             dueChecked = self._dueDateTimeCombo.IsChecked()
             if startChecked and dueChecked:
                 # 4.2.1 Both enabled - adj Duration
                 self.__updateImplicitDuration()
-            # 4.3 If Start-Date disabled (or Due-Date disabled), Duration handled by __updateFieldStates
+            # 4.2.2 If Due-Date Unset-Action / 4.3 If Start-Date Unset-Action → Duration handled by __updateFieldStates
 
         # 5. Update Field States (See: UI Field States section)
         self.__updateFieldStates()
@@ -1992,10 +1993,7 @@ class DatesPage(Page):
             # Both dates present - show calculated duration (read-only)
             self._plannedDurationCtrl.Enable(True)
             self._plannedDurationCtrl.SetReadOnly(True)
-            if due > start:
-                duration = due - start
-            else:
-                duration = dt.timedelta()  # Zero or negative = show 0
+            duration = due - start  # 4.2.1.3 Negative Durations permitted
             self._plannedDurationCtrl.SetDuration(duration)
             self.__updatePresetSelection()
         else:
@@ -2261,7 +2259,10 @@ class BudgetPage(Page):
             if len(self.items) == 1
             else date.TimeDelta()
         )
-        self._budgetEntry = entry.TimeDeltaEntry(self, currentBudget)
+        self._budgetEntry = widgets.MaskedDurationCtrl(
+            self, showSeconds=True
+        )
+        self._budgetEntry.SetDuration(currentBudget)
         self._budgetSync = attributesync.AttributeSync(
             "budget",
             self._budgetEntry,
@@ -2272,19 +2273,21 @@ class BudgetPage(Page):
             self.items[0].budgetChangedEventType(),
         )
         self.addEntry(
-            _("Budget"), self._budgetEntry, flags=[wx.ALIGN_RIGHT, wx.ALL]
+            _("Budget"), self._budgetEntry, flags=[None, wx.ALL]
         )
 
     def addTimeSpentEntry(self):
         assert len(self.items) == 1
         # pylint: disable=W0201
-        self._timeSpentEntry = entry.TimeDeltaEntry(
-            self, self.items[0].timeSpent(), readonly=True
+        self._timeSpentEntry = widgets.MaskedDurationCtrl(
+            self, showSeconds=True
         )
+        self._timeSpentEntry.SetDuration(self.items[0].timeSpent(), quiet=True)
+        self._timeSpentEntry.SetReadOnly(True)
         self.addEntry(
             _("Time spent"),
             self._timeSpentEntry,
-            flags=[wx.ALIGN_RIGHT, wx.ALL],
+            flags=[None, wx.ALL],
         )
         pub.subscribe(
             self.onTimeSpentChanged, self.items[0].timeSpentChangedEventType()
@@ -2292,20 +2295,20 @@ class BudgetPage(Page):
 
     def onTimeSpentChanged(self, newValue, sender):
         if sender == self.items[0]:
-            time_spent = sender.timeSpent()
-            if time_spent != self._timeSpentEntry.GetValue():
-                self._timeSpentEntry.SetValue(time_spent)
+            self._timeSpentEntry.SetDuration(sender.timeSpent(), quiet=True)
 
     def addBudgetLeftEntry(self):
         assert len(self.items) == 1
         # pylint: disable=W0201
-        self._budgetLeftEntry = entry.TimeDeltaEntry(
-            self, self.items[0].budgetLeft(), readonly=True
+        self._budgetLeftEntry = widgets.MaskedDurationCtrl(
+            self, showSeconds=True
         )
+        self._budgetLeftEntry.SetDuration(self.items[0].budgetLeft(), quiet=True)
+        self._budgetLeftEntry.SetReadOnly(True)
         self.addEntry(
             _("Budget left"),
             self._budgetLeftEntry,
-            flags=[wx.ALIGN_RIGHT, wx.ALL],
+            flags=[None, wx.ALL],
         )
         pub.subscribe(
             self.onBudgetLeftChanged,
@@ -2314,9 +2317,7 @@ class BudgetPage(Page):
 
     def onBudgetLeftChanged(self, newValue, sender):  # pylint: disable=W0613
         if sender == self.items[0]:
-            budget_left = sender.budgetLeft()
-            if budget_left != self._budgetLeftEntry.GetValue():
-                self._budgetLeftEntry.SetValue(budget_left)
+            self._budgetLeftEntry.SetDuration(sender.budgetLeft(), quiet=True)
 
     def addRevenueEntries(self):
         self.addHourlyFeeEntry()
@@ -2425,14 +2426,16 @@ class BudgetPage(Page):
         super().close()
 
     def entries(self):
-        return dict(
+        result = dict(
             firstEntry=self._budgetEntry,
             budget=self._budgetEntry,
-            budgetLeft=self._budgetEntry,
             hourlyFee=self._hourlyFeeEntry,
             fixedFee=self._fixedFeeEntry,
-            revenue=self._hourlyFeeEntry,
         )
+        if len(self.items) == 1:
+            result["budgetLeft"] = self._budgetLeftEntry
+            result["revenue"] = self._revenueEntry
+        return result
 
 
 class PageWithViewer(Page):
@@ -3931,7 +3934,7 @@ class EffortEditBook(Page):
             return
         self._updatingControls = True
         try:
-            self.__syncEffortState('start')
+            self.__syncEffortState(source_field='start')
         finally:
             self._updatingControls = False
 
@@ -3941,7 +3944,7 @@ class EffortEditBook(Page):
             return
         self._updatingControls = True
         try:
-            self.__syncEffortState('stop')
+            self.__syncEffortState(source_field='stop')
         finally:
             self._updatingControls = False
 
@@ -3952,7 +3955,7 @@ class EffortEditBook(Page):
             return
         self._updatingControls = True
         try:
-            self.__syncEffortState('start')
+            self.__syncEffortState(source_field='start')
         finally:
             self._updatingControls = False
         event.Skip()
@@ -3964,7 +3967,7 @@ class EffortEditBook(Page):
             return
         self._updatingControls = True
         try:
-            self.__syncEffortState('stop')
+            self.__syncEffortState(source_field='stop')
         finally:
             self._updatingControls = False
         event.Skip()
@@ -3977,7 +3980,7 @@ class EffortEditBook(Page):
 
         self._updatingControls = True
         try:
-            self.__syncEffortState('duration')
+            self.__syncEffortState(source_field='duration')
         finally:
             self._updatingControls = False
         event.Skip()
@@ -4021,7 +4024,7 @@ class EffortEditBook(Page):
                 new_stop = start if start > now else now
                 self._stopDateTimeCombo.SetDateTime(new_stop)
                 # Sync based on mode
-                self.__syncEffortState('stop')
+                self.__syncEffortState(source_field='stop')
                 # Commit the change
                 command.EditEffortStopDateTimeCommand(
                     None, self.items, newValue=self._stopDateTimeCombo.GetValue()
@@ -4064,16 +4067,37 @@ class EffortEditBook(Page):
 
     def __applyEffortEntryMode(self):
         """Apply the current entry mode to control states and recalculate values."""
-        self.__syncEffortState('mode')
+        self.__syncEffortState(source_field='mode')
 
-    def __syncEffortState(self, changed_field):
-        """Central sync function implementing the Logic Flow.
+    def __syncEffortState(self, source_field=None, depth=0):
+        """Central sync function implementing the Effort Logic Flow.
 
-        Called on every change of Start-Date, Stop-Date, Duration, or Mode.
+        The logic flow is triggered by ONE user-initiated change at a time.
+        The flow processes (including explicit loops) until it stabilizes.
+
+        See docs/DURATION_CALCULATIONS.md "Edit Effort Window" section.
+        Implements: __syncEffortState()
+        Called on: Every change of Start-Date, Stop-Date, Duration, or Mode dropdown.
 
         Args:
-            changed_field: 'start', 'duration', 'stop', or 'mode'
+            source_field: Which field triggered this sync:
+                         'start', 'stop', 'duration', 'mode', or None (depth>0 loop).
+                         Proxy for user-action — cannot differentiate user clicks from
+                         system-triggered changes. See TODO item 4 in doc.
+            depth: Recursive depth counter (doc 0.3).
+                   0 = initial call from handler (default).
+                   1 = explicit Loop call (source_field=None, reads widget state).
+                   >1 = error, exit immediately.
         """
+        # 0.3 Recursive safety
+        if depth > 1:
+            # 0.3.3 Depth > 1 should never occur, log error, exit
+            log_step("ERROR: __syncEffortState depth > 1 (%d), exiting" % depth, prefix="EFFORT")
+            return
+        if depth == 1 and source_field is not None:
+            # 0.3.2 depth==1 should never receive a source_field, log error, continue
+            log_step("ERROR: __syncEffortState depth==1 received source_field=%s, expected None" % source_field, prefix="EFFORT")
+
         is_standard = self._effortEntryMode == 0
         is_retroactive = self._effortEntryMode == 1
         stop_enabled = self._stopDateTimeCombo.IsChecked()
@@ -4084,125 +4108,216 @@ class EffortEditBook(Page):
         total_seconds = int(duration.total_seconds()) if duration else 0
 
         if is_standard:
-            # Auto-switch: if stop is active and duration is 0, switch to Implicit
-            if stop_enabled and total_seconds == 0:
-                self._effortEntryMode = 2
-                self._effortEntryModeChoice.SetSelection(2)
-                # Fall through to Implicit branch by re-calling
-                self.__syncEffortState(changed_field)
-                return
-
-            # 1.2 Set Start-Date editable, Duration editable
+            # 1.3 Set Start-Date editable
             self._startDateTimeCombo.SetEditable(True)
             self._startFromLastEffortButton.Enable(
                 self._effortList.maxDateTime() is not None
             )
+            # 1.4 Set Duration editable
+            self._effortDurationCtrl.Enable(True)
             self._effortDurationCtrl.SetReadOnly(False)
 
-            # 1.3 If Start-Date changed
-            if changed_field == 'start':
-                # 1.3.1 If Duration > 0, Then adj Stop-Date
+            # 1.5 If Start-Date changed
+            if source_field == 'start':
+                # 1.5.1 If Duration > 0, Then adj Stop-Date [0.2]
                 if total_seconds > 0 and start:
                     new_stop = start + duration
-                    self._stopDateTimeCombo.SetDateTime(new_stop)
+                    if self._stopDateTimeCombo.GetDateTime() != new_stop:
+                        self._stopDateTimeCombo.SetDateTime(new_stop)
+                # 1.5.2 If Duration = 0, Then do nothing
 
-            # 1.4 If Duration changed
-            elif changed_field == 'duration':
-                # 1.4.1 If Duration > 0
+            # 1.6 If Duration changed
+            elif source_field == 'duration':
+                # 1.6.1 If Duration > 0
                 if total_seconds > 0:
-                    # 1.4.1.1 Enable Stop-Date
-                    if not stop_enabled:
+                    # 1.6.1.1 Enable Stop-Date [0.2]
+                    if not self._stopDateTimeCombo.IsChecked():
                         self._stopDateTimeCombo.SetChecked(True)
                         self._stopDateTimeCombo.SetDateTime(date.DateTime.now())
-                    # 1.4.1.2 Adj Stop-Date
+                    # 1.6.1.2 Adj Stop-Date [0.2]
                     if start:
                         new_stop = start + duration
-                        self._stopDateTimeCombo.SetDateTime(new_stop)
-                # 1.4.2 If Duration = 0, Then disable Stop-Date
+                        if self._stopDateTimeCombo.GetDateTime() != new_stop:
+                            self._stopDateTimeCombo.SetDateTime(new_stop)
+                # 1.6.2 If Duration = 0, Then disable Stop-Date [0.2]
                 elif total_seconds == 0:
-                    self._stopDateTimeCombo.SetChecked(False)
+                    if self._stopDateTimeCombo.IsChecked():
+                        self._stopDateTimeCombo.SetChecked(False)
 
-            # 1.5 If Stop-Date changed
-            elif changed_field == 'stop':
-                if stop and start:
-                    # 1.5.1 If Stop-Date <= Start-Date
+            # 1.7 If Stop-Date changed
+            elif source_field == 'stop':
+                # 1.7.1 If Stop-Date Set-Action (stop enabled + duration = 0)
+                if stop_enabled and total_seconds == 0:
+                    # 1.7.1.1 Set Implicit mode, Loop
+                    self._effortEntryMode = 2
+                    self._effortEntryModeChoice.SetSelection(2)
+                    command.EditEffortEntryModeCommand(
+                        items=self.items, newValue="implicit"
+                    ).do()
+                    return self.__syncEffortState(depth=depth+1)  # Loop
+                # 1.7.1.2 If Duration > 0, Then adj Duration [0.2]
+                elif total_seconds > 0 and stop and start:
+                    calc_duration = stop - start
+                    calc_seconds = max(0, int(calc_duration.total_seconds()))
+                    new_dur = datetime.timedelta(seconds=calc_seconds)
+                    if self._effortDurationCtrl.GetTimeDelta() != new_dur:
+                        self._effortDurationCtrl.SetDuration(new_dur, quiet=True)
+                elif stop and start:
+                    # 1.7.2 If Stop-Date <= Start-Date
                     if stop <= start:
-                        # 1.5.1.1 Set Stop-Date = Start-Date + 1s
+                        # 1.7.2.1 Incoherent state, Autoheal, Thus
+                        # 1.7.2.2 Set Stop-Date = Start-Date + 1s [0.2]
                         new_stop = start + datetime.timedelta(seconds=1)
-                        self._stopDateTimeCombo.SetDateTime(new_stop)
-                        # 1.5.1.2 Adj Duration to 1s
-                        self._effortDurationCtrl.SetDuration(datetime.timedelta(seconds=1), quiet=True)
-                    # 1.5.2 If Stop-Date > Start-Date, Then adj Duration
+                        if self._stopDateTimeCombo.GetDateTime() != new_stop:
+                            self._stopDateTimeCombo.SetDateTime(new_stop)
+                        # 1.7.2.3 Adj Duration to 1s [0.2]
+                        new_dur = datetime.timedelta(seconds=1)
+                        if self._effortDurationCtrl.GetTimeDelta() != new_dur:
+                            self._effortDurationCtrl.SetDuration(new_dur, quiet=True)
+                    # 1.7.3 If Stop-Date > Start-Date, Then adj Duration [0.2]
                     else:
                         calc_duration = stop - start
                         calc_seconds = max(0, int(calc_duration.total_seconds()))
-                        self._effortDurationCtrl.SetDuration(datetime.timedelta(seconds=calc_seconds), quiet=True)
+                        new_dur = datetime.timedelta(seconds=calc_seconds)
+                        if self._effortDurationCtrl.GetTimeDelta() != new_dur:
+                            self._effortDurationCtrl.SetDuration(new_dur, quiet=True)
+
+            # Re-read duration after steps may have changed it
+            duration = self._effortDurationCtrl.GetTimeDelta()
+            total_seconds = int(duration.total_seconds()) if duration else 0
+
+            # 1.9 If Duration <= 0, Then Autoheal, Thus
+            if total_seconds <= 0:
+                # 1.9.1 Set Duration to 0 [0.1, 0.2]
+                if source_field != 'duration' and total_seconds < 0:
+                    self._effortDurationCtrl.SetDuration(datetime.timedelta(seconds=0), quiet=True)
+                # 1.9.2 Disable Stop-Date [0.1, 0.2]
+                if source_field != 'stop' and self._stopDateTimeCombo.IsChecked():
+                    self._stopDateTimeCombo.SetChecked(False)
+            # 1.10 If Duration > 0, Then Autoheal, Thus
+            else:
+                # 1.10.1 Enable Stop-Date [0.1, 0.2]
+                if source_field != 'stop' and not self._stopDateTimeCombo.IsChecked():
+                    self._stopDateTimeCombo.SetChecked(True)
+                    self._stopDateTimeCombo.SetDateTime(date.DateTime.now())
+                # 1.10.2 Adj Stop-Date [0.1, 0.2]
+                if source_field != 'stop':
+                    start = self._startDateTimeCombo.GetDateTime()
+                    if start:
+                        new_stop = start + duration
+                        if self._stopDateTimeCombo.GetDateTime() != new_stop:
+                            self._stopDateTimeCombo.SetDateTime(new_stop)
 
         elif is_retroactive:
-            # 2.2 Set Start-Date read-only, Duration editable
+            # 2.3 Set Start-Date read-only
             self._startDateTimeCombo.SetEditable(False)
             self._startFromLastEffortButton.Enable(False)
+            # 2.4 Set Duration editable
+            self._effortDurationCtrl.Enable(True)
             self._effortDurationCtrl.SetReadOnly(False)
 
-            # 2.3 If Duration changed
-            if changed_field == 'duration':
-                # 2.3.1 If Duration > 0
+            # 2.5 If Stop-Date changed
+            if source_field == 'stop':
+                # 2.5.1 If Duration <= 0
+                if total_seconds <= 0:
+                    # 2.5.1.1 Incoherent state, Autoheal, Thus
+                    # 2.5.1.2 Set Duration to 1s [0.2]
+                    new_dur = datetime.timedelta(seconds=1)
+                    if self._effortDurationCtrl.GetTimeDelta() != new_dur:
+                        self._effortDurationCtrl.SetDuration(new_dur, quiet=True)
+                    # 2.5.1.3 Set Start-Date = Stop-Date - 1s [0.2]
+                    if stop:
+                        new_start = stop - datetime.timedelta(seconds=1)
+                        if self._startDateTimeCombo.GetDateTime() != new_start:
+                            self._startDateTimeCombo.SetDateTime(new_start)
+                # 2.5.2 If Duration > 0, Then adj Start-Date [0.2]
+                elif total_seconds > 0 and stop:
+                    new_start = stop - duration
+                    if self._startDateTimeCombo.GetDateTime() != new_start:
+                        self._startDateTimeCombo.SetDateTime(new_start)
+
+            # 2.6 If Duration changed
+            elif source_field == 'duration':
+                # 2.6.1 If Duration > 0
                 if total_seconds > 0:
-                    # 2.3.1.1 Enable Stop-Date
-                    if not stop_enabled:
+                    # 2.6.1.1 Enable Stop-Date [0.2]
+                    if not self._stopDateTimeCombo.IsChecked():
                         self._stopDateTimeCombo.SetChecked(True)
                         self._stopDateTimeCombo.SetDateTime(date.DateTime.now())
                         stop = self._stopDateTimeCombo.GetDateTime()
-                    # 2.3.1.2 Adj Start-Date
+                    # 2.6.1.2 Adj Start-Date [0.2]
                     if stop:
                         new_start = stop - duration
-                        self._startDateTimeCombo.SetDateTime(new_start)
-                # 2.3.2 If Duration = 0, Then disable Stop-Date
+                        if self._startDateTimeCombo.GetDateTime() != new_start:
+                            self._startDateTimeCombo.SetDateTime(new_start)
+                # 2.6.2 If Duration = 0, Then disable Stop-Date [0.2]
                 elif total_seconds == 0:
-                    self._stopDateTimeCombo.SetChecked(False)
+                    if self._stopDateTimeCombo.IsChecked():
+                        self._stopDateTimeCombo.SetChecked(False)
 
-            # 2.4 If Stop-Date changed
-            elif changed_field == 'stop':
-                # 2.4.1 If Duration <= 0
-                if total_seconds <= 0:
-                    # 2.4.1.1 Set Duration to 1s
-                    self._effortDurationCtrl.SetDuration(datetime.timedelta(seconds=1), quiet=True)
-                    # 2.4.1.2 Set Start-Date = Stop-Date - 1s
+            # Re-read duration after steps may have changed it
+            duration = self._effortDurationCtrl.GetTimeDelta()
+            total_seconds = int(duration.total_seconds()) if duration else 0
+
+            # 2.8 If Duration <= 0, Then Autoheal, Thus
+            if total_seconds <= 0:
+                # 2.8.1 Set Duration to 0 [0.1, 0.2]
+                if source_field != 'duration' and total_seconds < 0:
+                    self._effortDurationCtrl.SetDuration(datetime.timedelta(seconds=0), quiet=True)
+                # 2.8.2 Disable Stop-Date [0.1, 0.2]
+                if source_field != 'stop' and self._stopDateTimeCombo.IsChecked():
+                    self._stopDateTimeCombo.SetChecked(False)
+            # 2.9 If Duration > 0, Then Autoheal, Thus
+            else:
+                # 2.9.1 Enable Stop-Date [0.1, 0.2]
+                if source_field != 'stop' and not self._stopDateTimeCombo.IsChecked():
+                    self._stopDateTimeCombo.SetChecked(True)
+                    self._stopDateTimeCombo.SetDateTime(date.DateTime.now())
+                # 2.9.2 Adj Start-Date [0.1, 0.2]
+                if source_field != 'start':
+                    stop = self._stopDateTimeCombo.GetDateTime()
                     if stop:
-                        new_start = stop - datetime.timedelta(seconds=1)
-                        self._startDateTimeCombo.SetDateTime(new_start)
-                # 2.4.2 If Duration > 0, Then adj Start-Date
-                elif total_seconds > 0 and stop:
-                    new_start = stop - duration
-                    self._startDateTimeCombo.SetDateTime(new_start)
+                        new_start = stop - duration
+                        if self._startDateTimeCombo.GetDateTime() != new_start:
+                            self._startDateTimeCombo.SetDateTime(new_start)
 
         else:  # Implicit mode (mode == 2)
-            # 3.2 Set Start-Date editable
+            # 3.3 If Duration changed (only possible via Presets change)
+            if source_field == 'duration':
+                # 3.3.1 Only possible via Presets change
+                # 3.3.2 Leave Duration as set by preset, do NOT adj
+                # 3.3.3 Set Standard Mode, Loop
+                self._effortEntryMode = 0
+                self._effortEntryModeChoice.SetSelection(0)
+                command.EditEffortEntryModeCommand(
+                    items=self.items, newValue="standard"
+                ).do()
+                return self.__syncEffortState(depth=depth+1)  # Loop
+
+            # 3.4 Set Start-Date editable
             self._startDateTimeCombo.SetEditable(True)
             self._startFromLastEffortButton.Enable(
                 self._effortList.maxDateTime() is not None
             )
-            # 3.3 Set Duration read-only
-            self._effortDurationCtrl.SetReadOnly(True)
 
-            # 3.4 If Start-Date or Stop-Date changed (or mode switched)
-            if changed_field in ('start', 'stop', 'mode'):
-                if stop_enabled and stop and start:
-                    if stop > start:
-                        calc_duration = stop - start
-                        calc_seconds = max(0, int(calc_duration.total_seconds()))
-                        self._effortDurationCtrl.SetDuration(
-                            datetime.timedelta(seconds=calc_seconds), quiet=True
-                        )
-                    else:
-                        # Stop <= Start: set duration to 0
-                        self._effortDurationCtrl.SetDuration(
-                            datetime.timedelta(seconds=0), quiet=True
-                        )
+            # 3.5 If Stop-Date does not exist, Disable Duration
+            if not stop_enabled:
+                self._effortDurationCtrl.Enable(False)
+                self._effortDurationCtrl.SetDuration(datetime.timedelta(seconds=0), quiet=True)
+            # 3.6 If Stop-Date exists
+            elif stop_enabled and stop and start:
+                # 3.6.1 Enable Duration (Read-Only)
+                self._effortDurationCtrl.Enable(True)
+                self._effortDurationCtrl.SetReadOnly(True)
+                # 3.6.2 Adj Duration
+                # 3.6.3 Negative Durations permitted
+                calc_duration = stop - start
+                self._effortDurationCtrl.SetDuration(calc_duration, quiet=True)
 
         self.__updateEffortPresetSelection()
         self.__update_invalid_period_message()
         self.__updateTimeSpentDisplay()
+
 
     def __populateEffortDurationPresets(self):
         """Populate the effort duration presets dropdown from settings."""
@@ -4288,15 +4403,13 @@ class EffortEditBook(Page):
 
         self._updatingControls = True
         try:
-            # Auto-switch from Implicit to Standard when a preset is selected
-            if self._effortEntryMode == 2 and total_seconds > 0:
-                self._effortEntryMode = 0
-                self._effortEntryModeChoice.SetSelection(0)
-                command.EditEffortEntryModeCommand(
-                    items=self.items, newValue="standard"
-                ).do()
-                self._effortDurationCtrl.SetReadOnly(False)
-                self._effortDurationPresetsChoice.Enable(True)
+            # For Implicit mode: set duration and let __syncEffortState handle
+            # mode switch via flow step 3.6 (Duration changed → Set Standard Mode, Loop)
+            if self._effortEntryMode == 2:
+                self._effortDurationCtrl.SetDuration(datetime.timedelta(seconds=total_seconds), quiet=True)
+                self._updatingControls = False
+                self.__syncEffortState(source_field='duration')
+                return
 
             # Update duration control
             self._effortDurationCtrl.SetDuration(datetime.timedelta(seconds=total_seconds), quiet=True)
@@ -4424,7 +4537,7 @@ class EffortEditBook(Page):
             if self._startDateTimeCombo.GetValue() != maxDateTime:
                 self._startDateTimeCombo.SetDateTime(maxDateTime)
                 self._startDateTimeSync.onAttributeEdited(event)
-            self.__syncEffortState('start')
+            self.__syncEffortState(source_field='start')
             self.__update_invalid_period_message()
         finally:
             self._updatingControls = False
@@ -4436,7 +4549,7 @@ class EffortEditBook(Page):
             new_value = date.DateTime.now()
             self._stopDateTimeCombo.SetChecked(True)
             self._stopDateTimeCombo.SetDateTime(new_value)
-            self.__syncEffortState('stop')
+            self.__syncEffortState(source_field='stop')
             command.EditEffortStopDateTimeCommand(
                 None, self.items, newValue=new_value
             ).do()

--- a/taskcoachlib/gui/dialog/entry.py
+++ b/taskcoachlib/gui/dialog/entry.py
@@ -171,7 +171,7 @@ class AmountEntry(widgets.PanelWithBoxSizer):
         self.fit()
 
     def createEntry(self, amount):
-        return widgets.masked.AmountCtrl(self, amount)
+        return widgets.CurrencyCtrl(self, amount)
 
     def NavigateBook(self, event):
         self.GetParent().NavigateBook(not event.ShiftDown())

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,10 +41,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "55"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.1.52
+patch = "56"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.1.56
 
-release_day = "28"  # Day of the release (1-31)
+release_day = "30"  # Day of the release (1-31)
 release_month = "January"  # Month of the release
 release_year = "2026"  # Year of the release
 

--- a/taskcoachlib/persistence/templatelist.py
+++ b/taskcoachlib/persistence/templatelist.py
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, pickle, tempfile, shutil
 from pubsub import pub
+from taskcoachlib.meta.debug import log_step
 from .xml import TemplateXMLWriter, TemplateXMLReader
 
 
@@ -43,8 +44,7 @@ class TemplateList(object):
         try:
             return TemplateReader(fd).read()
         except Exception as e:
-            import sys
-            print(f"Error reading template {filename}: {e}", file=sys.stderr)
+            log_step(f"ERROR! Reading template {filename}: {e}", prefix="TEMPLATE")
             import traceback
             traceback.print_exc()
         finally:

--- a/taskcoachlib/widgets/__init__.py
+++ b/taskcoachlib/widgets/__init__.py
@@ -55,5 +55,6 @@ from .calendarconfig import CalendarConfigDialog
 from .password import GetPassword
 from .hcalendar import HierarchicalCalendar
 from .hcalendarconfig import HierarchicalCalendarConfigDialog
+from .currencyctrl import CurrencyCtrl
 from . import masked
 from wx.lib import sized_controls

--- a/taskcoachlib/widgets/currencyctrl.py
+++ b/taskcoachlib/widgets/currencyctrl.py
@@ -1,0 +1,134 @@
+"""
+Task Coach - Your friendly task manager
+Copyright (C) 2004-2016 Task Coach developers <developers@taskcoach.org>
+
+Task Coach is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Task Coach is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import locale
+import wx
+
+
+class CurrencyValidator(wx.Validator):
+    """Validator that restricts input to valid currency characters:
+    digits, a single locale-aware decimal point, and navigation keys."""
+
+    def __init__(self, decimal_char=None):
+        super().__init__()
+        self._decimalChar = decimal_char or locale.localeconv().get("decimal_point", ".")
+        if not self._decimalChar:
+            self._decimalChar = "."
+        self.Bind(wx.EVT_CHAR, self.OnChar)
+
+    def Clone(self):
+        return CurrencyValidator(self._decimalChar)
+
+    def Validate(self, parent):
+        return True
+
+    def TransferToWindow(self):
+        return True
+
+    def TransferFromWindow(self):
+        return True
+
+    def OnChar(self, event):
+        keycode = event.GetKeyCode()
+
+        # Always allow navigation/control keys
+        if keycode < wx.WXK_SPACE or keycode == wx.WXK_DELETE:
+            event.Skip()
+            return
+        if keycode in (wx.WXK_RETURN, wx.WXK_TAB, wx.WXK_BACK,
+                       wx.WXK_LEFT, wx.WXK_RIGHT, wx.WXK_HOME, wx.WXK_END):
+            event.Skip()
+            return
+        # Allow Ctrl+key combos (copy, paste, select all, etc.)
+        if event.ControlDown() or event.CmdDown():
+            event.Skip()
+            return
+
+        char = chr(keycode) if keycode < 256 else None
+
+        if char is None:
+            event.Skip()
+            return
+
+        # Allow digits
+        if char.isdigit():
+            event.Skip()
+            return
+
+        # Allow single decimal point
+        if char == self._decimalChar:
+            ctrl = self.GetWindow()
+            if self._decimalChar not in ctrl.GetValue():
+                event.Skip()
+            return
+
+        # Block everything else (no beep, just silently reject)
+
+
+class CurrencyCtrl(wx.TextCtrl):
+    """Currency input control using wx.TextCtrl + CurrencyValidator.
+
+    Replaces the crash-prone wx.lib.masked.NumCtrl (AmountCtrl).
+    Right-aligned, locale-aware decimal point, formats to 2dp on focus loss.
+    """
+
+    def __init__(self, parent, value=0.0, **kwargs):
+        self._decimalChar = locale.localeconv().get("decimal_point", ".") or "."
+        super().__init__(
+            parent,
+            style=wx.TE_RIGHT | wx.TE_PROCESS_TAB,
+            validator=CurrencyValidator(self._decimalChar),
+            **kwargs,
+        )
+        self.SetValue(value)
+        self.Bind(wx.EVT_KILL_FOCUS, self._onKillFocus)
+
+    def GetValue(self):
+        """Return the current value as a float."""
+        text = super().GetValue().strip()
+        if not text:
+            return 0.0
+        # Normalize locale decimal to Python float decimal
+        text = text.replace(self._decimalChar, ".")
+        try:
+            return float(text)
+        except ValueError:
+            return 0.0
+
+    def SetValue(self, value):
+        """Set the control to display a formatted float value."""
+        if isinstance(value, (int, float)):
+            text = self._format(value)
+        else:
+            text = str(value)
+        super().SetValue(text)
+
+    def _format(self, value):
+        """Format a float to 2 decimal places using locale decimal char."""
+        formatted = "%.2f" % value
+        if self._decimalChar != ".":
+            formatted = formatted.replace(".", self._decimalChar)
+        return formatted
+
+    def _onKillFocus(self, event):
+        """Auto-format to 2 decimal places when focus leaves the control."""
+        event.Skip()
+        if not self.IsEnabled():
+            return
+        current = self.GetValue()
+        self.SetValue(current)

--- a/taskcoachlib/widgets/maskedtimectrl.py
+++ b/taskcoachlib/widgets/maskedtimectrl.py
@@ -1124,6 +1124,7 @@ class NumericField:
         self.__padZeros = padZeros
         self.__digitCount = 0  # Number of digits typed in current entry
         self.__lastKeyTime = 0  # Timestamp of last digit keystroke
+        self._negativePrefix = False  # If True, paint "-" before value
         self.SetChoices(choices)  # Use SetChoices for proper handling
 
     @property
@@ -1194,7 +1195,10 @@ class NumericField:
             amW, amH = dc.GetTextExtent("AM")
             pmW, pmH = dc.GetTextExtent("PM")
             return (max(amW, pmW), max(amH, pmH))
-        return dc.GetTextExtent("0" * max(self.__width, 1))
+        w = max(self.__width, 1)
+        if self._negativePrefix:
+            w += 1  # Extra char for "-" prefix
+        return dc.GetTextExtent("0" * w)
 
     def PaintValue(self, dc, x, y, w, h):
         """Paint the field value in its area.
@@ -1220,6 +1224,8 @@ class NumericField:
         else:
             # Right-align space-padded values so rightmost digit touches next element
             txt = str(self.__value)
+            if self._negativePrefix:
+                txt = "-" + txt
             tw, th = dc.GetTextExtent(txt)
             dc.DrawText(txt, int(x + w - tw), int(y + (h - th) / 2))
 
@@ -1804,16 +1810,19 @@ class DurationCtrl(FieldsCtrl):
             elements.append(("literal", ":"))
             elements.append(("second", seconds, secondChoices))
 
+        self._negative = False
         super().__init__(parent, elements)
 
     def GetDuration(self):
-        result = datetime.timedelta(
+        result = date.TimeDelta(
             days=self.GetFieldValue('day'),
             hours=self.GetFieldValue('hour'),
             minutes=self.GetFieldValue('minute')
         )
         if self._showSeconds:
-            result += datetime.timedelta(seconds=self.GetFieldValue('second'))
+            result += date.TimeDelta(seconds=self.GetFieldValue('second'))
+        if self._negative:
+            result = -result
         return result
 
     def GetTimeDelta(self):
@@ -1828,8 +1837,10 @@ class DurationCtrl(FieldsCtrl):
             quiet: If True, don't fire value changed events
         """
         if duration is None:
-            duration = datetime.timedelta()
+            duration = date.TimeDelta()
         total = int(duration.total_seconds())
+        negative = total < 0
+        total = abs(total)
         days, remainder = divmod(total, 86400)
         hours, remainder = divmod(remainder, 3600)
         minutes, seconds = divmod(remainder, 60)
@@ -1837,6 +1848,10 @@ class DurationCtrl(FieldsCtrl):
         if quiet:
             self._suppressEvents = True
         try:
+            self._negative = negative
+            dayField = self._fields.get('day')
+            if dayField:
+                dayField._negativePrefix = negative
             self.SetFieldValue('day', days)
             self.SetFieldValue('hour', hours)
             self.SetFieldValue('minute', minutes)
@@ -1848,6 +1863,14 @@ class DurationCtrl(FieldsCtrl):
 
     def SetTimeDelta(self, duration, quiet=False):
         """Alias for SetDuration for consistency with other controls."""
+        self.SetDuration(duration, quiet=quiet)
+
+    def GetValue(self):
+        """Alias for GetDuration for AttributeSync compatibility."""
+        return self.GetDuration()
+
+    def SetValue(self, duration, quiet=False):
+        """Alias for SetDuration for AttributeSync compatibility."""
         self.SetDuration(duration, quiet=quiet)
 
 
@@ -1919,16 +1942,19 @@ class DurationCtrlVerbose(FieldsCtrl):
             elements.append(("second", seconds, secondChoices))
             elements.append(("literal", " " + _("secs")))
 
+        self._negative = False
         super().__init__(parent, elements)
 
     def GetDuration(self):
-        result = datetime.timedelta(
+        result = date.TimeDelta(
             days=self.GetFieldValue('day'),
             hours=self.GetFieldValue('hour'),
             minutes=self.GetFieldValue('minute')
         )
         if self._showSeconds:
-            result += datetime.timedelta(seconds=self.GetFieldValue('second'))
+            result += date.TimeDelta(seconds=self.GetFieldValue('second'))
+        if self._negative:
+            result = -result
         return result
 
     def GetTimeDelta(self):
@@ -1943,8 +1969,10 @@ class DurationCtrlVerbose(FieldsCtrl):
             quiet: If True, don't fire value changed events
         """
         if duration is None:
-            duration = datetime.timedelta()
+            duration = date.TimeDelta()
         total = int(duration.total_seconds())
+        negative = total < 0
+        total = abs(total)
         days, remainder = divmod(total, 86400)
         hours, remainder = divmod(remainder, 3600)
         minutes, seconds = divmod(remainder, 60)
@@ -1952,6 +1980,10 @@ class DurationCtrlVerbose(FieldsCtrl):
         if quiet:
             self._suppressEvents = True
         try:
+            self._negative = negative
+            dayField = self._fields.get('day')
+            if dayField:
+                dayField._negativePrefix = negative
             self.SetFieldValue('day', days)
             self.SetFieldValue('hour', hours)
             self.SetFieldValue('minute', minutes)
@@ -1963,6 +1995,14 @@ class DurationCtrlVerbose(FieldsCtrl):
 
     def SetTimeDelta(self, duration, quiet=False):
         """Alias for SetDuration for consistency with other controls."""
+        self.SetDuration(duration, quiet=quiet)
+
+    def GetValue(self):
+        """Alias for GetDuration for AttributeSync compatibility."""
+        return self.GetDuration()
+
+    def SetValue(self, duration, quiet=False):
+        """Alias for SetDuration for AttributeSync compatibility."""
         self.SetDuration(duration, quiet=quiet)
 
 


### PR DESCRIPTION
Budget tab:
- Replace TimeDeltaEntry with MaskedDurationCtrl for budget, time spent, and budget left fields
- Fix budgetLeft() to calculate even when budget is zero
- Fix entries() to properly reference budgetLeft and revenue controls
- Use SetDuration/SetReadOnly API instead of legacy SetValue/readonly

Effort editor:
- Rewrite effort sync to fix infinite loop from deferred wx events
- Merge __syncEffortState/__syncEffortStateInner into single function
- Add change-only rule: skip control updates when value unchanged
- Add source_field guards on autoheal to not override user's field
- Fix duration control disabled after switching from Implicit mode
- Add error logging for unexpected recursion (doc 0.3.2, 0.3.3)

Task dates:
- Update comments to use Unset-Action terminology from doc
- Allow negative durations in implicit mode
- Expand style priority range to -999..999

New widget:
- Add CurrencyCtrl for masked monetary input

Other:
- Bump version to 2.0.1.56, update README download links
- Add TimeDelta.__neg__ for negative duration support
- Add icon and template error logging
- Launcher logs to both file and stdout
- Fix Windows build to use python.exe for console output
- Expand duration calculations documentation

dll loading error on Windows #331
Budget tab fields completely broken, needs full refactor #189