### PR TITLE
Add DateTimeCombo2 widget, fix recurrence, improve editor layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.57-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.57-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.57_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.57_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.57_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.57-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.58-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.58-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.58_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.58_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.58_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.58-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.57-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.57-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.57_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.57_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.57-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.57-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.58-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.58-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.58_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.58_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.58-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.58-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.57_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.57_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.58_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.58_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.57-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.57-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.58-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.58-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.57-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.57-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.58-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.58-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.57-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.57-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.58-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.58-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.57-x86_64.AppImage
+./TaskCoach-2.0.1.58-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/docs/DATETIME_CONTROLS.md
+++ b/docs/DATETIME_CONTROLS.md
@@ -45,11 +45,17 @@ Simple time and duration input controls with explicit subfields and translatable
   - [Popup Toggle Logic](#popup-toggle-logic)
   - [Dropdown Width and Position](#dropdown-width-and-position)
   - [Events from Popup](#events-from-popup)
-  - [Sync Pattern: Standard wx.EVT_KILL_FOCUS](#sync-pattern-standard-wxevt_kill_focus)
+  - [Sync Pattern: EVT_VALUE_CHANGED (DateTimeCombo2)](#sync-pattern-evt_value_changed-datetimecombo2)
 - [Wayland](#wayland)
   - [Problem](#problem)
   - [Why GDK_BACKEND=x11 Is Not Viable](#why-gdk_backendx11-is-not-viable)
   - [Solution: wx.PopupWindow on Wayland](#solution-wxpopupwindow-on-wayland)
+- [2026-Jan Refactor: ComboCtrl Integration](#2026-jan-refactor-comboctrl-integration)
+  - [Motivation](#motivation)
+  - [Approach](#approach)
+  - [Key Classes](#key-classes)
+  - [Focus Management in DateCtrl3](#focus-management-in-datectrl3)
+  - [Demo](#demo-1)
 
 **Demo:** `docs/scripts/datetime_controls_demo.py`
 
@@ -58,21 +64,27 @@ Self-contained module with custom-painted single field and navigable subfields.
 
 ## TODO
 
-1. Add `Activate()` method to DateTimeCombo — programmatically checks the
-   checkbox and enables fields, using the internally stored value (typically
-   `now()` from construction). Used by duration calc logic (steps 2.1, 3.1)
-   to activate a missing date without specifying a value.
-2. Add `Deactivate()` / `Unset()` method to DateTimeCombo — programmatically
-   unchecks the checkbox and disables fields. Review integration with the
-   existing `SetNone` pattern from the old smartdatetimectrl (see
-   [SetNone: Unchecking the Checkbox](#setnone-unchecking-the-checkbox)).
-   Used by duration calc logic (steps 2.5.1, 3.5.1) to deactivate a date.
-3. Checkbox toggle does NOT trigger EVT_KILL_FOCUS (blur) because focus
-   stays on the checkbox. AttributeSync relies on EVT_KILL_FOCUS to
-   commit the value change. The checkbox toggle needs to either trigger
-   a blur/focus-change or fire an immediate commit so the attribute
-   pattern can pick up the checked/unchecked state change.
+1. ~~Add `Activate()` method to DateTimeCombo~~ — **Done.** `ActivateValue()` on
+   DateTimeCombo2. Editor uses it in `__activateStartDate()` / `__activateDueDate()`.
+2. ~~Add `Deactivate()` method to DateTimeCombo~~ — **Done.** `DeactivateValue()` on
+   DateTimeCombo2. Editor deactivation goes through commands (domain write →
+   pubsub → SetValue(sentinel) → unchecks). `DeactivateValue()` available for
+   direct UI use (e.g. entry.py recurrence stop date).
+3. ~~Checkbox toggle EVT_KILL_FOCUS gap~~ — **Resolved.** ~~Editor binds
+   `EVT_CHECKBOX` via `combo.Bind(wx.EVT_CHECKBOX, handler)` and calls
+   `sync.commit()` explicitly.~~
+   **Update:** EVT_CHECKBOX is no longer exposed by DateTimeCombo2. The
+   checkbox is an internal implementation detail. All AttributeSync instances
+   now use `EVT_VALUE_CHANGED` as `editedEventType`, which fires on checkbox
+   toggle AND date/time edits — no external EVT_CHECKBOX handlers needed.
    See [DURATION_CALCULATIONS.md](DURATION_CALCULATIONS.md) TODO item 9.
+   **Bug found & fixed:** `_onCheckboxChanged` was posting `EVT_VALUE_CHANGED`
+   to `DateCtrl4` via `wx.PostEvent()`, but `DateCtrl4.Bind()` forwards
+   `EVT_VALUE_CHANGED` to the inner `_EmbeddedDateCtrl`. Event posted on
+   parent, handler on child — command events propagate up, not down — event
+   lost. Fix: `DateCtrl4._fireValueChanged()` delegates to inner control.
+   `_onCheckboxChanged` now calls `self._dateCtrl._fireValueChanged()` instead
+   of `wx.PostEvent()`.
 
 ## Location
 
@@ -598,9 +610,9 @@ DateTimeCombo(parent, value=None, hourChoices=None, minuteChoices=None, showSeco
 - `value=None` → checkbox unchecked, fields disabled
 
 **Three States:**
-1. **Checked** (normal): checkbox ON, fields enabled and editable
-2. **Unchecked**: checkbox OFF, fields disabled, `GetDateTime()` returns `None`
-3. **Inactive** (`SetEditable(False)`): checkbox ON but disabled, fields show values greyed out (read-only, not editable)
+1. **Active + Editable** (normal): checkbox ON, fields enabled and editable
+2. **Inactive** (unchecked): checkbox OFF, fields show "N/A", `GetDateTime()` returns `None`
+3. **Active + Read-only** (`SetReadOnly()`): checkbox ON but disabled, fields greyed
 
 **Default to "Now":** When unchecked and user checks the checkbox, "now" is used as the initial value.
 
@@ -640,10 +652,14 @@ combo.SetDateTime(datetime.datetime(2026, 1, 18, 14, 30))
 combo.SetDateTime(None)  # Unchecks the checkbox
 
 # State control
-combo.SetEditable(False)  # Inactive: values visible but greyed, not editable
-combo.SetEditable(True)   # Normal editable mode
+combo.SetReadOnly()       # Values visible but greyed, not editable
+combo.SetEditable()       # Normal editable mode
 combo.IsEditable()        # Check if editable
-combo.IsChecked()         # Check if checkbox is checked
+combo.IsActive()          # Check if has a value (non-null)
+
+# Value activation
+combo.ActivateValue()     # Activate (uses internally stored value)
+combo.DeactivateValue()   # Deactivate (values preserved internally)
 ```
 
 ## Events
@@ -911,14 +927,15 @@ The popup fires three events:
 - `EVT_CHOICE_SELECTED`: Enter key or click selection (confirms value)
 - `EVT_POPUP_DISMISS`: Popup closed for any reason (Escape, click outside, selection)
 
-### Sync Pattern: Standard wx.EVT_KILL_FOCUS
+### Sync Pattern: EVT_VALUE_CHANGED (DateTimeCombo2)
 
-The controls use standard `wx.EVT_KILL_FOCUS` for synchronization, just like other wx controls (e.g., SingleLineTextCtrl for subject field). This approach:
+DateTimeCombo2 uses `EVT_VALUE_CHANGED` for AttributeSync synchronization.
+This single event fires on all value changes: checkbox toggle, date edit,
+and time edit. The checkbox is an internal implementation detail — external
+code never binds to `EVT_CHECKBOX`.
 
-- Syncs only when the user finishes editing (focus leaves)
-- Prevents list reordering during typing
-- Uses standard wx events (no custom event types needed)
-- Matches the pattern used throughout the application
+Other controls (subject, description, budget, etc.) still use
+`EVT_KILL_FOCUS` for synchronization to batch typed edits.
 
 **AttributeSync Usage:**
 
@@ -929,7 +946,7 @@ self._plannedStartDateTimeSync = attributesync.AttributeSync(
     plannedStartDateTime,
     self.items,
     command.EditPlannedStartDateTimeCommand,
-    wx.EVT_KILL_FOCUS,  # Standard wx event
+    widgets.EVT_VALUE_CHANGED,  # Fires on checkbox toggle AND date/time edits
     self.items[0].plannedStartDateTimeChangedEventType(),
 )
 ```
@@ -1002,3 +1019,130 @@ The GTK3 caret visibility bug (wxWidgets #18261) that affects `wx.PopupTransient
 Platform-conditional base class:
 - **Wayland**: `wx.PopupWindow` (xdg_popup, compositor-positioned)
 - **X11/macOS**: `wx.Dialog` (proven cross-platform, absolute positioning works)
+
+## 2026-Jan Refactor: ComboCtrl Integration
+
+### Motivation
+
+The original `DateCtrl` uses `_PopupWindow` (wx.Dialog) for its calendar popup, which cannot be positioned on Wayland (xdg_toplevel ignores Move()/SetPosition()). Custom dropdown buttons using `RendererNative.DrawComboBoxDropButton()` are also invisible on Wayland.
+
+### Approach
+
+Use `wx.ComboCtrl` which provides a **native dropdown button** and manages popup positioning natively (including Wayland-safe xdg_popup). The inner date field is a clean `FieldsCtrl` subclass with all popup/frame logic removed.
+
+### Key Classes
+
+**`_EmbeddedDateCtrl(FieldsCtrl)`** — Clean date control for embedding inside a ComboCtrl:
+- No calendar popup, no frame drawing (`_drawFrame=False`), no field dropdown popups
+- F4/Enter delegates to parent ComboCtrl.Popup()
+- Click only changes subfield focus (no popup toggle)
+- Custom `_onPaint` using `IsThisEnabled()` (own state) so parent ComboCtrl's disabled state for read-only mode shows greyed values, not "N/A"
+- Same date validation, GetDate/SetDate, locale-aware format as DateCtrl
+
+**`DateCtrl4(wx.ComboCtrl)`** — ComboCtrl wrapper around `_EmbeddedDateCtrl`:
+- Native dropdown button and popup management
+- `_CalendarComboPopup` for the calendar dropdown
+- `SetReadOnly(True)` disables the ComboCtrl (greys button) + sets inner control read-only
+- `Enable(False)` disables both ComboCtrl and inner control (shows "N/A")
+- `HasOpenPopup()` — public API using `IsPopupShown()`
+- `Bind()` override forwards UI events (EVT_VALUE_CHANGED, EVT_KEY_DOWN, EVT_KILL_FOCUS, EVT_SET_FOCUS) to inner control
+- `_fireValueChanged()` delegates to inner `_EmbeddedDateCtrl._fireValueChanged()` — needed because `wx.PostEvent()` to the ComboCtrl won't reach handlers bound on the inner control (command events propagate up, not down)
+- Focus redirection from ComboCtrl's text control to inner DateCtrl
+
+**`DateTimeCombo2`** — Clean replacement for `DateTimeCombo`, using `DateCtrl4`:
+- Uses `DateCtrl4` instead of `DateCtrl` for the date field
+- Clean `HasOpenPopup()` using DateCtrl4's public API
+- Single `Bind()` method (DateTimeCombo had two shadowing definitions)
+- EVT_VALUE_CHANGED wrapping sets event object to the combo (for AttributeSync)
+
+**DateTimeCombo2 States:**
+
+| State | Visual | Entered Via |
+|-------|--------|------------|
+| **Active + Editable** | Checkbox checked/enabled, fields editable | `ActivateValue()`, `SetEditable()` |
+| **Inactive** | Checkbox unchecked/enabled, fields show "N/A" | `DeactivateValue()`, construct with `value=None` |
+| **Active + Read-only** | Checkbox checked/disabled, fields greyed | `SetReadOnly()` |
+
+**DateTimeCombo2 State Transition Methods:**
+
+| Method | Effect | Duration Calc Ref |
+|--------|--------|-------------------|
+| `ActivateValue(value=None)` | Activate with given datetime, or internally stored value if None. | Steps 2.1, 3.1 |
+| `DeactivateValue()` | Active → Inactive. Values preserved internally. | Steps 2.5.2, 3.5.2 |
+| `SetEditable()` | Make combo editable (no args) | UI Field States |
+| `SetReadOnly()` | Make combo read-only (no args) | UI Field States |
+| `HideCheckBox()` | Hide checkbox for always-active controls | Effort start |
+
+**DateTimeCombo2 State Query Methods:**
+
+| Method | Returns |
+|--------|---------|
+| `IsActive()` | True if control has an active value (non-null) |
+| `IsEditable()` | True if editable (not read-only) |
+| `IsReadOnly()` | True if read-only |
+
+**DateTimeCombo2 Value Access:**
+
+| Method | Type |
+|--------|------|
+| `GetValue()` / `SetValue()` | `date.DateTime` (domain-compatible for AttributeSync). `SetValue` routes through `ActivateValue`/`DeactivateValue`. |
+| `GetDateTime()` | `datetime.datetime` or `None` (read-only) |
+| `GetDate()` | `datetime.date` (read-only) |
+| `GetTime()` | `datetime.time` (read-only) |
+
+**DateTimeCombo2 Layout Accessors** (for sizer arrangement, not state logic):
+
+| Method | Returns |
+|--------|---------|
+| `GetCheckBox()` | `wx.CheckBox` |
+| `GetDateCtrl()` | `DateCtrl4` |
+| `GetTimeCtrl()` | `TimeCtrl` / `TimeWithSecondsCtrl` |
+| `GetWidgets()` | Tuple of all three |
+| `CreateRowPanel(parent)` | `wx.Panel` with all three arranged horizontally |
+
+**Deprecated methods** (log warnings, no-op, prefer semantic methods above):
+- `SetDateTime()` → `ActivateValue(datetime)` / `DeactivateValue()`
+- `SetDate()` → `ActivateValue(datetime)`
+- `SetTime()` → `ActivateValue(datetime)`
+- `IsChecked()` → `IsActive()`
+- `SetChecked(bool)` → `ActivateValue()` / `DeactivateValue()`
+- `Activate()` → `ActivateValue()`
+- `Deactivate()` → `DeactivateValue()`
+- `Enable(bool)` → `SetEditable()` / `DeactivateValue()` + `SetReadOnly()`
+- `Disable()` → `DeactivateValue()` + `SetReadOnly()`
+- `IsEnabled()` → `IsEditable()`
+
+**`_CalendarComboPopup(wx.ComboPopup)`** — Adapter wrapping the custom-painted calendar:
+- `Create()` — creates interior panel, binds paint/mouse/key events
+- `GetAdjustedSize()` — returns calendar dimensions
+- `GetStringValue()` — returns selected date as ISO string
+- `OnPopup()` — syncs selection from parent DateCtrl4
+- Duck-typed `_getDateCtrl2()` finds parent via `hasattr` checks
+
+### Focus Management in DateCtrl4
+
+The ComboCtrl's internal text control is hidden behind the overlaid `_EmbeddedDateCtrl`. DateCtrl4 handles this by:
+
+1. **Focus redirection**: `EVT_SET_FOCUS` on the ComboCtrl's text control redirects focus to the inner DateCtrl, with a `_redirectingFocus` guard to prevent recursion.
+2. **Text interception**: `EVT_TEXT` handler clears any text the ComboCtrl auto-inserts.
+3. **Post-selection focus**: After calendar date selection, focus moves to inner DateCtrl via `wx.CallAfter`.
+
+### Wiring
+
+`__init__.py` exports aliases so existing app code works unchanged:
+- `DateCtrl4 as MaskedDateCtrl`
+- `DateTimeCombo2 as DateTimeCombo`
+
+Old `DateCtrl`, `DateTimeCombo` remain in `maskedtimectrl.py` for transition.
+
+### Demo
+
+Demo rows in `docs/scripts/datetime_controls_demo.py`:
+- **Section 2**: Old `DateTimeCombo` (regression reference)
+- **3.0**: Standard `wx.ComboBox` baseline
+- **3.1**: `DateCtrl4` standalone
+- **3.2**: `DateCtrl4` standalone read-only
+- **3.3**: `DateTimeCombo2` — Planned Start (checked, with dropdowns)
+- **3.4**: `DateTimeCombo2` — Due Date (unchecked)
+- **3.5**: `DateTimeCombo2` — Completed (SetReadOnly(), toggle button)
+- **3.6**: `DateTimeCombo2` — Reminder (checked, no dropdowns)

--- a/docs/DURATION_CALCULATIONS.md
+++ b/docs/DURATION_CALCULATIONS.md
@@ -39,11 +39,13 @@ Duration calculations for Edit Task Dates and Edit Effort windows.
    OPEN QUESTION: How to differentiate between loading in process
    (mode not yet set, should wait) and invalid value requiring reset
    to automatic?
-9. DateTimeCombo Checkbox toggle does NOT trigger EVT_KILL_FOCUS (blur),
-   so AttributeSync does not commit the value change. The editor may
-   need a checkbox handler to trigger a blur or immediate commit when
-   the checkbox is toggled, so the attribute pattern picks up the
-   checked/unchecked state change and runs the sync calc.
+9. ~~DateTimeCombo Checkbox toggle EVT_KILL_FOCUS gap~~ — **Resolved.**
+   ~~Editor binds `EVT_CHECKBOX` via `combo.Bind(wx.EVT_CHECKBOX, handler)`
+   and calls `sync.commit()` explicitly.~~
+   **Update:** EVT_CHECKBOX is no longer exposed by DateTimeCombo2. All
+   AttributeSync instances use `EVT_VALUE_CHANGED` as `editedEventType`,
+   which fires on checkbox toggle AND date/time edits. External
+   EVT_CHECKBOX handlers and `sync.commit()` hacks removed.
    See [DATETIME_CONTROLS.md](DATETIME_CONTROLS.md) TODO item 3.
 
 ## Notes
@@ -183,7 +185,7 @@ Implements: __syncTaskState()
 Called on: Every change of Start-Date, Due-Date, Duration, or Mode dropdown.
 Note: Business logic — reads/sets domain values through commands.
       The attribute pattern (Layer 2) updates widgets automatically.
-      All sync goes through EVT_KILL_FOCUS → AttributeSync → command.
+      All sync goes through EVT_VALUE_CHANGED → AttributeSync → command.
 ```
 
 ### Calculation Mode Dropdown Build Logic
@@ -354,7 +356,7 @@ Implements: __syncEffortState()
 Called on: Every change of Start-Date, Stop-Date, Duration, or Mode dropdown.
 Note: Business logic — reads/sets domain values through commands.
       The attribute pattern (Layer 2) updates widgets automatically.
-      All sync goes through EVT_KILL_FOCUS → AttributeSync → command.
+      All sync goes through EVT_VALUE_CHANGED → AttributeSync → command.
 ```
 
 ### Time Spent

--- a/docs/scripts/datetime_controls_demo.py
+++ b/docs/scripts/datetime_controls_demo.py
@@ -7,18 +7,21 @@ Also demonstrates DateTimeCombo for flexible table layouts.
 
 import sys
 import os
+import datetime
 
 # Add taskcoachlib to path (go up two levels from docs/scripts/)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 # Import wx first and create App before importing controls
 import wx
+import wx.adv
 app = wx.App()
 
 from taskcoachlib.widgets import maskedtimectrl
 from taskcoachlib.widgets.maskedtimectrl import (
     DurationCtrl, DurationCtrlVerbose, TimeCtrl, TimeWithSecondsCtrl,
-    DateCtrl, DateTimeCombo, _PopupWindow, PopupDismissEvent
+    DateCtrl, DateCtrl4, DateTimeCombo, DateTimeCombo2, _PopupWindow,
+    PopupDismissEvent, _CalendarComboPopup
 )
 
 # =============================================================================
@@ -134,30 +137,41 @@ if _is_wayland():
 
 class DemoFrame(wx.Frame):
     def __init__(self):
-        super().__init__(None, title="DateTime Controls Demo", size=(900, 950))
+        displayH = wx.Display().GetClientArea().height
+        super().__init__(None, title="DateTime Controls Demo", size=(900, int(displayH * 0.90)))
 
-        panel = wx.Panel(self)
+        scrolled = wx.ScrolledWindow(self)
+        scrolled.SetScrollRate(0, 10)
+
+        panel = scrolled
         mainSizer = wx.BoxSizer(wx.VERTICAL)
 
         # Title
         title = wx.StaticText(panel, label="maskedtimectrl Demo - Dropdown List Sources")
         title.SetFont(title.GetFont().Bold().Scaled(1.5))
-        mainSizer.Add(title, 0, wx.ALL | wx.ALIGN_CENTER, 15)
+        mainSizer.Add(title, 0, wx.ALL | wx.EXPAND, 15)
+
+        # =============================================================
+        # Section 1: Individual Controls
+        # =============================================================
+        sec1Title = wx.StaticText(panel, label="1. Individual Controls")
+        sec1Title.SetFont(sec1Title.GetFont().Bold().Scaled(1.3))
+        mainSizer.Add(sec1Title, 0, wx.ALL | wx.EXPAND, 10)
 
         # Grid for controls
         grid = wx.FlexGridSizer(cols=3, hgap=15, vgap=10)
         grid.AddGrowableCol(2)
 
-        # 1. DurationCtrl with NO choices (no dropdowns)
-        grid.Add(wx.StaticText(panel, label="DurationCtrl:"), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
+        # 1.1 DurationCtrl with NO choices (no dropdowns)
+        grid.Add(wx.StaticText(panel, label="1.1 DurationCtrl:"), 0, wx.ALIGN_CENTER_VERTICAL)
         self.ctrl1 = DurationCtrl(panel, days=1, hours=2, minutes=30)
         grid.Add(self.ctrl1, 0, wx.ALIGN_CENTER_VERTICAL)
         lbl1 = wx.StaticText(panel, label="None = NO dropdowns")
         lbl1.SetForegroundColour(wx.RED)
         grid.Add(lbl1, 0, wx.ALIGN_CENTER_VERTICAL)
 
-        # 2. DurationCtrl WITH choices (has dropdowns)
-        grid.Add(wx.StaticText(panel, label="DurationCtrl:"), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
+        # 1.2 DurationCtrl WITH choices (has dropdowns)
+        grid.Add(wx.StaticText(panel, label="1.2 DurationCtrl:"), 0, wx.ALIGN_CENTER_VERTICAL)
         self.ctrl2 = DurationCtrl(
             panel, days=7, hours=8, minutes=0,
             dayChoices=[1, 7, 14, 21, 28],
@@ -167,16 +181,16 @@ class DemoFrame(wx.Frame):
         grid.Add(self.ctrl2, 0, wx.ALIGN_CENTER_VERTICAL)
         grid.Add(wx.StaticText(panel, label="WITH choices: [1,7,14,21,28], [8,9,10,17,18], [0,30]"), 0, wx.ALIGN_CENTER_VERTICAL)
 
-        # 3. TimeCtrl with NO choices
-        grid.Add(wx.StaticText(panel, label="TimeCtrl:"), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
+        # 1.3 TimeCtrl with NO choices
+        grid.Add(wx.StaticText(panel, label="1.3 TimeCtrl:"), 0, wx.ALIGN_CENTER_VERTICAL)
         self.ctrl3 = TimeCtrl(panel, hours=14, minutes=30)
         grid.Add(self.ctrl3, 0, wx.ALIGN_CENTER_VERTICAL)
         lbl3 = wx.StaticText(panel, label="None = NO dropdowns")
         lbl3.SetForegroundColour(wx.RED)
         grid.Add(lbl3, 0, wx.ALIGN_CENTER_VERTICAL)
 
-        # 4. TimeCtrl WITH choices
-        grid.Add(wx.StaticText(panel, label="TimeCtrl:"), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
+        # 1.4 TimeCtrl WITH choices
+        grid.Add(wx.StaticText(panel, label="1.4 TimeCtrl:"), 0, wx.ALIGN_CENTER_VERTICAL)
         self.ctrl4 = TimeCtrl(
             panel, hours=9, minutes=0,
             hourChoices=[9, 10, 11, 13, 14, 15, 16],
@@ -185,16 +199,16 @@ class DemoFrame(wx.Frame):
         grid.Add(self.ctrl4, 0, wx.ALIGN_CENTER_VERTICAL)
         grid.Add(wx.StaticText(panel, label="WITH choices: [9,10,11,13,14,15,16], [0,15,30,45]"), 0, wx.ALIGN_CENTER_VERTICAL)
 
-        # 5. TimeWithSecondsCtrl with NO choices
-        grid.Add(wx.StaticText(panel, label="TimeWithSecondsCtrl:"), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
+        # 1.5 TimeWithSecondsCtrl with NO choices
+        grid.Add(wx.StaticText(panel, label="1.5 TimeWithSecondsCtrl:"), 0, wx.ALIGN_CENTER_VERTICAL)
         self.ctrl5 = TimeWithSecondsCtrl(panel, hours=10, minutes=45, seconds=30)
         grid.Add(self.ctrl5, 0, wx.ALIGN_CENTER_VERTICAL)
         lbl5 = wx.StaticText(panel, label="None = NO dropdowns")
         lbl5.SetForegroundColour(wx.RED)
         grid.Add(lbl5, 0, wx.ALIGN_CENTER_VERTICAL)
 
-        # 6. TimeWithSecondsCtrl with MIXED (some with choices, some without)
-        grid.Add(wx.StaticText(panel, label="TimeWithSecondsCtrl:"), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
+        # 1.6 TimeWithSecondsCtrl with MIXED (some with choices, some without)
+        grid.Add(wx.StaticText(panel, label="1.6 TimeWithSecondsCtrl:"), 0, wx.ALIGN_CENTER_VERTICAL)
         self.ctrl6 = TimeWithSecondsCtrl(
             panel, hours=0, minutes=5, seconds=0,
             hourChoices=[0, 1, 2],
@@ -204,8 +218,8 @@ class DemoFrame(wx.Frame):
         grid.Add(self.ctrl6, 0, wx.ALIGN_CENTER_VERTICAL)
         grid.Add(wx.StaticText(panel, label="MIXED: hours=[0,1,2], mins=None, secs=[0,15,30,45]"), 0, wx.ALIGN_CENTER_VERTICAL)
 
-        # 7. DurationCtrlVerbose with choices
-        grid.Add(wx.StaticText(panel, label="DurationCtrlVerbose:"), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
+        # 1.7 DurationCtrlVerbose with choices
+        grid.Add(wx.StaticText(panel, label="1.7 DurationCtrlVerbose:"), 0, wx.ALIGN_CENTER_VERTICAL)
         self.ctrl7 = DurationCtrlVerbose(
             panel, days=3, hours=5, minutes=45,
             dayChoices=[0, 1, 2, 3, 5, 7, 14, 30],
@@ -215,8 +229,8 @@ class DemoFrame(wx.Frame):
         grid.Add(self.ctrl7, 0, wx.ALIGN_CENTER_VERTICAL)
         grid.Add(wx.StaticText(panel, label="WITH choices: [0-30], [0-23], [0,15,30,45]"), 0, wx.ALIGN_CENTER_VERTICAL)
 
-        # 8. DateCtrl (calendar popup)
-        grid.Add(wx.StaticText(panel, label="DateCtrl:"), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
+        # 1.8 DateCtrl (calendar popup)
+        grid.Add(wx.StaticText(panel, label="1.8 DateCtrl:"), 0, wx.ALIGN_CENTER_VERTICAL)
         self.ctrl8 = DateCtrl(panel)
         grid.Add(self.ctrl8, 0, wx.ALIGN_CENTER_VERTICAL)
         grid.Add(wx.StaticText(panel, label="calendar popup (click or Enter)"), 0, wx.ALIGN_CENTER_VERTICAL)
@@ -226,10 +240,12 @@ class DemoFrame(wx.Frame):
         # Separator
         mainSizer.Add(wx.StaticLine(panel), 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 20)
 
-        # DateTimeCombo Section
-        comboTitle = wx.StaticText(panel, label="DateTimeCombo - Flexible Table Layout")
+        # =============================================================
+        # Section 2: DateTimeCombo - Flexible Table Layout
+        # =============================================================
+        comboTitle = wx.StaticText(panel, label="2. DateTimeCombo - Flexible Table Layout")
         comboTitle.SetFont(comboTitle.GetFont().Bold().Scaled(1.3))
-        mainSizer.Add(comboTitle, 0, wx.ALL | wx.ALIGN_CENTER, 10)
+        mainSizer.Add(comboTitle, 0, wx.ALL | wx.EXPAND, 10)
 
         # Create a table grid showing aligned DateTimeCombos
         # 5 columns: Label, Checkbox, Date, Time, Description
@@ -246,7 +262,7 @@ class DemoFrame(wx.Frame):
         comboGrid.Add(hdrTime, 0, wx.ALIGN_CENTER)
         comboGrid.Add(wx.StaticText(panel, label=""), 0)
 
-        # Row 1: Planned Start (value=datetime means checked)
+        # 2.1 Planned Start (value=datetime means checked)
         import datetime
         self.plannedStartCombo = DateTimeCombo(
             panel,
@@ -254,57 +270,57 @@ class DemoFrame(wx.Frame):
             hourChoices=[8, 9, 10, 11, 12],
             minuteChoices=[0, 15, 30, 45]
         )
-        comboGrid.Add(wx.StaticText(panel, label="Planned Start:"), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
+        comboGrid.Add(wx.StaticText(panel, label="2.1 Planned Start:"), 0, wx.ALIGN_CENTER_VERTICAL)
         comboGrid.Add(self.plannedStartCombo.GetCheckBox(), 0, wx.ALIGN_CENTER_VERTICAL)
         comboGrid.Add(self.plannedStartCombo.GetDateCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
         comboGrid.Add(self.plannedStartCombo.GetTimeCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
         comboGrid.Add(wx.StaticText(panel, label="(value=datetime -> checked)"), 0, wx.ALIGN_CENTER_VERTICAL)
 
-        # Row 2: Due Date (value=None means unchecked)
+        # 2.2 Due Date (value=None means unchecked)
         self.dueDateCombo = DateTimeCombo(
             panel,
             value=None,  # None = unchecked, defaults to "now" when user checks it
             hourChoices=[17, 18, 19, 20, 21],
             minuteChoices=[0, 30]
         )
-        comboGrid.Add(wx.StaticText(panel, label="Due Date:"), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
+        comboGrid.Add(wx.StaticText(panel, label="2.2 Due Date:"), 0, wx.ALIGN_CENTER_VERTICAL)
         comboGrid.Add(self.dueDateCombo.GetCheckBox(), 0, wx.ALIGN_CENTER_VERTICAL)
         comboGrid.Add(self.dueDateCombo.GetDateCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
         comboGrid.Add(self.dueDateCombo.GetTimeCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
         comboGrid.Add(wx.StaticText(panel, label="(value=None -> unchecked)"), 0, wx.ALIGN_CENTER_VERTICAL)
 
-        # Row 3: Actual Start (another checked example)
+        # 2.3 Actual Start (another checked example)
         self.actualStartCombo = DateTimeCombo(
             panel,
             value=datetime.datetime(2026, 6, 15, 9, 30)
         )
-        comboGrid.Add(wx.StaticText(panel, label="Actual Start:"), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
+        comboGrid.Add(wx.StaticText(panel, label="2.3 Actual Start:"), 0, wx.ALIGN_CENTER_VERTICAL)
         comboGrid.Add(self.actualStartCombo.GetCheckBox(), 0, wx.ALIGN_CENTER_VERTICAL)
         comboGrid.Add(self.actualStartCombo.GetDateCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
         comboGrid.Add(self.actualStartCombo.GetTimeCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
         comboGrid.Add(wx.StaticText(panel, label="(value=2026-06-15 09:30)"), 0, wx.ALIGN_CENTER_VERTICAL)
 
-        # Row 4: Completed (inactive/read-only - values visible but greyed)
+        # 2.4 Completed (inactive/read-only - values visible but greyed)
         self.completedCombo = DateTimeCombo(
             panel,
             value=datetime.datetime(2026, 1, 19, 14, 30)
         )
         self.completedCombo.SetEditable(False)  # Inactive: values visible but greyed
-        comboGrid.Add(wx.StaticText(panel, label="Completed:"), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
+        comboGrid.Add(wx.StaticText(panel, label="2.4 Completed:"), 0, wx.ALIGN_CENTER_VERTICAL)
         comboGrid.Add(self.completedCombo.GetCheckBox(), 0, wx.ALIGN_CENTER_VERTICAL)
         comboGrid.Add(self.completedCombo.GetDateCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
         comboGrid.Add(self.completedCombo.GetTimeCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
-        lbl_inactive = wx.StaticText(panel, label="(INACTIVE - values greyed, not editable)")
+        lbl_inactive = wx.StaticText(panel, label="(Read-Only / Editable - Toggle Button below)")
         lbl_inactive.SetForegroundColour(wx.RED)
         comboGrid.Add(lbl_inactive, 0, wx.ALIGN_CENTER_VERTICAL)
 
-        # Row 5: Reminder (enabled, no time dropdowns)
+        # 2.5 Reminder (enabled, no time dropdowns)
         self.reminderCombo = DateTimeCombo(
             panel,
             value=datetime.datetime(2026, 1, 21, 8, 0)
             # No hourChoices/minuteChoices = no dropdowns
         )
-        comboGrid.Add(wx.StaticText(panel, label="Reminder:"), 0, wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT)
+        comboGrid.Add(wx.StaticText(panel, label="2.5 Reminder:"), 0, wx.ALIGN_CENTER_VERTICAL)
         comboGrid.Add(self.reminderCombo.GetCheckBox(), 0, wx.ALIGN_CENTER_VERTICAL)
         comboGrid.Add(self.reminderCombo.GetDateCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
         comboGrid.Add(self.reminderCombo.GetTimeCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
@@ -312,10 +328,168 @@ class DemoFrame(wx.Frame):
 
         mainSizer.Add(comboGrid, 0, wx.ALL | wx.EXPAND, 20)
 
-        # Toggle button to test inactive/editable state
-        toggleBtn = wx.Button(panel, label="Toggle 'Completed' Editable State")
+        # Toggle button to test read-only/editable state
+        toggleBtn = wx.Button(panel, label="Toggle 2.4 'Completed' Read-Only / Editable")
         toggleBtn.Bind(wx.EVT_BUTTON, self._onToggleCompleted)
         mainSizer.Add(toggleBtn, 0, wx.ALL | wx.ALIGN_CENTER, 10)
+
+        # Separator
+        mainSizer.Add(wx.StaticLine(panel), 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 20)
+
+        # =====================================================================
+        # Section 3: ComboCtrl-Based Date Controls
+        # =====================================================================
+        dc2Title = wx.StaticText(panel, label="3. ComboCtrl-Based Date Controls")
+        dc2Title.SetFont(dc2Title.GetFont().Bold().Scaled(1.3))
+        mainSizer.Add(dc2Title, 0, wx.ALL | wx.EXPAND, 10)
+
+        dc2Grid = wx.FlexGridSizer(cols=3, hgap=15, vgap=10)
+        dc2Grid.AddGrowableCol(2)
+
+        # 3.0 Standard ComboBox baseline reference
+        dc2Grid.Add(wx.StaticText(panel, label="3.0 Baseline:"), 0,
+                     wx.ALIGN_CENTER_VERTICAL)
+        self.dc2Baseline = wx.ComboBox(panel, value="Standard ComboBox (reference)",
+            choices=["Standard ComboBox (reference)", "Option 2", "Option 3"],
+            style=wx.CB_DROPDOWN)
+        dc2Grid.Add(self.dc2Baseline, 0, wx.ALIGN_CENTER_VERTICAL | wx.EXPAND)
+        lbl_baseline = wx.StaticText(panel, label="(standard height baseline)")
+        lbl_baseline.SetForegroundColour(wx.Colour(128, 128, 128))
+        dc2Grid.Add(lbl_baseline, 0, wx.ALIGN_CENTER_VERTICAL)
+
+        # 3.1 DateCtrl4 standalone (no checkbox, no time)
+        self.dc2EmbedDate = DateCtrl4(panel,
+            year=2026, month=1, day=31)
+        dc2Grid.Add(wx.StaticText(panel, label="3.1 DateCtrl4:"), 0,
+                     wx.ALIGN_CENTER_VERTICAL)
+        dc2Grid.Add(self.dc2EmbedDate, 0, wx.ALIGN_CENTER_VERTICAL)
+        lbl_31 = wx.StaticText(panel, label="(standalone DateCtrl4, no checkbox/time)")
+        lbl_31.SetForegroundColour(wx.Colour(0, 128, 0))
+        dc2Grid.Add(lbl_31, 0, wx.ALIGN_CENTER_VERTICAL)
+
+        # 3.2 DateCtrl4 standalone read-only
+        self.dc2EmbedDateRO = DateCtrl4(panel,
+            year=2026, month=1, day=19)
+        self.dc2EmbedDateRO.SetReadOnly(True)
+        dc2Grid.Add(wx.StaticText(panel, label="3.2 DateCtrl4:"), 0,
+                     wx.ALIGN_CENTER_VERTICAL)
+        dc2Grid.Add(self.dc2EmbedDateRO, 0, wx.ALIGN_CENTER_VERTICAL)
+        lbl_32 = wx.StaticText(panel, label="(standalone DateCtrl4, read-only)")
+        lbl_32.SetForegroundColour(wx.Colour(128, 128, 128))
+        dc2Grid.Add(lbl_32, 0, wx.ALIGN_CENTER_VERTICAL)
+
+        mainSizer.Add(dc2Grid, 0, wx.ALL | wx.EXPAND, 20)
+
+        # --- 3.3-3.6 DateTimeCombo2 (DateCtrl4-based, same API as section 2) ---
+        dc3Grid = wx.FlexGridSizer(cols=5, hgap=10, vgap=8)
+
+        # Header row
+        dc3Grid.Add(wx.StaticText(panel, label=""), 0)
+        dc3Grid.Add(wx.StaticText(panel, label=""), 0)
+        hdrDate3 = wx.StaticText(panel, label="Date")
+        hdrDate3.SetFont(hdrDate3.GetFont().Bold())
+        dc3Grid.Add(hdrDate3, 0, wx.ALIGN_CENTER)
+        hdrTime3 = wx.StaticText(panel, label="Time")
+        hdrTime3.SetFont(hdrTime3.GetFont().Bold())
+        dc3Grid.Add(hdrTime3, 0, wx.ALIGN_CENTER)
+        dc3Grid.Add(wx.StaticText(panel, label=""), 0)
+
+        # 3.3 Planned Start (checked, with dropdowns)
+        self.dc3PlannedStartCombo = DateTimeCombo2(
+            panel,
+            value=datetime.datetime(2026, 1, 20, 9, 0),
+            hourChoices=[8, 9, 10, 11, 12],
+            minuteChoices=[0, 15, 30, 45]
+        )
+        dc3Grid.Add(wx.StaticText(panel, label="3.3 Planned Start:"), 0,
+                     wx.ALIGN_CENTER_VERTICAL)
+        dc3Grid.Add(self.dc3PlannedStartCombo.GetCheckBox(), 0, wx.ALIGN_CENTER_VERTICAL)
+        dc3Grid.Add(self.dc3PlannedStartCombo.GetDateCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
+        dc3Grid.Add(self.dc3PlannedStartCombo.GetTimeCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
+        dc3Grid.Add(wx.StaticText(panel, label="(checked, with time dropdowns)"), 0,
+                     wx.ALIGN_CENTER_VERTICAL)
+
+        # 3.4 Due Date (unchecked)
+        self.dc3DueDateCombo = DateTimeCombo2(
+            panel,
+            value=None,
+            hourChoices=[17, 18, 19, 20, 21],
+            minuteChoices=[0, 30]
+        )
+        dc3Grid.Add(wx.StaticText(panel, label="3.4 Due Date:"), 0,
+                     wx.ALIGN_CENTER_VERTICAL)
+        dc3Grid.Add(self.dc3DueDateCombo.GetCheckBox(), 0, wx.ALIGN_CENTER_VERTICAL)
+        dc3Grid.Add(self.dc3DueDateCombo.GetDateCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
+        dc3Grid.Add(self.dc3DueDateCombo.GetTimeCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
+        dc3Grid.Add(wx.StaticText(panel, label="(unchecked, fields disabled)"), 0,
+                     wx.ALIGN_CENTER_VERTICAL)
+
+        # 3.5 Completed (read-only / editable toggle)
+        self.dc3CompletedCombo = DateTimeCombo2(
+            panel,
+            value=datetime.datetime(2026, 1, 19, 14, 30)
+        )
+        self.dc3CompletedCombo.SetReadOnly()
+        dc3Grid.Add(wx.StaticText(panel, label="3.5 Completed:"), 0,
+                     wx.ALIGN_CENTER_VERTICAL)
+        dc3Grid.Add(self.dc3CompletedCombo.GetCheckBox(), 0, wx.ALIGN_CENTER_VERTICAL)
+        dc3Grid.Add(self.dc3CompletedCombo.GetDateCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
+        dc3Grid.Add(self.dc3CompletedCombo.GetTimeCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
+        lbl_dc3_ro = wx.StaticText(panel, label="(Read-Only / Editable - Toggle Button below)")
+        lbl_dc3_ro.SetForegroundColour(wx.RED)
+        dc3Grid.Add(lbl_dc3_ro, 0, wx.ALIGN_CENTER_VERTICAL)
+
+        # 3.6 Reminder (checked, no time dropdowns)
+        self.dc3ReminderCombo = DateTimeCombo2(
+            panel,
+            value=datetime.datetime(2026, 1, 21, 8, 0)
+        )
+        dc3Grid.Add(wx.StaticText(panel, label="3.6 Reminder:"), 0,
+                     wx.ALIGN_CENTER_VERTICAL)
+        dc3Grid.Add(self.dc3ReminderCombo.GetCheckBox(), 0, wx.ALIGN_CENTER_VERTICAL)
+        dc3Grid.Add(self.dc3ReminderCombo.GetDateCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
+        dc3Grid.Add(self.dc3ReminderCombo.GetTimeCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
+        dc3Grid.Add(wx.StaticText(panel, label="(checked, no time dropdowns)"), 0,
+                     wx.ALIGN_CENTER_VERTICAL)
+
+        mainSizer.Add(dc3Grid, 0, wx.ALL | wx.EXPAND, 20)
+
+        # Toggle button to test read-only/editable state on 3.5
+        dc3ToggleBtn = wx.Button(panel, label="Toggle 3.5 'Completed' Read-Only / Editable")
+        dc3ToggleBtn.Bind(wx.EVT_BUTTON, self._onToggleDc3Completed)
+        mainSizer.Add(dc3ToggleBtn, 0, wx.ALL | wx.ALIGN_CENTER, 10)
+
+        # Separator
+        mainSizer.Add(wx.StaticLine(panel), 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 20)
+
+        # =====================================================================
+        # Section 4: Standard wxPython Date/Calendar Controls
+        # =====================================================================
+        stdTitle = wx.StaticText(panel, label="4. Standard wxPython Date/Calendar Controls")
+        stdTitle.SetFont(stdTitle.GetFont().Bold().Scaled(1.3))
+        mainSizer.Add(stdTitle, 0, wx.ALL | wx.EXPAND, 10)
+
+        stdGrid = wx.FlexGridSizer(cols=3, hgap=15, vgap=10)
+        stdGrid.AddGrowableCol(2)
+
+        # 4.1 DatePickerCtrl - Native dropdown (week start from locale)
+        stdGrid.Add(wx.StaticText(panel, label="4.1 DatePickerCtrl:"), 0,
+                     wx.ALIGN_CENTER_VERTICAL)
+        self.stdDatePickerDD = wx.adv.DatePickerCtrl(panel, style=wx.adv.DP_DROPDOWN)
+        stdGrid.Add(self.stdDatePickerDD, 0, wx.ALIGN_CENTER_VERTICAL)
+        stdGrid.Add(wx.StaticText(panel, label="DP_DROPDOWN — native popup, week start from locale"), 0,
+                     wx.ALIGN_CENTER_VERTICAL)
+
+        # 4.2 DatePickerCtrlGeneric - locale week start
+        stdGrid.Add(wx.StaticText(panel, label="4.2 DatePickerCtrlGeneric:"), 0,
+                     wx.ALIGN_CENTER_VERTICAL)
+        self.stdDatePickerGen = wx.adv.DatePickerCtrlGeneric(
+            panel, style=wx.adv.DP_DROPDOWN)
+        stdGrid.Add(self.stdDatePickerGen, 0, wx.ALIGN_CENTER_VERTICAL)
+        stdGrid.Add(wx.StaticText(panel, label="Generic popup, week start from locale"), 0,
+                     wx.ALIGN_CENTER_VERTICAL)
+
+        mainSizer.Add(stdGrid, 0, wx.ALL | wx.EXPAND, 20)
 
         # Instructions
         instructions = wx.StaticText(panel, label=(
@@ -326,10 +500,9 @@ class DemoFrame(wx.Frame):
             "- value=datetime -> checkbox ON, fields editable\n"
             "- value=None -> checkbox OFF, fields disabled\n"
             "- SetEditable(False) -> checkbox ON but disabled, fields greyed (read-only)\n\n"
-            "Constructor: DateTimeCombo(parent, value=None, hourChoices=None, minuteChoices=None)\n"
-            "- value: datetime.datetime (checked) or None (unchecked)\n"
-            "- When unchecked and user checks it, defaults to 'now'\n\n"
-            "Layout: GetCheckBox(), GetDateCtrl(), GetTimeCtrl() for flexible table"
+            "Standard wxPython Date Pickers:\n"
+            "- DatePickerCtrl (DP_DROPDOWN): Native popup, week start from locale only\n"
+            "- DatePickerCtrlGeneric: Generic popup, week start from locale"
         ))
         mainSizer.Add(instructions, 0, wx.ALL | wx.EXPAND, 20)
 
@@ -340,6 +513,13 @@ class DemoFrame(wx.Frame):
         """Toggle the editable state of the 'Completed' DateTimeCombo."""
         currentState = self.completedCombo.IsEditable()
         self.completedCombo.SetEditable(not currentState)
+
+    def _onToggleDc3Completed(self, event):
+        """Toggle read-only/editable on the 3.5 Completed DateTimeCombo2."""
+        if self.dc3CompletedCombo.IsEditable():
+            self.dc3CompletedCombo.SetReadOnly()
+        else:
+            self.dc3CompletedCombo.SetEditable()
 
 
 def main():

--- a/taskcoachlib/domain/task/task.py
+++ b/taskcoachlib/domain/task/task.py
@@ -523,26 +523,30 @@ class Task(
 
     def _onCompletionDateTimeChanged(self, event):
         self.__status = None
-        if self.completed() and self.recurrence():
-            self.recur(self.completionDateTime())
+        # Use direct datetime comparison instead of self.completed() because
+        # computedStatus() cache is stale at this point (not yet recomputed).
+        completionDateTime = self.completionDateTime()
+        isCompleted = completionDateTime != self.maxDateTime
+        if isCompleted and self.recurrence():
+            self.recur(completionDateTime)
             return  # recur resets completionDateTime, triggering this callback again
         parent = self.parent()
-        if self.completed():
+        if isCompleted:
             self.setReminder(None)
             self.setPercentageComplete(100)
             for child in self.children():
-                if not child.completed():
+                if child.completionDateTime() == self.maxDateTime:
                     child.setRecurrence()
-                    child.setCompletionDateTime(self.completionDateTime())
+                    child.setCompletionDateTime(completionDateTime)
             if self.isBeingTracked():
                 self.stopTracking()
         elif self.percentageComplete() == 100:
             self.setPercentageComplete(0)
         if parent:
-            if self.completed():
+            if isCompleted:
                 if parent.shouldBeMarkedCompleted():
-                    parent.setCompletionDateTime(self.completionDateTime())
-            elif parent.completed():
+                    parent.setCompletionDateTime(completionDateTime)
+            elif parent.completionDateTime() != self.maxDateTime:
                 parent.setCompletionDateTime(self.maxDateTime)
             parent.sendPriorityChangedMessage()
         self.markDirty()

--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -1279,19 +1279,17 @@ class DatesPage(Page):
             minuteChoices=lambda: get_suggested_minute_choices(self._DatesPage__settings)
         )
         # Use AttributeSync for automatic external update handling
-        # Use EVT_KILL_FOCUS to sync on focus loss (same pattern as subject field)
+        # Sync on EVT_VALUE_CHANGED — fires on checkbox toggle AND date/time edits
         self._plannedStartDateTimeSync = attributesync.AttributeSync(
             "plannedStartDateTime",
             self._plannedStartDateTimeCombo,
             plannedStartDateTime,
             self.items,
             command.EditPlannedStartDateTimeCommand,
-            wx.EVT_KILL_FOCUS,
+            widgets.EVT_VALUE_CHANGED,
             self.items[0].plannedStartDateTimeChangedEventType(),
             callback=self.__onPlannedStartChanged,
         )
-        # Bind checkbox to track which date is activated first for auto mode detection
-        self._plannedStartDateTimeCombo.GetCheckBox().Bind(wx.EVT_CHECKBOX, self.__onPlannedStartCheckboxChanged)
         # Rebuild dropdown when focus leaves this field
         self._plannedStartDateTimeCombo.Bind(wx.EVT_KILL_FOCUS, self.__onDurationFieldKillFocus)
 
@@ -1410,19 +1408,17 @@ class DatesPage(Page):
             minuteChoices=lambda: get_suggested_minute_choices(self._DatesPage__settings)
         )
         # Use AttributeSync for automatic external update handling
-        # Use EVT_KILL_FOCUS to sync on focus loss (same pattern as subject field)
+        # Sync on EVT_VALUE_CHANGED — fires on checkbox toggle AND date/time edits
         self._dueDateTimeSync = attributesync.AttributeSync(
             "dueDateTime",
             self._dueDateTimeCombo,
             dueDateTime,
             self.items,
             command.EditDueDateTimeCommand,
-            wx.EVT_KILL_FOCUS,
+            widgets.EVT_VALUE_CHANGED,
             self.items[0].dueDateTimeChangedEventType(),
             callback=self.__onDueDateChanged,
         )
-        # Bind checkbox to track which date is activated first for auto mode detection
-        self._dueDateTimeCombo.GetCheckBox().Bind(wx.EVT_CHECKBOX, self.__onDueDateCheckboxChanged)
         # Rebuild dropdown when focus leaves this field
         self._dueDateTimeCombo.Bind(wx.EVT_KILL_FOCUS, self.__onDurationFieldKillFocus)
 
@@ -1456,31 +1452,23 @@ class DatesPage(Page):
             minuteChoices=lambda: get_suggested_minute_choices(self._DatesPage__settings)
         )
         # Use AttributeSync for automatic external update handling
-        # Use EVT_KILL_FOCUS to sync on focus loss (same pattern as subject field)
+        # Sync on EVT_VALUE_CHANGED — fires on checkbox toggle AND date/time edits
         self._actualStartDateTimeSync = attributesync.AttributeSync(
             "actualStartDateTime",
             self._actualStartDateTimeCombo,
             actualStartDateTime,
             self.items,
             command.EditActualStartDateTimeCommand,
-            wx.EVT_KILL_FOCUS,
+            widgets.EVT_VALUE_CHANGED,
             self.items[0].actualStartDateTimeChangedEventType(),
             callback=self.__onActualStartChanged,
         )
-        # Commit on checkbox toggle (same as focus loss)
-        self._actualStartDateTimeCombo.GetCheckBox().Bind(wx.EVT_CHECKBOX, self.__onActualStartCheckboxChanged)
 
         self.addEntry(
             _("Actual start date"),
             self._actualStartDateTimeCombo.CreateRowPanel(self),
             wx.StaticText(self, label=""),
         )
-
-    def __onActualStartCheckboxChanged(self, event):
-        """Handle actual start checkbox toggle."""
-        # Commit value to model immediately (checkbox toggle = focus loss)
-        self._actualStartDateTimeSync.commit()
-        event.Skip()
 
     def __onActualStartChanged(self, value):
         """AttributeSync callback for actual start date changes."""
@@ -1504,30 +1492,22 @@ class DatesPage(Page):
         )
 
         # Use AttributeSync for automatic external update handling
-        # Use EVT_KILL_FOCUS to sync on focus loss (same pattern as other date fields)
+        # Sync on EVT_VALUE_CHANGED — fires on checkbox toggle AND date/time edits
         self._completionDateTimeSync = attributesync.AttributeSync(
             "completionDateTime",
             self._completionDateTimeCombo,
             completionDateTime,
             self.items,
             command.EditCompletionDateTimeCommand,
-            wx.EVT_KILL_FOCUS,
+            widgets.EVT_VALUE_CHANGED,
             self.items[0].completionDateTimeChangedEventType(),
         )
-        # Commit on checkbox toggle (same as focus loss)
-        self._completionDateTimeCombo.GetCheckBox().Bind(wx.EVT_CHECKBOX, self.__onCompletionCheckboxChanged)
 
         self.addEntry(
             _("Completion date"),
             self._completionDateTimeCombo.CreateRowPanel(self),
             wx.StaticText(self, label=""),
         )
-
-    def __onCompletionCheckboxChanged(self, event):
-        """Handle completion checkbox toggle."""
-        # Commit value to model immediately (checkbox toggle = focus loss)
-        self._completionDateTimeSync.commit()
-        event.Skip()
 
     def addDateEntry(self, label, taskMethodName):
         """Add a date entry using the old DateTimeEntry control (for comparison)."""
@@ -1674,15 +1654,7 @@ class DatesPage(Page):
         )
         cmd.do()
 
-    def __onPlannedStartCheckboxChanged(self, event):
-        """Checkbox toggle does NOT trigger EVT_KILL_FOCUS — force commit."""
-        self._plannedStartDateTimeSync.commit()
-        event.Skip()
 
-    def __onDueDateCheckboxChanged(self, event):
-        """Checkbox toggle does NOT trigger EVT_KILL_FOCUS — force commit."""
-        self._dueDateTimeSync.commit()
-        event.Skip()
 
     def __onDurationFieldKillFocus(self, event):
         """Rebuild mode dropdown on focus loss."""
@@ -1724,11 +1696,11 @@ class DatesPage(Page):
 
     def __activateStartDate(self):
         """Activate Start-Date combo (step 2.1). Uses internally stored value."""
-        self._plannedStartDateTimeCombo.SetChecked(True)
+        self._plannedStartDateTimeCombo.ActivateValue()
 
     def __activateDueDate(self):
         """Activate Due-Date combo (step 3.1). Uses internally stored value."""
-        self._dueDateTimeCombo.SetChecked(True)
+        self._dueDateTimeCombo.ActivateValue()
 
     def __adjStartDate(self):
         """start = due - duration. Reads widgets, writes through command."""
@@ -1870,12 +1842,10 @@ class DatesPage(Page):
 
         if mode == "automatic":
             # Automatic | Editable | Editable | Editable
-            self._plannedStartDateTimeCombo.Enable(True)
-            self._plannedStartDateTimeCombo.SetEditable(True)
+            self._plannedStartDateTimeCombo.SetEditable()
             self._plannedDurationCtrl.Enable(True)
             self._plannedDurationCtrl.SetReadOnly(False)
-            self._dueDateTimeCombo.Enable(True)
-            self._dueDateTimeCombo.SetEditable(True)
+            self._dueDateTimeCombo.SetEditable()
 
         elif mode == "adjdue":
             # Adjust Due | Editable | Editable | Read-only
@@ -1883,12 +1853,10 @@ class DatesPage(Page):
                 log_step("WARNING: adjdue mode but Start-Date does not exist", prefix="DURATION")
             if not self.__dueDateExists():
                 log_step("WARNING: adjdue mode but Due-Date does not exist", prefix="DURATION")
-            self._plannedStartDateTimeCombo.Enable(True)
-            self._plannedStartDateTimeCombo.SetEditable(True)
+            self._plannedStartDateTimeCombo.SetEditable()
             self._plannedDurationCtrl.Enable(True)
             self._plannedDurationCtrl.SetReadOnly(False)
-            self._dueDateTimeCombo.Enable(True)
-            self._dueDateTimeCombo.SetEditable(False)  # Read-only
+            self._dueDateTimeCombo.SetReadOnly()
 
         elif mode == "adjstart":
             # Adjust Start | Read-only | Editable | Editable
@@ -1896,19 +1864,15 @@ class DatesPage(Page):
                 log_step("WARNING: adjstart mode but Start-Date does not exist", prefix="DURATION")
             if not self.__dueDateExists():
                 log_step("WARNING: adjstart mode but Due-Date does not exist", prefix="DURATION")
-            self._plannedStartDateTimeCombo.Enable(True)
-            self._plannedStartDateTimeCombo.SetEditable(False)  # Read-only
+            self._plannedStartDateTimeCombo.SetReadOnly()
             self._plannedDurationCtrl.Enable(True)
             self._plannedDurationCtrl.SetReadOnly(False)
-            self._dueDateTimeCombo.Enable(True)
-            self._dueDateTimeCombo.SetEditable(True)
+            self._dueDateTimeCombo.SetEditable()
 
         elif mode == "implicit":
             # Start and Due always Editable
-            self._plannedStartDateTimeCombo.Enable(True)
-            self._plannedStartDateTimeCombo.SetEditable(True)
-            self._dueDateTimeCombo.Enable(True)
-            self._dueDateTimeCombo.SetEditable(True)
+            self._plannedStartDateTimeCombo.SetEditable()
+            self._dueDateTimeCombo.SetEditable()
             if self.__startDateExists() and self.__dueDateExists():
                 # Both dates exist: Duration Read-only
                 self._plannedDurationCtrl.Enable(True)
@@ -2050,14 +2014,14 @@ class DatesPage(Page):
             minuteChoices=lambda: get_suggested_minute_choices(self._DatesPage__settings)
         )
         # Use AttributeSync for automatic external update handling
-        # Use EVT_KILL_FOCUS to sync on focus loss (same pattern as subject field)
+        # Sync on EVT_VALUE_CHANGED — fires on checkbox toggle AND date/time edits
         self._reminderDateTimeSync = attributesync.AttributeSync(
             "reminder",
             self._reminderDateTimeCombo,
             reminderDateTime,
             self.items,
             command.EditReminderDateTimeCommand,
-            wx.EVT_KILL_FOCUS,
+            widgets.EVT_VALUE_CHANGED,
             self.items[0].reminderChangedEventType(),
             callback=self.__onReminderChanged,
         )
@@ -2091,11 +2055,17 @@ class DatesPage(Page):
             entry.EVT_RECURRENCEENTRY,
             self.items[0].recurrenceChangedEventType(),
         )
-        self.addEntry(
-            _("Recurrence"),
-            self._recurrenceEntry,
-            flags=[None, wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_LEFT | wx.EXPAND],
-        )
+        # Place each recurrence sub-panel as its own grid row.
+        # "Recurrence" label on the first row; empty label on the rest.
+        recurrenceFlags = [None, wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_LEFT | wx.EXPAND]
+        panels = self._recurrenceEntry.getSubPanels()
+        for i, panel in enumerate(panels):
+            panel.Reparent(self)
+            self.addEntry(
+                _("Recurrence") if i == 0 else "",
+                panel,
+                flags=recurrenceFlags,
+            )
 
     def entries(self):
         # pylint: disable=E1101
@@ -3731,7 +3701,7 @@ class EffortEditBook(Page):
             secondChoices=lambda: get_suggested_second_choices(self._settings),
         )
         # Hide checkbox - start is always required
-        self._startDateTimeCombo.GetCheckBox().Hide()
+        self._startDateTimeCombo.HideCheckBox()
 
         self._startDateTimeSync = attributesync.AttributeSync(
             "getStart",
@@ -3739,7 +3709,7 @@ class EffortEditBook(Page):
             current_start_date_time,
             self.items,
             command.EditEffortStartDateTimeCommand,
-            wx.EVT_KILL_FOCUS,
+            widgets.EVT_VALUE_CHANGED,
             self.items[0].startChangedEventType(),
             callback=self.__onEffortStartChanged,
         )
@@ -3869,11 +3839,10 @@ class EffortEditBook(Page):
             current_stop_date_time,
             self.items,
             command.EditEffortStopDateTimeCommand,
-            wx.EVT_KILL_FOCUS,
+            widgets.EVT_VALUE_CHANGED,
             self.items[0].stopChangedEventType(),
             callback=self.__onEffortStopChanged,
         )
-        self._stopDateTimeCombo.GetCheckBox().Bind(wx.EVT_CHECKBOX, self.__onStopCheckboxChanged)
         self._stopNowButton = self.__create_stop_now_button()
 
         self.addEntry(
@@ -3919,11 +3888,6 @@ class EffortEditBook(Page):
         """Called when stop datetime is committed."""
         self.__syncEffortState(sourceField='stop')
 
-    def __onStopCheckboxChanged(self, event):
-        """Checkbox toggle does NOT trigger EVT_KILL_FOCUS — force commit."""
-        self._stopDateTimeSync.commit()
-        event.Skip()
-
     def __onEffortEntryModeChanged(self, event):
         """Handle switching between Standard and Retroactive entry modes."""
         self._effortEntryMode = self._effortEntryModeChoice.GetSelection()
@@ -3941,7 +3905,7 @@ class EffortEditBook(Page):
 
     def __stopDateExists(self):
         """Check if stop date is active."""
-        return self._stopDateTimeCombo.IsChecked()
+        return self._stopDateTimeCombo.IsActive()
 
     def __setEffortEntryMode(self, newMode):
         """Set entry mode, update dropdown, write through command.
@@ -4067,7 +4031,7 @@ class EffortEditBook(Page):
 
         if self._effortEntryMode == 0:  # 1. If Mode Standard
             # 1.3 Set Start-Date editable
-            self._startDateTimeCombo.SetEditable(True)
+            self._startDateTimeCombo.SetEditable()
             self._startFromLastEffortButton.Enable(
                 self._effortList.maxDateTime() is not None
             )
@@ -4144,7 +4108,7 @@ class EffortEditBook(Page):
 
         elif self._effortEntryMode == 1:  # 2. If Mode Retroactive
             # 2.3 Set Start-Date read-only
-            self._startDateTimeCombo.SetEditable(False)
+            self._startDateTimeCombo.SetReadOnly()
             self._startFromLastEffortButton.Enable(False)
             # 2.4 Set Duration editable
             self._effortDurationCtrl.Enable(True)
@@ -4197,7 +4161,7 @@ class EffortEditBook(Page):
         elif self._effortEntryMode == 2:  # 3. If Mode Implicit
             # 3.3 Set Presets dropdown disabled [Ref1]
             # 3.4 Set Start-Date editable
-            self._startDateTimeCombo.SetEditable(True)
+            self._startDateTimeCombo.SetEditable()
             self._startFromLastEffortButton.Enable(
                 self._effortList.maxDateTime() is not None
             )
@@ -4442,7 +4406,7 @@ class EffortEditBook(Page):
             now = date.DateTime.now()
             start_value = self._startDateTimeCombo.GetValue()
             stop_value = None
-            if self._stopDateTimeCombo.IsChecked():
+            if self._stopDateTimeCombo.IsActive():
                 stop_value = self._stopDateTimeCombo.GetValue()
             if stop_value is not None and start_value is not None and start_value >= stop_value:
                 warnings.append(_("Warning: start date-time is after the stop date-time!"))

--- a/taskcoachlib/gui/dialog/entry.py
+++ b/taskcoachlib/gui/dialog/entry.py
@@ -763,11 +763,7 @@ class RecurrenceEntry(wx.Panel):
             hourChoices=lambda: get_suggested_hour_choices(self._settings),
             minuteChoices=lambda: get_suggested_minute_choices(self._settings),
         )
-        # Bind checkbox toggle
-        self._recurrenceStopDateTimeCombo.GetCheckBox().Bind(
-            wx.EVT_CHECKBOX, self.onRecurrenceStopDateTimeChecked
-        )
-        # Bind value change
+        # Bind value change — fires on checkbox toggle AND date/time edits
         self._recurrenceStopDateTimeCombo.Bind(
             widgets.EVT_VALUE_CHANGED, self.onRecurrenceEdited
         )
@@ -792,17 +788,21 @@ class RecurrenceEntry(wx.Panel):
         )
         stopPanel.SetSizerAndFit(panelSizer)
 
-        panelSizer = wx.BoxSizer(wx.VERTICAL)
-        panelSizer.Add(recurrenceFrequencyPanel)
-        panelSizer.Add(self.verticalSpace)
-        panelSizer.Add(self._weekdayPanel)
-        panelSizer.Add(self.verticalSpace)
-        panelSizer.Add(schedulePanel)
-        panelSizer.Add(self.verticalSpace)
-        panelSizer.Add(maxPanel)
-        panelSizer.Add(stopPanel)
-        self.SetSizerAndFit(panelSizer)
+        # Store sub-panels for external layout (DatesPage places them as
+        # separate grid rows so they get the same spacing as other entries).
+        self._subPanels = [
+            recurrenceFrequencyPanel,
+            self._weekdayPanel,
+            schedulePanel,
+            maxPanel,
+            stopPanel,
+        ]
+        self.Hide()  # RecurrenceEntry itself is invisible; sub-panels are reparented
         self.SetValue(recurrence)
+
+    def getSubPanels(self):
+        """Return the list of sub-panels for external layout."""
+        return list(self._subPanels)
 
     def updateRecurrenceLabel(self):
         recurrenceDict = {
@@ -826,7 +826,11 @@ class RecurrenceEntry(wx.Panel):
     def onRecurrencePeriodEdited(self, event):
         recurrenceOn = event.String != _("None")
         self._maxRecurrenceCheckBox.Enable(recurrenceOn)
-        self._recurrenceStopDateTimeCombo.Enable(recurrenceOn)
+        if recurrenceOn:
+            self._recurrenceStopDateTimeCombo.SetEditable()
+        else:
+            self._recurrenceStopDateTimeCombo.DeactivateValue()
+            self._recurrenceStopDateTimeCombo.SetReadOnly()
         self._recurrenceFrequencyEntry.Enable(recurrenceOn)
         self._scheduleChoice.Enable(recurrenceOn)
         self._maxRecurrenceCountEntry.Enable(
@@ -839,10 +843,6 @@ class RecurrenceEntry(wx.Panel):
         maxRecurrenceOn = event.IsChecked()
         self._maxRecurrenceCountEntry.Enable(maxRecurrenceOn)
         self.onRecurrenceEdited()
-
-    def onRecurrenceStopDateTimeChecked(self, event):
-        self.onRecurrenceEdited()
-        event.Skip()  # Allow checkbox to update visual state
 
     def onRecurrenceEdited(self, event=None):  # pylint: disable=W0613
         wx.PostEvent(self, RecurrenceEntryEvent())
@@ -871,11 +871,16 @@ class RecurrenceEntry(wx.Panel):
             1 if recurrence.recurBasedOnCompletion else 0
         )
         self._scheduleChoice.Enable(bool(recurrence))
-        self._recurrenceStopDateTimeCombo.Enable(bool(recurrence))
-        has_stop_datetime = recurrence.stop_datetime != date.DateTime()
-        self._recurrenceStopDateTimeCombo.SetChecked(has_stop_datetime)
-        if has_stop_datetime:
-            self._recurrenceStopDateTimeCombo.SetValue(recurrence.stop_datetime)
+        if bool(recurrence):
+            self._recurrenceStopDateTimeCombo.SetEditable()
+            has_stop_datetime = recurrence.stop_datetime != date.DateTime()
+            if has_stop_datetime:
+                self._recurrenceStopDateTimeCombo.SetValue(recurrence.stop_datetime)
+            else:
+                self._recurrenceStopDateTimeCombo.DeactivateValue()
+        else:
+            self._recurrenceStopDateTimeCombo.DeactivateValue()
+            self._recurrenceStopDateTimeCombo.SetReadOnly()
         self.updateRecurrenceLabel()
 
     def GetValue(self):
@@ -894,7 +899,7 @@ class RecurrenceEntry(wx.Panel):
         kwargs["amount"] = self._recurrenceFrequencyEntry.Value
         kwargs["sameWeekday"] = self._recurrenceSameWeekdayCheckBox.IsChecked()
         kwargs["recurBasedOnCompletion"] = bool(self._scheduleChoice.Selection)
-        if self._recurrenceStopDateTimeCombo.IsChecked():
+        if self._recurrenceStopDateTimeCombo.IsActive():
             kwargs["stop_datetime"] = self._recurrenceStopDateTimeCombo.GetValue()
         # Get selected weekdays (0-6 for Mon-Sun)
         kwargs["weekdays"] = [

--- a/taskcoachlib/gui/dialog/preferences.py
+++ b/taskcoachlib/gui/dialog/preferences.py
@@ -1463,15 +1463,15 @@ class LanguagePage(SettingsPage):
         self.addEntry(_("Date format:"), dateFormatPanel,
                       flags=(wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, wx.ALIGN_LEFT))
 
-        # Demo DateCtrl showing the selected format (interactive, starts with today)
-        from taskcoachlib.widgets.maskedtimectrl import DateCtrl
+        # Demo DateCtrl4 showing the selected format (interactive, starts with today)
+        from taskcoachlib.widgets.maskedtimectrl import DateCtrl4
         import datetime
         today = datetime.date.today()
         demoPanel = wx.Panel(self)
         demoSizer = wx.BoxSizer(wx.HORIZONTAL)
         demoLabel = wx.StaticText(demoPanel, label=_("Preview:"))
         demoSizer.Add(demoLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10)
-        self._demoDateCtrl = DateCtrl(
+        self._demoDateCtrl = DateCtrl4(
             demoPanel,
             year=today.year, month=today.month, day=today.day,
             dateFormat=currentFormat or None
@@ -1677,8 +1677,8 @@ class LanguagePage(SettingsPage):
         choice = event.GetEventObject()
         newFormat = choice.GetClientData(choice.GetSelection())
 
-        # Recreate the demo DateCtrl with new format, using today's date
-        from taskcoachlib.widgets.maskedtimectrl import DateCtrl
+        # Recreate the demo DateCtrl4 with new format, using today's date
+        from taskcoachlib.widgets.maskedtimectrl import DateCtrl4
         import datetime
         today = datetime.date.today()
         parent = self._demoDateCtrl.GetParent()
@@ -1686,7 +1686,7 @@ class LanguagePage(SettingsPage):
 
         # Destroy old and create new with today's date
         self._demoDateCtrl.Destroy()
-        self._demoDateCtrl = DateCtrl(
+        self._demoDateCtrl = DateCtrl4(
             parent,
             year=today.year,
             month=today.month,

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,11 +41,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "57"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.1.57
+patch = "58"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.1.58
 
-release_day = "30"  # Day of the release (1-31)
-release_month = "January"  # Month of the release
+release_day = "1"  # Day of the release (1-31)
+release_month = "February"  # Month of the release
 release_year = "2026"  # Year of the release
 
 # =============================================================================

--- a/taskcoachlib/widgets/__init__.py
+++ b/taskcoachlib/widgets/__init__.py
@@ -33,8 +33,8 @@ from .maskedtimectrl import (
     DurationCtrlVerbose as MaskedDurationCtrlVerbose,
     TimeCtrl as MaskedTimeCtrl,
     TimeWithSecondsCtrl as MaskedTimeWithSecondsCtrl,
-    DateCtrl as MaskedDateCtrl,
-    DateTimeCombo,
+    DateCtrl4 as MaskedDateCtrl,
+    DateTimeCombo2 as DateTimeCombo,
     EVT_VALUE_CHANGED,
 )
 from .textctrl import (

--- a/taskcoachlib/widgets/maskedtimectrl.py
+++ b/taskcoachlib/widgets/maskedtimectrl.py
@@ -76,6 +76,7 @@ from pubsub import pub
 
 from taskcoachlib.i18n import _
 from taskcoachlib.domain import date
+from taskcoachlib.meta.debug import log_step
 
 
 # =============================================================================
@@ -1337,6 +1338,7 @@ class FieldsCtrl(wx.Panel):
         # Get margin from system metrics for native look
         self.MARGIN, _ = getTextCtrlContentOffset()
 
+        self._drawFrame = True  # Draw own frame; False when inside ComboCtrl
         self._fields = {}  # name -> NumericField
         self._fieldList = []  # All NumericField objects in order
         self._widgets = []  # (item, x, y, w, h) - item is Field or string
@@ -1395,11 +1397,9 @@ class FieldsCtrl(wx.Panel):
                 minH = max(minH, h)
                 curX += w
 
-        # Set minimum size
-        self.SetMinSize(wx.Size(
-            curX + self.MARGIN,
-            minH + 2 * self.MARGIN
-        ))
+        # Set minimum size and remember the natural content size for centering
+        self._naturalSize = wx.Size(curX + self.MARGIN, minH + 2 * self.MARGIN)
+        self.SetMinSize(self._naturalSize)
 
         # Focus first field
         if self._fieldList:
@@ -1418,15 +1418,19 @@ class FieldsCtrl(wx.Panel):
         hasFocus = self._hasFocus
 
         # Draw native text control border using system theme
-        flags = 0
-        if hasFocus and not self._readOnly:
-            flags |= wx.CONTROL_FOCUSED
-        if not self.IsEnabled() or self._readOnly:
-            flags |= wx.CONTROL_DISABLED
-
-        wx.RendererNative.Get().DrawTextCtrl(self, dc, wx.Rect(0, 0, w, h), flags)
+        # (skip when embedded inside ComboCtrl which provides its own frame)
+        if self._drawFrame:
+            flags = 0
+            if hasFocus and not self._readOnly:
+                flags |= wx.CONTROL_FOCUSED
+            if not self.IsEnabled() or self._readOnly:
+                flags |= wx.CONTROL_DISABLED
+            wx.RendererNative.Get().DrawTextCtrl(self, dc, wx.Rect(0, 0, w, h), flags)
 
         dc.SetFont(self.GetFont())
+
+        # Offset to center content when control is larger than minimum
+        xOff, yOff = self._getContentOffset()
 
         if self.IsEnabled() and not self._readOnly:
             # Normal editable mode - show values
@@ -1434,17 +1438,17 @@ class FieldsCtrl(wx.Panel):
             for widget, x, y, ww, hh in self._widgets:
                 if isinstance(widget, str):
                     dc.SetTextForeground(textColour)
-                    dc.DrawText(widget, int(x), int(y))
+                    dc.DrawText(widget, int(x + xOff), int(y + yOff))
                 else:
                     # NumericField - draw focus highlight only if focused
                     if widget == self._focus and hasFocus:
-                        drawFocusRect(self, dc, x, y, ww, hh)
+                        drawFocusRect(self, dc, x + xOff, y + yOff, ww, hh)
                         dc.SetTextForeground(
                             wx.SystemSettings.GetColour(wx.SYS_COLOUR_HIGHLIGHTTEXT)
                         )
                     else:
                         dc.SetTextForeground(textColour)
-                    widget.PaintValue(dc, x, y, ww, hh)
+                    widget.PaintValue(dc, x + xOff, y + yOff, ww, hh)
         elif not self.IsEnabled():
             # Disabled mode (unchecked checkbox) - show "N/A" centered
             # Values are preserved internally but hidden behind "N/A"
@@ -1459,9 +1463,9 @@ class FieldsCtrl(wx.Panel):
             dc.SetTextForeground(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
             for widget, x, y, ww, hh in self._widgets:
                 if isinstance(widget, str):
-                    dc.DrawText(widget, int(x), int(y))
+                    dc.DrawText(widget, int(x + xOff), int(y + yOff))
                 else:
-                    widget.PaintValue(dc, x, y, ww, hh)
+                    widget.PaintValue(dc, x + xOff, y + yOff, ww, hh)
 
     def _onChar(self, event):
         keyCode = event.GetKeyCode()
@@ -1546,17 +1550,26 @@ class FieldsCtrl(wx.Panel):
         """Open dropdown popup for currently focused field."""
         if not self._focus:
             return
+        xOff, yOff = self._getContentOffset()
         # Find the widget entry for the focused field
         for widget, x, y, w, h in self._widgets:
             if widget == self._focus:
                 choices = self._focus.GetChoices()
                 if choices:
-                    self._showPopup(self._focus, choices, x, y, w, h)
+                    self._showPopup(self._focus, choices, x + xOff, y + yOff, w, h)
                 break
 
     # Time thresholds for focus and popup behavior (in seconds)
     FOCUS_DELAY = 0.05  # Minimum time before showing popup after focus
     POPUP_TOGGLE_DELAY = 0.2  # Time window to detect click-to-close toggle
+
+    def _getContentOffset(self):
+        """Offset to center content when control is larger than natural size."""
+        cw, ch = self.GetClientSize()
+        mw, mh = self._naturalSize
+        xOff = max(0, (cw - mw) // 2) if cw > mw else 0
+        yOff = max(0, (ch - mh) // 2) if ch > mh else 0
+        return xOff, yOff
 
     def _onLeftUp(self, event):
         pt = event.GetPosition()
@@ -1566,10 +1579,11 @@ class FieldsCtrl(wx.Panel):
             event.Skip()
             return
 
+        xOff, yOff = self._getContentOffset()
         # Find which widget was clicked
         for widget, x, y, w, h in self._widgets:
             if isinstance(widget, NumericField):
-                if x <= pt.x <= x + w and y <= pt.y <= y + h:
+                if (x + xOff) <= pt.x <= (x + xOff) + w and (y + yOff) <= pt.y <= (y + yOff) + h:
                     # Set focus to this field
                     self._focus = widget
                     self._focus.ResetState()
@@ -1592,7 +1606,7 @@ class FieldsCtrl(wx.Panel):
                         if time.time() - self._focusStamp >= self.FOCUS_DELAY:
                             choices = widget.GetChoices()
                             if choices:
-                                self._showPopup(widget, choices, x, y, w, h)
+                                self._showPopup(widget, choices, x + xOff, y + yOff, w, h)
 
                     self.Refresh()
                     return
@@ -2451,6 +2465,757 @@ class DateCtrl(FieldsCtrl):
         self.SetFieldValue('date_day', d.day)
 
 
+class _CalendarComboPopup(wx.ComboPopup):
+    """ComboPopup adapter for the custom-painted calendar.
+
+    Wraps the same calendar painting/interaction logic from _CalendarPopup
+    into the wx.ComboPopup interface, so it can be used with wx.ComboCtrl.
+    The ComboCtrl provides the native dropdown button and manages the popup
+    window (including Wayland-safe positioning).
+    """
+
+    def __init__(self, minDate=None, maxDate=None):
+        super().__init__()
+        self._minDate = minDate
+        self._maxDate = maxDate
+        self._panel = None
+        self._selection = datetime.date.today()
+        self._highlightedDate = self._selection
+        self._originalDate = self._selection
+        self._year = self._selection.year
+        self._month = self._selection.month
+        self._maxDim = None
+        self._font = None
+        self._days = []
+        self._win = None
+        self._contentOffsetX = 0
+        self._contentOffsetY = 0
+
+    def Create(self, parent):
+        self._panel = wx.Panel(parent, style=wx.BORDER_NONE)
+        self._panel.Bind(wx.EVT_PAINT, self._onPaint)
+        self._panel.Bind(wx.EVT_LEFT_UP, self._onLeftUp)
+        self._panel.Bind(wx.EVT_MOTION, self._onMotion)
+        self._panel.Bind(wx.EVT_LEAVE_WINDOW, self._onLeaveWindow)
+        self._panel.Bind(wx.EVT_CHAR, self._onChar)
+        pub.subscribe(self._onColoursChanged, 'calendar.colours.changed')
+        return True
+
+    def GetControl(self):
+        return self._panel
+
+    def SetStringValue(self, val):
+        """Parse date string from ComboCtrl text field."""
+        pass  # We don't use the text field for date parsing
+
+    def GetStringValue(self):
+        """Return selected date as string."""
+        return str(self._highlightedDate) if self._highlightedDate else ''
+
+    def GetAdjustedSize(self, minWidth, prefHeight, maxHeight):
+        if self._panel is None:
+            return wx.Size(minWidth, prefHeight)
+        dc = wx.ClientDC(self._panel)
+        size = self._getExtent(dc)
+        return size
+
+    def _getDateCtrl2(self):
+        """Get the DateCtrl4 (ComboCtrl) that owns this popup."""
+        combo = self.GetComboCtrl()
+        if combo:
+            if hasattr(combo, '_dateCtrl') and hasattr(combo, '_setDateFromCalendar'):
+                return combo
+        return None
+
+    def OnPopup(self):
+        """Called when popup is shown — sync selection from parent or text."""
+        dc2 = self._getDateCtrl2()
+        if dc2:
+            self._selection = dc2._dateCtrl.GetDate()
+            self._font = dc2._dateCtrl.GetFont()
+        else:
+            # Standalone ComboCtrl — try to parse date from text field
+            combo = self.GetComboCtrl()
+            if combo:
+                self._font = combo.GetFont()
+                text = combo.GetValue().strip()
+                if text:
+                    try:
+                        self._selection = datetime.date.fromisoformat(text)
+                    except (ValueError, AttributeError):
+                        pass
+        self._originalDate = self._selection
+        self._highlightedDate = self._selection
+        self._year = self._selection.year
+        self._month = self._selection.month
+        if self._panel:
+            dc = wx.ClientDC(self._panel)
+            self._panel.SetMinSize(self._getExtent(dc))
+
+    def OnDismiss(self):
+        """Called when popup is hidden."""
+        pass
+
+    def DestroyPopup(self):
+        pub.unsubscribe(self._onColoursChanged, 'calendar.colours.changed')
+
+    def _onColoursChanged(self):
+        if self._panel:
+            self._panel.Refresh()
+
+    def _onChar(self, event):
+        keyCode = event.GetKeyCode()
+        if keyCode in (wx.WXK_ESCAPE, wx.WXK_F4):
+            self.Dismiss()
+        elif keyCode == wx.WXK_RETURN:
+            dc2 = self._getDateCtrl2()
+            if dc2:
+                dc2._setDateFromCalendar(self._highlightedDate)
+            self.Dismiss()
+        elif keyCode == wx.WXK_LEFT:
+            self._moveHighlight(datetime.timedelta(days=-1))
+        elif keyCode == wx.WXK_RIGHT:
+            self._moveHighlight(datetime.timedelta(days=1))
+        elif keyCode == wx.WXK_UP:
+            self._moveHighlight(datetime.timedelta(days=-7))
+        elif keyCode == wx.WXK_DOWN:
+            self._moveHighlight(datetime.timedelta(days=7))
+        else:
+            event.Skip()
+
+    def _moveHighlight(self, delta):
+        newDate = self._highlightedDate + delta
+        if self._minDate is not None and newDate < self._minDate:
+            wx.Bell()
+            return
+        if self._maxDate is not None and newDate > self._maxDate:
+            wx.Bell()
+            return
+        if newDate.year < 1 or newDate.year > 9999:
+            wx.Bell()
+            return
+        self._highlightedDate = newDate
+        if self._highlightedDate.year != self._year or self._highlightedDate.month != self._month:
+            self._year = self._highlightedDate.year
+            self._month = self._highlightedDate.month
+            dc = wx.ClientDC(self._panel)
+            self._panel.SetMinSize(self._getExtent(dc))
+            self._panel.GetParent().Layout()
+        self._panel.Refresh()
+
+    # --- Calendar painting and interaction (same logic as _CalendarPopup) ---
+
+    def _getExtent(self, dc):
+        if self._font:
+            dc.SetFont(self._font)
+        W, H = 0, 0
+        for month in range(1, 13):
+            header = datetime.date(year=self._year, month=month, day=11).strftime("%B %Y")
+            tw, th = dc.GetTextExtent(header)
+            W = max(W, tw)
+            H = max(H, th)
+
+        lines = monthcalendarex(self._year, self._month, weeks=1)
+        self._maxDim = 0
+        for line in lines:
+            for year, month, day in line:
+                tw, th = dc.GetTextExtent("%d" % day)
+                self._maxDim = max(self._maxDim, tw, th)
+
+        for hdr in calendar.weekheader(2).split():
+            tw, th = dc.GetTextExtent(hdr)
+            self._maxDim = max(self._maxDim, tw, th)
+
+        self._maxDim += 4
+        contentOffsetX, contentOffsetY = getTextCtrlContentOffset()
+        return wx.Size(
+            max(W + 48 + 4, self._maxDim * len(lines[0])) + contentOffsetX * 2,
+            H + 2 + self._maxDim * (len(lines) + 1) + contentOffsetY * 2,
+        )
+
+    def _onPaint(self, event):
+        win = event.GetEventObject()
+        dc = wx.PaintDC(win)
+        w, h = win.GetClientSize()
+        renderer = wx.RendererNative.Get()
+
+        renderer.DrawTextCtrl(win, dc, wx.Rect(0, 0, w, h), wx.CONTROL_FOCUSED)
+
+        contentOffsetX, contentOffsetY = getTextCtrlContentOffset()
+        contentW = w - contentOffsetX * 2
+
+        if self._font:
+            dc.SetFont(self._font)
+        self._win = win
+        self._contentOffsetX = contentOffsetX
+        self._contentOffsetY = contentOffsetY
+
+        colours = getCalendarColours()
+
+        textColour = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOWTEXT)
+        dc.SetPen(wx.Pen(textColour))
+        dc.SetBrush(wx.Brush(textColour))
+        dc.SetTextForeground(textColour)
+
+        header = datetime.date(year=self._year, month=self._month, day=1).strftime("%B %Y")
+        tw, th = dc.GetTextExtent(header)
+        dc.DrawText(header, contentOffsetX + (contentW - 48 - tw) // 2, contentOffsetY)
+
+        buttonDim = min(th, 10)
+
+        cx = w - contentOffsetX - 24
+        cy = contentOffsetY + th // 2 + 1
+
+        gc = wx.GraphicsContext.Create(dc)
+        gc.SetPen(gc.CreatePen(wx.Pen(textColour)))
+        gc.SetBrush(gc.CreateBrush(wx.Brush(textColour)))
+
+        # Prev month button (left arrow)
+        if self._month != 1 or self._year != 1:
+            gp = gc.CreatePath()
+            xinf = w - contentOffsetX - 48 + 16 - buttonDim
+            xsup = w - contentOffsetX - 48 + 16
+            yinf = contentOffsetY + th / 2 + 1 - buttonDim / 2
+            ysup = contentOffsetY + th / 2 + 1 + buttonDim / 2
+
+            gp.MoveToPoint(xinf, contentOffsetY + th // 2 + 1)
+            gp.AddArc(
+                cx, cy,
+                math.sqrt((xsup - cx) * (xsup - cx) + (yinf - cy) * (yinf - cy)),
+                math.pi * 3 / 4, math.pi * 5 / 4, True,
+            )
+            gc.DrawPath(gp)
+
+        # Next month button (right arrow)
+        if self._month != 12 or self._year != 9999:
+            gp = gc.CreatePath()
+            xinf = w - contentOffsetX - 16
+            xsup = w - contentOffsetX - 16 + buttonDim
+            yinf = contentOffsetY + th / 2 + 1 - buttonDim / 2
+
+            gp.MoveToPoint(xsup, contentOffsetY + th // 2 + 1)
+            gp.AddArc(
+                cx, cy,
+                math.sqrt((xinf - cx) * (xinf - cx) + (yinf - cy) * (yinf - cy)),
+                math.pi / 4, -math.pi / 4, False,
+            )
+            gc.DrawPath(gp)
+
+        # Today button (circle)
+        gp = gc.CreatePath()
+        gp.AddArc(cx, cy, buttonDim * 3 / 4, 0, math.pi * 2, True)
+        gc.DrawPath(gp)
+
+        y = contentOffsetY + th + 2
+
+        # Weekday headers
+        hdrBg = colours['weekday_header_bg']
+        dc.SetPen(wx.Pen(hdrBg))
+        dc.SetBrush(wx.Brush(hdrBg))
+        dc.DrawRectangle(contentOffsetX, y, self._maxDim * 7, self._maxDim)
+        dc.SetTextForeground(colours['weekday_header_fg'])
+        for idx, hdr in enumerate(calendar.weekheader(2).split()):
+            tw, th_hdr = dc.GetTextExtent(hdr)
+            dc.DrawText(
+                hdr,
+                contentOffsetX + self._maxDim * idx + int((self._maxDim - tw) // 2),
+                y + int((self._maxDim - th_hdr) // 2),
+            )
+
+        y += self._maxDim
+
+        # Days
+        self._days = []
+        for line in monthcalendarex(self._year, self._month, weeks=1):
+            x = contentOffsetX
+            for dayIndex, (year, month, day) in enumerate(line):
+                dt = datetime.date(year=year, month=month, day=day)
+                active = (self._minDate is None or dt >= self._minDate) and (
+                    self._maxDate is None or dt <= self._maxDate
+                )
+                thisMonth = year == self._year and month == self._month
+
+                dc.SetPen(wx.Pen(textColour))
+                dc.SetTextForeground(
+                    colours['weekend_day_fg'] if (dayIndex + calendar.firstweekday()) % 7 in [5, 6] else textColour
+                )
+
+                if not active:
+                    inactiveBg = wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE)
+                    dc.SetPen(wx.Pen(inactiveBg))
+                    dc.SetBrush(wx.Brush(inactiveBg))
+                    dc.DrawRectangle(x, y, self._maxDim, self._maxDim)
+                elif not thisMonth:
+                    otherMonthBg = colours['other_month_bg'] if colours['other_month_bg'] is not None else wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE)
+                    dc.SetPen(wx.Pen(otherMonthBg))
+                    dc.SetBrush(wx.Brush(otherMonthBg))
+                    dc.DrawRectangle(x, y, self._maxDim, self._maxDim)
+
+                isHighlighted = (dt == self._highlightedDate and active)
+
+                if isHighlighted:
+                    drawFocusRect(self._win, dc, x, y, self._maxDim, self._maxDim)
+                    dc.SetTextForeground(
+                        wx.SystemSettings.GetColour(wx.SYS_COLOUR_HIGHLIGHTTEXT)
+                    )
+
+                now = datetime.datetime.now()
+                if (dt.year, dt.month, dt.day) == (now.year, now.month, now.day):
+                    dc.SetPen(wx.Pen(colours['today_border']))
+                    dc.SetBrush(wx.TRANSPARENT_BRUSH)
+                    dc.DrawRectangle(x, y, self._maxDim, self._maxDim)
+
+                label = "%d" % day
+                tw, th_day = dc.GetTextExtent(label)
+                dc.DrawText(
+                    label,
+                    x + (self._maxDim - tw) // 2,
+                    y + (self._maxDim - th_day) // 2,
+                )
+
+                if active:
+                    self._days.append((x, y, (year, month, day)))
+                x += self._maxDim
+            y += self._maxDim
+
+    def _onLeftUp(self, event):
+        w, h = self._panel.GetClientSize()
+        contentOffsetX, contentOffsetY = getTextCtrlContentOffset()
+
+        dc = wx.ClientDC(self._panel)
+        if self._font:
+            dc.SetFont(self._font)
+        header = datetime.date(year=self._year, month=self._month, day=1).strftime("%B %Y")
+        tw, th = dc.GetTextExtent(header)
+
+        # Buttons area (top right)
+        if event.GetY() < contentOffsetY + th + 2 and event.GetX() > w - contentOffsetX - 48:
+            if event.GetX() < w - contentOffsetX - 48 + 16 and (self._month != 1 or self._year != 1):
+                if self._month == 1:
+                    self._year -= 1
+                    self._month = 12
+                else:
+                    self._month -= 1
+            elif event.GetX() < w - contentOffsetX - 48 + 32:
+                today = datetime.datetime.now()
+                self._year = today.year
+                self._month = today.month
+            elif self._month != 12 or self._year != 9999:
+                if self._month == 12:
+                    self._year += 1
+                    self._month = 1
+                else:
+                    self._month += 1
+            dc2 = wx.ClientDC(self._panel)
+            self._panel.SetMinSize(self._getExtent(dc2))
+            self._panel.GetParent().Layout()
+            self._panel.Refresh()
+            return
+
+        # Day selection
+        for x, y, (year, month, day) in self._days:
+            if (
+                event.GetX() >= x
+                and event.GetX() < x + self._maxDim
+                and event.GetY() >= y
+                and event.GetY() < y + self._maxDim
+            ):
+                dc2 = self._getDateCtrl2()
+                if dc2:
+                    dc2._setDateFromCalendar(
+                        datetime.date(year=year, month=month, day=day)
+                    )
+                self.Dismiss()
+                break
+
+    def _onMotion(self, event):
+        newHighlight = None
+        for x, y, (year, month, day) in self._days:
+            if (
+                event.GetX() >= x
+                and event.GetX() < x + self._maxDim
+                and event.GetY() >= y
+                and event.GetY() < y + self._maxDim
+            ):
+                newHighlight = datetime.date(year=year, month=month, day=day)
+                break
+        if newHighlight is not None and newHighlight != self._highlightedDate:
+            self._highlightedDate = newHighlight
+            self._panel.Refresh()
+
+    def _onLeaveWindow(self, event):
+        pass
+
+
+class _EmbeddedDateCtrl(FieldsCtrl):
+    """Date control designed for embedding inside a ComboCtrl.
+
+    A clean copy of DateCtrl with all popup/frame/calendar logic removed.
+    The parent ComboCtrl owns the dropdown — this control only handles
+    subfield editing, keyboard navigation, and date validation.
+
+    - No calendar popup (_showCalendarPopup, _onCalendarDismiss removed)
+    - No frame drawing (_drawFrame = False)
+    - No field dropdown popups (_openPopupForFocusedField = no-op)
+    - F4/Enter delegates to parent ComboCtrl.Popup()
+    - Click only changes subfield focus (no popup toggle)
+    """
+
+    def __init__(self, parent, comboCtrl, year=None, month=None, day=None,
+                 minDate=None, maxDate=None, dateFormat=None):
+        # Default to today's date
+        today = datetime.date.today()
+        if year is None:
+            year = today.year
+        if month is None:
+            month = today.month
+        if day is None:
+            day = today.day
+
+        self._minDate = minDate
+        self._maxDate = maxDate
+        self._comboCtrl = comboCtrl
+
+        # Get date format: use explicit override, or read from settings, or detect from locale
+        if dateFormat is not None:
+            field_order, separator = getLocaleDateFormat(override=dateFormat if dateFormat else None)
+        else:
+            field_order, separator = getEffectiveDateFormat()
+
+        # Map field names to their values
+        field_values = {
+            'year': year,
+            'month': month,
+            'date_day': day,
+        }
+
+        # Build elements list based on locale order
+        elements = []
+        for i, field_name in enumerate(field_order):
+            if i > 0:
+                elements.append(("literal", separator))
+            elements.append((field_name, field_values[field_name]))
+
+        super().__init__(parent, elements)
+        self._drawFrame = False
+
+    def _onPaint(self, event):
+        """Paint override for embedded context.
+
+        Uses IsThisEnabled() (own state) instead of IsEnabled() (parent chain)
+        so that disabling the parent ComboCtrl for read-only visuals doesn't
+        trigger the "N/A" branch. Only a direct Enable(False) on DateCtrl4
+        (which propagates to this control's own state) shows "N/A".
+
+        No frame drawing — the parent ComboCtrl provides the frame.
+        """
+        dc = wx.PaintDC(self)
+        w, h = self.GetClientSize()
+        dc.SetFont(self.GetFont())
+        xOff, yOff = self._getContentOffset()
+
+        if self._readOnly:
+            # Read-only: greyed values (standalone or inside disabled ComboCtrl)
+            dc.SetTextForeground(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
+            for widget, x, y, ww, hh in self._widgets:
+                if isinstance(widget, str):
+                    dc.DrawText(widget, int(x + xOff), int(y + yOff))
+                else:
+                    widget.PaintValue(dc, x + xOff, y + yOff, ww, hh)
+        elif not self.IsThisEnabled():
+            # Disabled (checkbox unchecked): show "N/A" centered
+            text = "N/A"
+            tw, th = dc.GetTextExtent(text)
+            dc.SetTextForeground(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
+            dc.DrawText(text, (w - tw) // 2, (h - th) // 2)
+        else:
+            # Normal editable
+            hasFocus = self._hasFocus
+            textColour = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOWTEXT)
+            for widget, x, y, ww, hh in self._widgets:
+                if isinstance(widget, str):
+                    dc.SetTextForeground(textColour)
+                    dc.DrawText(widget, int(x + xOff), int(y + yOff))
+                else:
+                    if widget == self._focus and hasFocus:
+                        drawFocusRect(self, dc, x + xOff, y + yOff, ww, hh)
+                        dc.SetTextForeground(
+                            wx.SystemSettings.GetColour(wx.SYS_COLOUR_HIGHLIGHTTEXT)
+                        )
+                    else:
+                        dc.SetTextForeground(textColour)
+                    widget.PaintValue(dc, x + xOff, y + yOff, ww, hh)
+
+    def _onChar(self, event):
+        """Handle keyboard input — F4/Enter open parent ComboCtrl popup."""
+        if not self._focus:
+            event.Skip()
+            return
+
+        keyCode = event.GetKeyCode()
+
+        # Tab exits control (always allowed, even in read-only mode)
+        if keyCode == wx.WXK_TAB:
+            self.Navigate(not event.ShiftDown())
+            return
+
+        # Block all other input in read-only mode
+        if self._readOnly:
+            return
+
+        # Escape — nothing to dismiss, let parent handle it
+        if keyCode == wx.WXK_ESCAPE:
+            event.Skip()
+            return
+
+        # F4/Enter open the parent ComboCtrl popup
+        if keyCode in (wx.WXK_RETURN, wx.WXK_NUMPAD_ENTER, wx.WXK_F4):
+            self._comboCtrl.Popup()
+            return
+
+        # Left/Right arrows navigate between subfields
+        if keyCode == wx.WXK_LEFT:
+            self._focusPrevField()
+            return
+        if keyCode == wx.WXK_RIGHT:
+            self._focusNextField()
+            return
+
+        # Let the focused field handle the key (Up/Down for increment/decrement)
+        if self._focus.HandleKey(event):
+            return
+
+        event.Skip()
+
+    def _onLeftUp(self, event):
+        """Click changes subfield focus only — no popup."""
+        if self._readOnly:
+            event.Skip()
+            return
+
+        pt = event.GetPosition()
+        xOff, yOff = self._getContentOffset()
+
+        for widget, x, y, w, h in self._widgets:
+            if isinstance(widget, NumericField):
+                if (x + xOff) <= pt.x <= (x + xOff) + w and (y + yOff) <= pt.y <= (y + yOff) + h:
+                    self._focus = widget
+                    self._focus.ResetState()
+                    self.SetFocus()
+                    self.Refresh()
+                    return
+
+        event.Skip()
+
+    def _openPopupForFocusedField(self):
+        """No-op — embedded control has no field dropdown popups."""
+        pass
+
+    def DismissPopup(self):
+        """No-op — embedded control owns no popups."""
+        pass
+
+    def ValidateChange(self, field, value):
+        """Validate date changes, adjusting day if needed for month/year changes."""
+        year = self.GetFieldValue('year')
+        month = self.GetFieldValue('month')
+        day = self.GetFieldValue('date_day')
+
+        max_day = calendar.monthrange(year, month)[1]
+        if day > max_day:
+            day = max_day
+            self.SetFieldValue('date_day', day)
+
+        return value
+
+    def GetDate(self):
+        """Get the current date value."""
+        return datetime.date(
+            year=self.GetFieldValue('year'),
+            month=self.GetFieldValue('month'),
+            day=self.GetFieldValue('date_day')
+        )
+
+    def SetDate(self, d):
+        """Set the date value.
+
+        Args:
+            d: datetime.date or None (defaults to today)
+        """
+        if d is None:
+            d = datetime.date.today()
+        self.SetFieldValue('year', d.year)
+        self.SetFieldValue('month', d.month)
+        self.SetFieldValue('date_day', d.day)
+
+
+class DateCtrl4(wx.ComboCtrl):
+    """Date control: _EmbeddedDateCtrl inside a ComboCtrl.
+
+    Uses _EmbeddedDateCtrl which has all popup/frame logic removed at the
+    class level. The ComboCtrl provides the native dropdown button and
+    manages popup positioning.
+    """
+
+    def __init__(self, parent, year=None, month=None, day=None,
+                 minDate=None, maxDate=None, dateFormat=None):
+        super().__init__(parent)
+
+        # Calendar popup via ComboPopup interface
+        self._calendarPopup = _CalendarComboPopup(
+            minDate=minDate, maxDate=maxDate
+        )
+        self.SetPopupControl(self._calendarPopup)
+
+        # Clean embedded DateCtrl — no monkey-patches needed
+        self._dateCtrl = _EmbeddedDateCtrl(
+            self, comboCtrl=self, year=year, month=month, day=day,
+            minDate=minDate, maxDate=maxDate, dateFormat=dateFormat
+        )
+
+        # Derive horizontal padding from the vertical padding the ComboCtrl
+        # naturally adds around the text area (theme-dependent).
+        dateW, dateH = self._dateCtrl._naturalSize
+        stdH = self.GetBestSize().height
+        self._padding = max(0, (stdH - dateH) // 2)
+        comboW = dateW + 2 * self._padding + self.GetButtonSize().width
+        self.SetMinSize(wx.Size(comboW, stdH))
+
+        # Redirect focus from ComboCtrl's text control to inner DateCtrl
+        # so the caret never appears in the hidden text field.
+        self._redirectingFocus = False
+        self._tabbingOut = False
+        self._popupWasShown = False
+        textCtrl = self.GetTextCtrl()
+        if textCtrl:
+            textCtrl.Bind(wx.EVT_SET_FOCUS, self._onTextCtrlFocus)
+
+        # Intercept Shift+Tab from inner DateCtrl: set _tabbingOut flag
+        # so _onTextCtrlFocus knows to pass focus through instead of
+        # redirecting back to DateCtrl.
+        origNavigate = self._dateCtrl.Navigate
+        def _navigateWithFlag(forward=True):
+            if not forward:
+                self._tabbingOut = True
+            return origNavigate(forward)
+        self._dateCtrl.Navigate = _navigateWithFlag
+
+        # Intercept any text the ComboCtrl auto-inserts (e.g. on popup dismiss)
+        self.Bind(wx.EVT_TEXT, self._onComboText)
+
+        # Track when popup opens (covers both F4/Enter and button click)
+        self.Bind(wx.EVT_COMBOBOX_DROPDOWN, self._onPopupOpen)
+
+        # Position the DateCtrl on resize
+        self.Bind(wx.EVT_SIZE, self._onSize)
+        # Also do initial positioning after layout settles
+        wx.CallAfter(self._positionDateCtrl)
+
+    def _onTextCtrlFocus(self, event):
+        """Redirect focus from ComboCtrl's text control to inner DateCtrl."""
+        if self._redirectingFocus:
+            return
+        if self._tabbingOut:
+            self._tabbingOut = False
+            wx.CallAfter(self.GetTextCtrl().Navigate, False)
+            return
+        if self._popupWasShown:
+            self._dateCtrl._returningFromPopup = True
+            self._popupWasShown = False
+        self._redirectingFocus = True
+        self._dateCtrl.SetFocus()
+        self._redirectingFocus = False
+
+    def _onComboText(self, event):
+        """Clear any text the ComboCtrl auto-inserts on popup dismiss."""
+        if self.GetValue():
+            self.ChangeValue('')
+
+    def _positionDateCtrl(self):
+        """Center the DateCtrl over the ComboCtrl's text area."""
+        if not self:
+            return
+        comboW, comboH = self.GetClientSize()
+        btnW = self.GetButtonSize().width
+        textAreaW = comboW - btnW
+        dateW, dateH = self._dateCtrl._naturalSize
+        x = (textAreaW - dateW) // 2
+        y = (comboH - dateH) // 2
+        self._dateCtrl.SetPosition(wx.Point(max(0, x), max(0, y)))
+        self._dateCtrl.SetSize(wx.Size(dateW, dateH))
+
+    def _onSize(self, event):
+        self._positionDateCtrl()
+        event.Skip()
+
+    def _onPopupOpen(self, event):
+        """Track that popup was shown, so we can restore subfield on dismiss."""
+        self._popupWasShown = True
+        event.Skip()
+
+    def _setDateFromCalendar(self, date):
+        """Called by _CalendarComboPopup when user selects a date."""
+        self._dateCtrl.SetDate(date)
+        self.ChangeValue('')
+        self._dateCtrl._returningFromPopup = True
+        wx.CallAfter(self._dateCtrl.SetFocus)
+
+    def DismissPopup(self):
+        """Dismiss any open popup."""
+        self.Dismiss()
+
+    # --- Delegate public API to inner DateCtrl ---
+
+    def GetDate(self):
+        return self._dateCtrl.GetDate()
+
+    def SetDate(self, d):
+        self._dateCtrl.SetDate(d)
+
+    def SetReadOnly(self, readOnly=True):
+        """Set read-only mode: values greyed but visible, dropdown disabled.
+
+        Disables the ComboCtrl (greys the dropdown button) and sets inner
+        _EmbeddedDateCtrl to read-only. The inner control's _onPaint uses
+        IsThisEnabled() so it shows greyed values, not "N/A", even though
+        the parent ComboCtrl is disabled.
+        """
+        self._dateCtrl.SetReadOnly(readOnly)
+        super().Enable(not readOnly)
+
+    def IsReadOnly(self):
+        return self._dateCtrl.IsReadOnly()
+
+    def HasOpenPopup(self):
+        """Return True if the calendar popup is currently shown."""
+        return self.IsPopupShown()
+
+    def _fireValueChanged(self):
+        """Delegate to inner _EmbeddedDateCtrl."""
+        self._dateCtrl._fireValueChanged()
+
+    def Bind(self, eventType, handler, source=None, id=wx.ID_ANY, id2=wx.ID_ANY):
+        """Forward UI events to inner _EmbeddedDateCtrl.
+
+        Events like EVT_VALUE_CHANGED, EVT_KEY_DOWN, EVT_KILL_FOCUS, and
+        EVT_SET_FOCUS fire on the inner control, not the ComboCtrl wrapper.
+        Other events (e.g. EVT_SIZE) go to the ComboCtrl itself.
+        """
+        if eventType in (EVT_VALUE_CHANGED, wx.EVT_KEY_DOWN,
+                         wx.EVT_KILL_FOCUS, wx.EVT_SET_FOCUS):
+            self._dateCtrl.Bind(eventType, handler, source, id, id2)
+        else:
+            super().Bind(eventType, handler, source, id, id2)
+
+    def Enable(self, enable=True):
+        """Enable or disable the control (shows N/A when disabled)."""
+        super().Enable(enable)
+        self._dateCtrl.Enable(enable)
+
+    def SetFocus(self):
+        self._dateCtrl.SetFocus()
+
+
 class DateTimeCombo:
     """Flexible date/time combo providing separate widgets for table layout.
 
@@ -2787,5 +3552,334 @@ class DateTimeCombo:
             self._checkbox.Bind(eventType, handler)
             self._dateCtrl.Bind(eventType, handler)
             self._timeCtrl.Bind(eventType, handler)
+
+
+class DateTimeCombo2:
+    """Date/time combo using DateCtrl4 (ComboCtrl-based date control).
+
+    Clean replacement for DateTimeCombo. Same API and behavior, but uses
+    DateCtrl4 instead of DateCtrl for the date field, giving native dropdown
+    button and Wayland-safe popup positioning.
+
+    Creates a checkbox, DateCtrl4, and TimeCtrl that are linked together.
+    The checkbox state is determined by the value:
+    - value=None -> checkbox unchecked, fields disabled (show "N/A")
+    - value=datetime -> checkbox checked, fields show that datetime
+
+    Three states:
+    1. Checked (normal): checkbox ON, fields enabled and editable
+    2. Unchecked: checkbox OFF, fields disabled, GetDateTime() returns None
+    3. Inactive (SetEditable(False)): checkbox ON but disabled, fields show
+       values greyed out (read-only), not editable
+
+    For flexible table layouts, get individual widgets with:
+    - GetCheckBox() - wx.CheckBox (no label)
+    - GetDateCtrl() - DateCtrl4
+    - GetTimeCtrl() - TimeCtrl or TimeWithSecondsCtrl
+
+    Args:
+        parent: Parent window for the widgets
+        value: datetime.datetime object, or None for unchecked state
+        hourChoices, minuteChoices: Dropdown choices for time fields
+        showSeconds: If True, use TimeWithSecondsCtrl (default False)
+        secondChoices: Dropdown choices for seconds field
+    """
+
+    def __init__(self, parent, value=None,
+                 hourChoices=None, minuteChoices=None,
+                 showSeconds=False, secondChoices=None):
+        self._parent = parent
+        self._showSeconds = showSeconds
+
+        checked = value is not None
+        display_value = value if value is not None else datetime.datetime.now()
+
+        self._checkbox = wx.CheckBox(parent)
+        self._checkbox.SetValue(checked)
+        self._checkbox.Bind(wx.EVT_CHECKBOX, self._onCheckboxChanged)
+
+        self._dateCtrl = DateCtrl4(parent, year=display_value.year,
+                                   month=display_value.month, day=display_value.day)
+
+        if showSeconds:
+            self._timeCtrl = TimeWithSecondsCtrl(
+                parent, hours=display_value.hour, minutes=display_value.minute,
+                seconds=display_value.second,
+                hourChoices=hourChoices, minuteChoices=minuteChoices,
+                secondChoices=secondChoices
+            )
+        else:
+            self._timeCtrl = TimeCtrl(
+                parent, hours=display_value.hour, minutes=display_value.minute,
+                hourChoices=hourChoices, minuteChoices=minuteChoices
+            )
+
+        self._readOnly = False
+        self._updateEnabled()
+
+    def _onCheckboxChanged(self, event):
+        """Handle checkbox state change — route through abstraction."""
+        if self._checkbox.GetValue():
+            self.ActivateValue()
+        else:
+            self.DeactivateValue()
+        self._dateCtrl._fireValueChanged()
+        event.Skip()
+
+    def _updateEnabled(self):
+        """Apply visual state based on checkbox + _readOnly flags.
+
+        This is the single authority for the visual state of all sub-controls.
+        SetEditable/SetReadOnly set flags and call this method.
+        """
+        checked = self._checkbox.GetValue()
+        self._checkbox.Enable(not self._readOnly)
+
+        if not checked:
+            # Unchecked: show "N/A". Clear read-only first so inner control
+            # paints "N/A" (not greyed values), then disable.
+            self._dateCtrl.SetReadOnly(False)
+            self._dateCtrl.Enable(False)
+            self._timeCtrl.SetReadOnly(False)
+            self._timeCtrl.Enable(False)
+        elif self._readOnly:
+            # Checked + read-only: re-enable from unchecked, then grey
+            self._dateCtrl.Enable(True)
+            self._dateCtrl.SetReadOnly(True)
+            self._timeCtrl.Enable(True)
+            self._timeCtrl.SetReadOnly(True)
+        else:
+            # Checked + editable: re-enable from unchecked
+            self._dateCtrl.Enable(True)
+            self._dateCtrl.SetReadOnly(False)
+            self._timeCtrl.Enable(True)
+            self._timeCtrl.SetReadOnly(False)
+
+    # Widget accessors (for layout only — use state methods for logic)
+    def GetCheckBox(self):
+        return self._checkbox
+
+    def GetDateCtrl(self):
+        return self._dateCtrl
+
+    def GetTimeCtrl(self):
+        return self._timeCtrl
+
+    def GetWidgets(self):
+        return (self._checkbox, self._dateCtrl, self._timeCtrl)
+
+    def HideCheckBox(self):
+        """Hide the checkbox for always-active controls (e.g. effort start)."""
+        self._checkbox.Hide()
+
+    def CreateRowPanel(self, parent=None):
+        """Create a panel containing checkbox + date + time in a horizontal row."""
+        if parent is None:
+            parent = self._parent
+
+        panel = wx.Panel(parent)
+        sizer = wx.BoxSizer(wx.HORIZONTAL)
+
+        self._checkbox.Reparent(panel)
+        self._dateCtrl.Reparent(panel)
+        self._timeCtrl.Reparent(panel)
+
+        sizer.Add(self._checkbox, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        sizer.Add(self._dateCtrl, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        sizer.Add(self._timeCtrl, 0, wx.ALIGN_CENTER_VERTICAL)
+
+        panel.SetSizer(sizer)
+
+        # Re-apply enabled state after reparenting. wx.ComboCtrl (DateCtrl4)
+        # loses its native visual state (button greying, background color)
+        # when reparented, because the platform re-creates theme state for
+        # the new parent hierarchy. FieldsCtrl-based controls don't have
+        # this issue since they paint everything in _onPaint.
+        self._updateEnabled()
+
+        return panel
+
+    def ContainsControl(self, ctrl):
+        return ctrl in (self._checkbox, self._dateCtrl, self._timeCtrl)
+
+    def HasOpenPopup(self):
+        """Return True if any child control has an open popup."""
+        # DateCtrl4 provides public HasOpenPopup()
+        if self._dateCtrl.HasOpenPopup():
+            return True
+        # TimeCtrl uses FieldsCtrl._popup (same module, acceptable)
+        if hasattr(self._timeCtrl, '_popup') and self._timeCtrl._popup is not None:
+            return True
+        return False
+
+    def Bind(self, eventType, handler, source=None, id=wx.ID_ANY, id2=wx.ID_ANY):
+        """Bind event handler to child controls.
+
+        Routing:
+        - EVT_VALUE_CHANGED: date + time, wrapped so event object is this combo
+        - Other events: all three widgets
+
+        Note: EVT_CHECKBOX is NOT exposed — the checkbox is an internal
+        implementation detail. All value changes (checkbox toggle, date edit,
+        time edit) fire EVT_VALUE_CHANGED.
+        """
+        if eventType == EVT_VALUE_CHANGED:
+            self._dateCtrl.Bind(eventType, handler)
+            self._timeCtrl.Bind(eventType, handler)
+        else:
+            self._checkbox.Bind(eventType, handler, source, id, id2)
+            self._dateCtrl.Bind(eventType, handler, source, id, id2)
+            self._timeCtrl.Bind(eventType, handler, source, id, id2)
+
+    # --- State transitions ---
+
+    def _setCheckboxState(self, checked):
+        """Set checkbox only if state differs (prevents recursive EVT_CHECKBOX)."""
+        if self._checkbox.GetValue() != checked:
+            self._checkbox.SetValue(checked)
+
+    def ActivateValue(self, value=None):
+        """Set the control to have a value (non-null).
+
+        Args:
+            value: datetime.datetime to set, or None to keep the internally
+                   stored value (typically now() from construction, or the
+                   last value before DeactivateValue was called).
+
+        Used by duration calc logic (steps 2.1, 3.1) to activate a missing
+        date without specifying a value. Also used by SetValue() to set a
+        specific datetime and activate in one call.
+        """
+        if value is not None:
+            self._dateCtrl.SetDate(value.date())
+            self._timeCtrl.SetTime(value.time())
+        self._setCheckboxState(True)
+        self._updateEnabled()
+
+    def DeactivateValue(self):
+        """Set the control to no value (null/cleared).
+
+        Values are preserved internally — ActivateValue restores the
+        previous value. Used by duration calc logic (steps 2.5.2, 3.5.2)
+        to deactivate a date.
+        """
+        self._setCheckboxState(False)
+        self._updateEnabled()
+
+    def IsActive(self):
+        """Return True if the control has an active value (non-null)."""
+        return self._checkbox.GetValue()
+
+    # Deprecated — log warning and delegate to new methods
+    def IsChecked(self):
+        log_step("DEPRECATED: IsChecked() — use IsActive()", prefix="DateTimeCombo2")
+        return self.IsActive()
+
+    def SetChecked(self, checked):
+        log_step("DEPRECATED: SetChecked() — use ActivateValue()/DeactivateValue()", prefix="DateTimeCombo2")
+        if checked:
+            self.ActivateValue()
+        else:
+            self.DeactivateValue()
+
+    def Activate(self):
+        log_step("DEPRECATED: Activate() — use ActivateValue()", prefix="DateTimeCombo2")
+        self.ActivateValue()
+
+    def Deactivate(self):
+        log_step("DEPRECATED: Deactivate() — use DeactivateValue()", prefix="DateTimeCombo2")
+        self.DeactivateValue()
+
+    def GetDateTime(self):
+        if not self._checkbox.GetValue():
+            return None
+        d = self._dateCtrl.GetDate()
+        t = self._timeCtrl.GetTime()
+        return datetime.datetime.combine(d, t)
+
+    def SetDateTime(self, dt):
+        log_step(
+            "DEPRECATED: SetDateTime() should not be called. "
+            "Use ActivateValue(datetime) to set a value, or "
+            "DeactivateValue() to clear it.",
+            prefix="DateTimeCombo2"
+        )
+
+    # Domain-compatible GetValue/SetValue for AttributeSync
+    def GetValue(self):
+        if not self._checkbox.GetValue():
+            return date.DateTime()
+        d = self._dateCtrl.GetDate()
+        t = self._timeCtrl.GetTime()
+        dt = datetime.datetime.combine(d, t)
+        return date.DateTime.fromDateTime(dt)
+
+    def SetValue(self, newValue):
+        if newValue is None or newValue == date.DateTime():
+            self.DeactivateValue()
+        else:
+            self.ActivateValue(datetime.datetime(
+                newValue.year, newValue.month, newValue.day,
+                newValue.hour, newValue.minute, newValue.second))
+
+    def GetDate(self):
+        return self._dateCtrl.GetDate()
+
+    def SetDate(self, d):
+        log_step(
+            "DEPRECATED: SetDate() should not be called. "
+            "Use ActivateValue(datetime) to set a value.",
+            prefix="DateTimeCombo2"
+        )
+
+    def GetTime(self):
+        return self._timeCtrl.GetTime()
+
+    def SetTime(self, t):
+        log_step(
+            "DEPRECATED: SetTime() should not be called. "
+            "Use ActivateValue(datetime) to set a value.",
+            prefix="DateTimeCombo2"
+        )
+
+    def GetChildren(self):
+        return [self._checkbox, self._dateCtrl, self._timeCtrl]
+
+    def GetId(self):
+        return self._checkbox.GetId()
+
+    def SetEditable(self):
+        """Make the combo editable.
+
+        - Checkbox enabled (user can toggle)
+        - Date/time fields editable with normal colors
+        - Dropdown button active
+        """
+        self._readOnly = False
+        self._updateEnabled()
+
+    def SetReadOnly(self):
+        """Make the combo read-only.
+
+        - Checkbox disabled (shows checked state, not clickable)
+        - Date/time fields show greyed values, not editable
+        - Dropdown button disabled
+        """
+        self._readOnly = True
+        self._updateEnabled()
+
+    def IsEditable(self):
+        """Return True if the combo is editable (not read-only)."""
+        return not self._readOnly
+
+    def IsReadOnly(self):
+        """Return True if the combo is read-only."""
+        return self._readOnly
+
+    def SetFocus(self):
+        if self._dateCtrl.IsEnabled():
+            self._dateCtrl.SetFocus()
+        else:
+            self._checkbox.SetFocus()
 
 

--- a/taskcoachlib/widgets/notebook.py
+++ b/taskcoachlib/widgets/notebook.py
@@ -54,7 +54,7 @@ class BookPage(wx.Panel):
     # Outer margin around page content (modern UI best practice: 10-12px)
     _outerMargin = 10
     # Grid spacing - subclasses can override
-    _vgap = 5
+    _vgap = 0
     _hgap = 5
     _borderWidth = 5
 
@@ -143,14 +143,13 @@ class BookPage(wx.Panel):
 
     def addLine(self):
         line = wx.StaticLine(self)
-        # No spacing above, regular spacing (10px) below
         colspan = max(self._columns, 1)
         self._sizer.Add(
             line,
             self._position.next(colspan),
             span=(1, colspan),
-            flag=wx.GROW | wx.ALIGN_CENTER_VERTICAL | wx.BOTTOM,
-            border=10,
+            flag=wx.GROW | wx.ALIGN_CENTER_VERTICAL | wx.TOP | wx.BOTTOM,
+            border=5,
         )
 
     def __addControl(self, columnIndex, control, flag, lastColumn):
@@ -175,7 +174,7 @@ class ScrolledBookPage(scrolledpanel.ScrolledPanel):
     # Outer margin around page content
     _outerMargin = 10
     # Grid spacing - subclasses can override
-    _vgap = 5
+    _vgap = 0
     _hgap = 5
     _borderWidth = 5
 
@@ -250,8 +249,8 @@ class ScrolledBookPage(scrolledpanel.ScrolledPanel):
             line,
             self._position.next(colspan),
             span=(1, colspan),
-            flag=wx.GROW | wx.ALIGN_CENTER_VERTICAL | wx.BOTTOM,
-            border=10,
+            flag=wx.GROW | wx.ALIGN_CENTER_VERTICAL | wx.TOP | wx.BOTTOM,
+            border=5,
         )
 
     def __addControl(self, columnIndex, control, flag, lastColumn):


### PR DESCRIPTION
New DateTimeCombo2 control replacing the old date/time entry widgets:
- Integrated checkbox + date picker + time control in a single widget
- Clean public API: ActivateValue/DeactivateValue, SetEditable/SetReadOnly
- EVT_VALUE_CHANGED fires on checkbox toggle and date/time edits
- _fireValueChanged delegation ensures AttributeSync receives all changes
- DateCtrl4 embedded date control with calendar popup

Fix broken task recurrence mechanism (regression from PR #338):
- _onCompletionDateTimeChanged used self.completed() which relies on stale computedStatus() cache, causing recurrence to be skipped when marking tasks complete and incorrectly triggered when unchecking
- Replace all completed() calls with direct datetime != maxDateTime comparisons, matching the original pre-refactor logic
- 168/168 recurrence tests pass

Editor dialog improvements:
- Wire DateTimeCombo2 into all date fields (dates tab, reminder, recurrence stop date, effort editor, preferences)
- Replace Enable(bool) with SetEditable/DeactivateValue+SetReadOnly for recurrence controls
- Break RecurrenceEntry sub-panels into separate grid rows for uniform spacing with other entries
- Remove vgap from BookPage/ScrolledBookPage GridBagSizer for tighter row spacing (10px row-to-row via borderWidth only)

Version bump to 2.0.1.58, update README package references.

recurrance totally broken https://github.com/taskcoach/taskcoach/issues/341
completion of parent tasks no longer completes the subtasks and other broken stuff https://github.com/taskcoach/taskcoach/issues/342
Request: preference settings for preferring typing vs pop-up for date/time fields https://github.com/taskcoach/taskcoach/issues/328
calendar/time popups far away from field https://github.com/taskcoach/taskcoach/issues/320