### PR TITLE
Fix preset/propose date defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.58-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.58-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.58_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.58_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.58_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.58-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.59-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.59-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.59_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.59_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.59_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.59-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.58-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.58-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.58_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.58_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.58-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.58-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.59-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.59-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.59_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.59_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.59-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.59-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.58_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.58_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.59_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.59_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.58-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.58-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.59-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.59-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.58-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.58-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.59-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.59-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.58-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.58-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.59-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.59-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.58-x86_64.AppImage
+./TaskCoach-2.0.1.59-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/docs/DATETIME_PRESETS.md
+++ b/docs/DATETIME_PRESETS.md
@@ -1,0 +1,358 @@
+# DateTime Presets and Proposed Dates
+
+Default date/time values for new tasks, configured in Preferences.
+
+## Index
+
+- [TODO](#todo)
+- [Overview](#overview)
+- [Preference Setting Format](#preference-setting-format)
+- [Preset Mode](#preset-mode)
+  - [Flow](#flow)
+  - [Constructor Bypass Problem](#constructor-bypass-problem)
+  - [Completion Date Preset](#completion-date-preset)
+  - [Reminder Preset](#reminder-preset)
+- [Propose Mode](#propose-mode)
+  - [Old Behavior (DateTimeEntry)](#old-behavior-datetimeentry)
+  - [Current Bug (DateTimeCombo2)](#current-bug-datetimecombo2)
+  - [Fix](#fix)
+- [Duration Mode Interaction](#duration-mode-interaction)
+- [Suggested DateTime Computation](#suggested-datetime-computation)
+- [Reminder Scheduling on Load](#reminder-scheduling-on-load)
+- [Related Documentation](#related-documentation)
+
+---
+
+## TODO
+
+1. **Unify preset and propose paths through the Attribute model or
+   DateTimeCombo2 public API.** Currently, preset mode writes directly to
+   the Task constructor kwargs (`uicommand.py:1693-1708`), bypassing both
+   the Attribute setter/callback chain and the editor widget API. Propose
+   mode relies on the editor widget to pre-fill a display value. These two
+   paths should be consolidated so that both modes go through the same
+   public interface — either:
+   - The Attribute model (setter + callback), so all domain invariants
+     (recurrence, reminder clearing, child completion) fire correctly; or
+   - A new `DateTimeCombo2` method such as
+     `ActivateValue(value, proposed=True)` + `DeactivateValue()`, where
+     `proposed=True` means: set the internal display value and mark the
+     checkbox checked, but flag the value as "proposed" so the editor
+     knows whether the user has explicitly confirmed it.
+   This would eliminate the split between `uicommand.py` (preset) and
+   `editor.py` (propose) and ensure domain invariants are always enforced.
+
+2. **Preset completion date bypasses `_onCompletionDateTimeChanged`.**
+   When `uicommand.py` passes `completionDateTime=...` to the Task
+   constructor, the Attribute is initialized directly (no `.set()` call),
+   so the callback never fires. This means recurrence is not triggered,
+   reminder is not cleared, children are not completed, and parent
+   completion cascade does not happen. The task is born in an inconsistent
+   state. See [Constructor Bypass Problem](#constructor-bypass-problem).
+
+3. **Fix propose mode for DateTimeCombo2** — the immediate minimal fix.
+   See [Fix](#fix) section.
+
+4. **Duration mode interaction with presets needs resolution.** New tasks
+   start in Implicit mode for legacy and preset/propose compatibility
+   reasons (see DURATION_CALCULATIONS.md "Logic Flow" note). Implicit
+   mode keeps both fields independently editable, avoiding conflicts
+   with preset/propose values. However, if a duration mode preference
+   is ever added, the interaction must be carefully designed. See
+   [Duration Mode Interaction](#duration-mode-interaction).
+
+---
+
+## Overview
+
+When creating a new task, each date field (planned start, due date, actual
+start, completion, reminder) can be pre-filled based on user preferences.
+There are two modes:
+
+| Mode | Checkbox State | Value Persisted | Where Applied |
+|------|---------------|----------------|---------------|
+| **Preset** | Checked | Yes — on the domain object at creation | `uicommand.py` (before editor opens) |
+| **Propose** | Unchecked | No — display hint only, hidden behind "N/A" | Editor widget (when editor opens) |
+
+Both modes compute the same datetime using `task.Task.suggestedDateTime()`.
+The mode only controls where and how the value is applied.
+
+---
+
+## Preference Setting Format
+
+Settings are stored in `TaskCoach.ini` under `[view]`:
+
+```ini
+defaultplannedstartdatetime = propose_today_currenttime
+defaultduedatetime = propose_tomorrow_endofworkingday
+defaultactualstartdatetime = propose_today_currenttime
+defaultcompletiondatetime = propose_today_currenttime
+defaultreminderdatetime = propose_tomorrow_startofworkingday
+```
+
+Format: `{preset|propose}_{day}_{time}`
+
+**Day options:** `today`, `tomorrow`, `dayaftertomorrow`, `nextfriday`, `nextmonday`
+
+**Time options:** `startofday`, `startofworkingday`, `currenttime`, `endofworkingday`, `endofday`
+
+The prefix (`preset` or `propose`) determines the mode. The `suggestedDateTime()`
+method strips the prefix (`dummy_prefix` at `task.py:1944`) and computes the
+same datetime regardless of mode.
+
+**File:** `taskcoachlib/config/defaults.py:78-82`
+
+**Preferences UI:** `taskcoachlib/gui/dialog/preferences.py:2038-2127`
+
+The preferences UI help text explains the distinction:
+
+> New tasks start with "Preset" dates and times filled in and checked.
+> "Proposed" dates and times are filled in, but not checked.
+
+Note: Completion date only supports propose mode (`[check_choices[1]]` at
+`preferences.py:2103`).
+
+---
+
+## Preset Mode
+
+### Flow
+
+When the preference starts with `"preset"`:
+
+1. **Task creation** (`uicommand.py:1691-1708`):
+   ```python
+   def doCommand(self, event, show=True):
+       kwargs = self.taskKeywords.copy()
+       if self.__shouldPresetPlannedStartDateTime():
+           kwargs["plannedStartDateTime"] = task.Task.suggestedPlannedStartDateTime()
+       if self.__shouldPresetDueDateTime():
+           kwargs["dueDateTime"] = task.Task.suggestedDueDateTime()
+       # ... same for actualStart, completion, reminder
+       newTaskCommand = command.NewTaskCommand(self.taskList, **kwargs)
+   ```
+
+2. **Task constructor** (`task.py:84-89`): The value is stored directly
+   in the Attribute via `Attribute.__init__()`, NOT via `.set()`.
+
+3. **Editor opens**: Reads from domain object. Value is non-None, so
+   `DateTimeCombo2` is constructed with `value=datetime`, checkbox starts
+   checked, fields show the preset datetime.
+
+### Constructor Bypass Problem
+
+`Attribute.__init__()` stores the value but does **NOT** fire the callback.
+Callbacks only fire on `Attribute.set()`. This means any business logic in
+the `_on*Changed` callback is skipped when a value is set via the constructor.
+
+For most date fields this is harmless — the callbacks for planned start,
+due date, and actual start just send pubsub notifications and mark dirty,
+which happen separately during task creation.
+
+But for **completion date** and **reminder**, the callbacks contain
+important business logic that is bypassed.
+
+### Completion Date Preset
+
+When `completionDateTime` is passed to the Task constructor:
+
+| Expected Side Effect | Actually Fires? | Why |
+|---------------------|----------------|-----|
+| Recurrence triggered (`self.recur()`) | No | Callback not fired |
+| Reminder cleared (`self.setReminder(None)`) | No | Callback not fired |
+| Percentage set to 100 | Yes | Handled separately in `__init__` lines 87-94 |
+| Children completed | No | Callback not fired |
+| Effort tracking stopped | No | Callback not fired |
+| Parent completion cascade | No | Callback not fired |
+
+The task is born in an **inconsistent state**: marked completed (percentage
+100) but without any of the normal completion side effects.
+
+Note: The preferences UI only allows propose mode for completion date
+(`preferences.py:2103`), so this path may never be reached in normal usage.
+But nothing prevents setting `"preset_..."` manually in `TaskCoach.ini`.
+
+### Reminder Preset
+
+When `reminder` is passed to the Task constructor, `setReminder()` is not
+called, so the `reminderChangedEventType` pubsub event is not fired.
+
+This is **not a problem** because the `ReminderController` uses polling —
+it iterates all tasks every second and checks `task.reminder()` directly.
+It does not rely on pubsub events to discover reminders, only to clear
+its "already shown" set when a reminder is snoozed.
+
+**File:** `taskcoachlib/gui/remindercontroller.py:63-98`
+
+---
+
+## Propose Mode
+
+### Old Behavior (DateTimeEntry)
+
+The old `DateTimeEntry` control (removed in the DateTimeCombo2 refactor)
+accepted a `suggestedDateTime` parameter:
+
+```python
+class DateTimeEntry(widgets.DateTimeCtrl):
+    def __init__(self, parent, ..., suggestedDateTime=None, ...):
+        if initialDateTime == date.DateTime() and suggestedDateTime:
+            self.setSuggested(suggestedDateTime)
+        else:
+            self.SetValue(initialDateTime)
+
+    def setSuggested(self, suggestedDateTime):
+        super().SetValue(suggestedDateTime)  # Pre-fill display fields
+        super().SetNone()                    # Uncheck (shows "N/A", hides values)
+```
+
+The old editor computed and passed the suggested datetime:
+
+```python
+# editor.py (old addDateEntry, ~line 1512)
+suggestedDateTime = getattr(self.items[0], "suggestedDueDateTime")()
+dateTimeEntry = entry.DateTimeEntry(..., suggestedDateTime=suggestedDateTime, ...)
+```
+
+Result: The display fields showed the suggested datetime (hidden behind
+"N/A"), and when the user checked the checkbox, the suggested value appeared.
+The value was **never persisted** until the user checked the box and the
+editor committed it through a command.
+
+### Current Bug (DateTimeCombo2)
+
+`DateTimeCombo2` was never given suggested datetime support. When
+`value=None` (propose mode), the constructor defaults to `datetime.now()`:
+
+```python
+# maskedtimectrl.py:3594-3595
+checked = value is not None
+display_value = value if value is not None else datetime.datetime.now()
+```
+
+When the user checks the checkbox, `ActivateValue()` (no args) reveals the
+internally stored `datetime.now()` from construction time, ignoring the
+user's preference setting entirely.
+
+### Fix
+
+Minimal one-line change in `DateTimeCombo2.__init__()`:
+
+**File:** `taskcoachlib/widgets/maskedtimectrl.py:3588`
+
+Add `suggestedValue=None` parameter:
+
+```python
+def __init__(self, parent, value=None, suggestedValue=None, ...):
+    ...
+    display_value = value if value is not None else (suggestedValue or datetime.datetime.now())
+```
+
+Pass `suggestedValue` at each `DateTimeCombo2(...)` construction in the editor:
+
+**File:** `taskcoachlib/gui/dialog/editor.py`
+
+| Date Field | Line | suggestedValue |
+|-----------|------|---------------|
+| Planned start | ~1276 | `task.Task.suggestedPlannedStartDateTime()` |
+| Due date | ~1405 | `task.Task.suggestedDueDateTime()` |
+| Actual start | ~1449 | `task.Task.suggestedActualStartDateTime()` |
+| Completion | ~1488 | `task.Task.suggestedCompletionDateTime()` |
+| Reminder | ~2011 | `task.Task.suggestedReminderDateTime()` |
+
+In preset mode, `value` is already non-None, so `suggestedValue` is ignored.
+
+---
+
+## Duration Mode Interaction
+
+New tasks start in **Implicit** duration mode (see DURATION_CALCULATIONS.md
+"Logic Flow" note). This is intentional: Implicit mode keeps both start
+and due fields independently editable, so preset and propose values can
+be applied to either field without conflict.
+
+If the default were Automatic mode instead, it would immediately resolve
+to adjdue or adjstart when a date is checked, making the other field
+read-only and overriding its preset/propose value:
+
+| Start Setting | Due Setting | Automatic Would Resolve To | Problem |
+|--------------|------------|---------------------------|---------|
+| Preset | Preset | adjdue (start first) | Due preset overwritten by start+duration calc |
+| Preset | Propose | adjdue | Due is read-only — propose value unreachable |
+| Propose | Preset | adjstart | Start is read-only — propose value unreachable |
+| Propose | Propose | stays Automatic | No conflict — both fields editable until user checks one |
+
+Implicit mode avoids all of these problems. Both fields remain editable
+regardless of the preset/propose combination.
+
+If a duration mode preference is ever added, these interactions must be
+carefully designed — the chosen mode must be compatible with the
+preset/propose settings, or the mode must be forced to implicit when
+presets are active.
+
+---
+
+## Suggested DateTime Computation
+
+The `suggestedDateTime()` classmethod computes a datetime from the preference
+setting and `now()`. It is called at dialog open time (propose mode) or at
+task creation time (preset mode).
+
+**File:** `taskcoachlib/domain/task/task.py:1941-1989`
+
+```python
+@classmethod
+def suggestedDateTime(cls, defaultDateTimeSetting, now=date.Now):
+    defaultDateTime = cls.settings.get("view", defaultDateTimeSetting)
+    dummy_prefix, defaultDate, defaultTime = defaultDateTime.split("_")
+    dateTime = now()
+    # Apply day offset: today, tomorrow, dayaftertomorrow, nextfriday, nextmonday
+    # Apply time: startofday, startofworkingday, currenttime, endofworkingday, endofday
+    ...
+```
+
+Key points:
+- Always computed from `now()` at call time — "tomorrow" means tomorrow
+  from when the method is called, not relative to task creation date
+- The `dummy_prefix` is the mode (`preset`/`propose`) — discarded here
+- Working day hours come from `efforthourstart` / `efforthourend` settings
+
+Convenience classmethods:
+- `suggestedPlannedStartDateTime()` → reads `defaultplannedstartdatetime`
+- `suggestedDueDateTime()` → reads `defaultduedatetime`
+- `suggestedActualStartDateTime()` → reads `defaultactualstartdatetime`
+- `suggestedCompletionDateTime()` → reads `defaultcompletiondatetime`
+- `suggestedReminderDateTime()` → reads `defaultreminderdatetime`
+
+---
+
+## Reminder Scheduling on Load
+
+When a `.tsk` file is loaded, tasks are reconstructed via `__init__` with
+reminder values from XML. The reminder is stored directly in `self.__reminder`
+(not through `setReminder()`), so no pubsub event fires.
+
+This works because `ReminderController` uses **polling** (checks all tasks
+every second via `timer.second`), not event-driven scheduling. It reads
+`task.reminder()` directly and doesn't need a pubsub notification to
+discover reminders.
+
+The pubsub subscription (`_onReminderChanged`) is only used to clear the
+"already shown" set when a reminder is snoozed — so it can fire again at the
+new snooze time.
+
+**File:** `taskcoachlib/gui/remindercontroller.py`
+
+---
+
+## Related Documentation
+
+- [DATETIME_CONTROLS.md](DATETIME_CONTROLS.md) — DateTimeCombo2 widget API,
+  ActivateValue/DeactivateValue, suggested datetime old behavior reference
+- [ATTRIBUTE_PATTERN.md](ATTRIBUTE_PATTERN.md) — Attribute model, setter/callback
+  pattern, constructor vs `.set()` behavior, three-layer relationship
+- [DURATION_CALCULATIONS.md](DURATION_CALCULATIONS.md) — Duration modes,
+  starting state documentation ("Start: Implicit mode")
+- [PERSISTENCE_XML.md](PERSISTENCE_XML.md) — XML writer/reader, skip conditions,
+  round-trip consistency

--- a/docs/DURATION_CALCULATIONS.md
+++ b/docs/DURATION_CALCULATIONS.md
@@ -47,6 +47,20 @@ Duration calculations for Edit Task Dates and Edit Effort windows.
    which fires on checkbox toggle AND date/time edits. External
    EVT_CHECKBOX handlers and `sync.commit()` hacks removed.
    See [DATETIME_CONTROLS.md](DATETIME_CONTROLS.md) TODO item 3.
+10. **Reconcile legacy "datestied" preference with duration mode.**
+   The `view.datestied` setting (`preferences.py:2029`) is a legacy
+   predecessor to duration mode. It has three options: nothing, "changing
+   start shifts due" (`startdue`), or "changing due shifts start"
+   (`duestart`). It only applies to **inline edits in the task list
+   viewer** (`gui/viewer/task.py:2121-2131`) via `keep_delta=True` on
+   `EditPlannedStartDateTimeCommand` / `EditDueDateTimeCommand`. It is
+   not wired into the editor dialog at all. Duration mode does the same
+   thing bidirectionally with explicit UI in the editor. These two
+   mechanisms should be unified or the legacy setting should be removed
+   in favor of duration mode.
+11. Effort Logic Flow: Renumber sections 1, 2, 3 to match the task
+    section pattern — consolidate x.1/x.2 mode-change rules into
+    a single x.1 note, renumber remaining items.
 
 ## Notes
 
@@ -112,56 +126,70 @@ for the next user change.
 ### Logic Flow
 
 ```
-Start: Automatic mode, all fields empty
+Start: Implicit mode, all fields empty (see note below)
+
+Note: New tasks always start in Implicit mode, not Automatic. This is
+intentional for two reasons:
+  (a) Legacy compatibility — the original code had no explicit calc
+      modes; it only saved planned start and due dates, so the duration
+      was always implied. The explicit calc mode system defaults to
+      Implicit to preserve this behavior.
+  (b) Preset/propose support — Automatic mode immediately resolves to
+      adjdue or adjstart when a date is checked, which would make the
+      calculated field read-only and override any preset/propose value
+      for that field. Implicit mode keeps both fields independently
+      editable, allowing preset and propose values to be applied without
+      conflict. See DATETIME_PRESETS.md "Duration Mode Interaction".
 
 0. See Preconditions and Global Logic section above.
    0.4 Sync-mode guard... See section above.
        0.4.1 Flag: task._durationSyncInProgress on domain Task instance.
 
 1. If Mode Automatic
-   1.1 If Start-Date exists, Then set Adj-Due mode, Loop
-   1.2 If Due-Date exists, Then set Adj-Start mode, Loop
-   1.3 If Implicit chosen, Then set Implicit mode, Loop
-   1.4 If Adj-Due chosen, Then set Adj-Due mode, Loop
-   1.5 If Adj-Start chosen, Then set Adj-Start mode, Loop
+   1.1 Note: Mode changes away never come back here
+   1.2 If Start-Date exists, Then set Adj-Due mode, Loop
+   1.3 If Due-Date exists, Then set Adj-Start mode, Loop
 
 2. If Mode Adj-Due
-   2.1 Activate Start-Date, If not Unset-Action [Ref2, 0.1.1]
-   2.2 Activate Due-Date (Read-Only) [Ref2]
-   2.3 Disable Automatic mode option in dropdown [Ref1]
-   2.4 If Duration changed, Then adj Due-Date
-   2.5 If Start-Date Unset-Action, Then
-       2.5.1 Set Sync-Mode [0.4]
-       2.5.2 Deactivate Due-Date
-       2.5.3 Reactivate Automatic mode option in dropdown
-       2.5.4 Set Automatic mode
-       2.5.5 Unset Sync-Mode
-       2.5.6 Loop
-   2.6 If Start-Date changed, Then adj Due-Date
+   2.1 Note: Mode changes away never come back here
+   2.2 Activate Start-Date, If not Unset-Action [Ref2, 0.1.1]
+   2.3 Activate Due-Date (Read-Only) [Ref2]
+   2.4 Disable Automatic mode option in dropdown [Ref1]
+   2.5 If Duration changed, Then adj Due-Date
+   2.6 If Start-Date Unset-Action, Then
+       2.6.1 Set Sync-Mode [0.4]
+       2.6.2 Deactivate Due-Date
+       2.6.3 Reactivate Automatic mode option in dropdown
+       2.6.4 Set Automatic mode
+       2.6.5 Unset Sync-Mode
+       2.6.6 Loop
+   2.7 If Start-Date changed, Then adj Due-Date
 
 3. If Mode Adj-Start
-   3.1 Activate Due-Date, If not Unset-Action [Ref2, 0.1.2]
-   3.2 Activate Start-Date (Read-Only) [Ref2]
-   3.3 Disable Automatic mode option in dropdown [Ref1]
-   3.4 If Duration changed, Then adj Start-Date
-   3.5 If Due-Date Unset-Action, Then
-       3.5.1 Set Sync-Mode [0.4]
-       3.5.2 Deactivate Start-Date
-       3.5.3 Reactivate Automatic mode option in dropdown
-       3.5.4 Set Automatic mode
-       3.5.5 Unset Sync-Mode
-       3.5.6 Loop
-   3.6 If Due-Date changed, Then adj Start-Date
+   3.1 Note: Mode changes away never come back here
+   3.2 Activate Due-Date, If not Unset-Action [Ref2, 0.1.2]
+   3.3 Activate Start-Date (Read-Only) [Ref2]
+   3.4 Disable Automatic mode option in dropdown [Ref1]
+   3.5 If Duration changed, Then adj Start-Date
+   3.6 If Due-Date Unset-Action, Then
+       3.6.1 Set Sync-Mode [0.4]
+       3.6.2 Deactivate Start-Date
+       3.6.3 Reactivate Automatic mode option in dropdown
+       3.6.4 Set Automatic mode
+       3.6.5 Unset Sync-Mode
+       3.6.6 Loop
+   3.7 If Due-Date changed, Then adj Start-Date
 
 4. If Mode Implicit
-   4.1 Disable Automatic mode option in dropdown [Ref1]
-   4.2 If Start-Date exists
-       4.2.1 If Due-Date exists
-           4.2.1.1 Enable Duration (Read-Only)
-           4.2.1.2 Adj Duration
-           4.2.1.3 Negative Durations permitted
-       4.2.2 If Due-Date Unset-Action, Then disable Duration
-   4.3 If Start-Date Unset-Action, Then disable Duration
+   4.1 Note: Mode changes away never come back here
+   4.2 Disable Automatic mode option in dropdown [Ref1]
+   4.3 If Start-Date exists
+       4.3.1 If Due-Date exists
+           4.3.1.1 Enable Duration (Read-Only)
+           4.3.1.2 Adj Duration
+           4.3.1.3 Negative Durations permitted
+       4.3.2 If Due-Date Unset-Action, Then disable Duration
+   4.4 If Start-Date Unset-Action, Then disable Duration
 
 5. Update Field States (See: UI Field States section)
 
@@ -277,8 +305,8 @@ Start: Standard mode, Duration 0, Stop-Date disabled
        0.4.1 Flag: effort._effortSyncInProgress on domain Effort instance.
 
 1. If Mode Standard
-   1.1 If Retroactive mode chosen, Loop
-   1.2 If Implicit mode chosen, Loop
+   1.1 Note: Mode changes away never come back here
+   1.2 See 1.1 and TODO item 11
    1.3 Set Start-Date editable
    1.4 Set Duration editable
    1.5 Set Presets dropdown enabled [Ref1]
@@ -308,8 +336,8 @@ Start: Standard mode, Duration 0, Stop-Date disabled
    1.14 If Duration < 0, Then Negative Durations permitted
 
 2. If Mode Retroactive
-   2.1 If Standard mode chosen, Loop
-   2.2 If Implicit mode chosen, Loop
+   2.1 Note: Mode changes away never come back here
+   2.2 See 2.1 and TODO item 11
    2.3 Set Start-Date read-only
    2.4 Set Duration editable
    2.5 Set Presets dropdown enabled [Ref1]
@@ -329,8 +357,8 @@ Start: Standard mode, Duration 0, Stop-Date disabled
    2.12 If Duration < 0, Then Negative Durations permitted
 
 3. If Mode Implicit
-   3.1 If Standard mode chosen, Loop
-   3.2 If Retroactive mode chosen, Loop
+   3.1 Note: Mode changes away never come back here
+   3.2 See 3.1 and TODO item 11
    3.3 Set Presets dropdown disabled [Ref1]
    3.4 Set Start-Date editable
    3.5 If Stop-Date does not exist, Disable Duration

--- a/docs/PERSISTENCE_XML.md
+++ b/docs/PERSISTENCE_XML.md
@@ -1,0 +1,201 @@
+# Persistence: XML Writer / Reader
+
+How domain objects are serialized to `.tsk` XML files and deserialized back.
+
+## Index
+
+- [TODO](#todo)
+- [Overview](#overview)
+- [Writer Skip Conditions](#writer-skip-conditions)
+  - [Task Node](#task-node)
+  - [Recurrence Node](#recurrence-node)
+  - [Effort Node](#effort-node)
+  - [Base Node (All Objects)](#base-node-all-objects)
+- [Reader Defaults](#reader-defaults)
+- [Round-Trip Consistency](#round-trip-consistency)
+- [Skip Condition Categories](#skip-condition-categories)
+- [Related Documentation](#related-documentation)
+
+---
+
+## TODO
+
+1. **Maybe always write values?** The writer omits attributes when the value
+   equals an assumed default. This scatters default-value knowledge across
+   the writer instead of centralizing it in the domain (Attribute pattern).
+   Always writing every attribute would make the XML slightly larger but
+   eliminate the implicit "is this worth saving" decision and the risk of
+   writer/reader default mismatch. At minimum, the writer and reader should
+   share a common source of truth for defaults.
+
+2. The writer and reader independently decide defaults in two different
+   files with no shared constant or domain method connecting them. They
+   agree by convention, not by contract. If one changes without the other,
+   round-trip silently corrupts data.
+
+3. ~~`plannedDurationMode` skip condition uses hardcoded `"implicit"` but
+   the documented default starting state is "automatic"~~ — **Resolved.**
+   The actual code default is `"implicit"` (task.py:52). The
+   DURATION_CALCULATIONS.md documentation has been corrected to match.
+   Writer and reader both agree on `"implicit"` as the default.
+
+---
+
+## Overview
+
+**File:** `taskcoachlib/persistence/xml/writer.py` (XMLWriter)
+**File:** `taskcoachlib/persistence/xml/reader.py` (XMLReader)
+
+The writer serializes domain objects to XML. For each field, it checks
+whether the value equals an assumed default — if so, the XML attribute is
+**omitted entirely** (not written as an empty string). The XML element has
+no trace of the attribute.
+
+The reader deserializes XML back to domain objects. For each field, if the
+XML attribute is missing, the reader provides its own default via
+`.get("attributeName", default)`.
+
+These two default decisions are made independently. They happen to agree
+by convention.
+
+---
+
+## Writer Skip Conditions
+
+The writer conditionally omits attributes from the XML. "Skipped" means
+the attribute is **not written to XML at all** — completely absent from
+the element, not written as an empty value.
+
+### Task Node
+
+`taskNode()` — lines 144-199:
+
+| Line | XML Attribute | Skip Condition | Type |
+|------|--------------|----------------|------|
+| 148 | `plannedstartdate` | `== maxDateTime` | Sentinel |
+| 150 | `duedate` | `== maxDateTime` | Sentinel |
+| 152 | `actualstartdate` | `== maxDateTime` | Sentinel |
+| 154 | `completiondate` | `== maxDateTime` | Sentinel |
+| 156 | `percentageComplete` | `== 0` (falsy) | Falsy |
+| 158 | `recurrence` | empty Recurrence (falsy) | Falsy |
+| 160 | `budget` | `== TimeDelta()` | Sentinel |
+| 162 | `plannedDuration` | `== TimeDelta()` | Sentinel |
+| 164 | `plannedDurationMode` | `!= "implicit"` (inverted) | Hardcoded string |
+| 166 | `priority` | `== 0` (falsy) | Falsy |
+| 168 | `hourlyFee` | `== 0` (falsy) | Falsy |
+| 170 | `fixedFee` | `== 0` (falsy) | Falsy |
+| 173 | `reminder` | `== maxDateTime` or `None` | Sentinel + None |
+| 187 | `prerequisites` | empty string (falsy) | Falsy |
+| 189 | `shouldMarkCompleted...` | `== None` | None check |
+
+### Recurrence Node
+
+`recurrenceNode()` — lines 201-217:
+
+| Line | XML Attribute | Skip Condition | Type |
+|------|--------------|----------------|------|
+| 203 | `amount` | `<= 1` | Numeric compare |
+| 205 | `count` | `<= 0` | Numeric compare |
+| 207 | `max` | `<= 0` | Numeric compare |
+| 209 | `stop_datetime` | `== maxDateTime` | Sentinel |
+| 211 | `sameWeekday` | falsy (`False`) | Falsy |
+| 213 | `recurBasedOnCompletion` | falsy (`False`) | Falsy |
+| 215 | `weekdays` | falsy (empty) | Falsy |
+
+### Effort Node
+
+`effortNode()` — lines 219-239:
+
+| Line | XML Attribute | Skip Condition | Type |
+|------|--------------|----------------|------|
+| 234 | `entryMode` | falsy or `== "standard"` | Hardcoded string |
+
+### Base Node (All Objects)
+
+`__baseNode()` / `baseNode()` / `baseCompositeNode()` — lines 286-353:
+
+| Line | XML Attribute | Skip Condition | Type |
+|------|--------------|----------------|------|
+| 292 | `creationDateTime` | `<= DateTime.min` | Sentinel |
+| 294 | `modificationDateTime` | `<= DateTime.min` | Sentinel |
+| 298 | `subject` | `""` (falsy) | Falsy |
+| 300 | `description` | `""` (falsy) | Falsy |
+| 308 | `fgColor` | `None` (falsy) | Falsy |
+| 310 | `bgColor` | `None` (falsy) | Falsy |
+| 312 | `font` | `None` (falsy) | Falsy |
+| 314 | `icon` | `""` (falsy) | Falsy |
+| 316 | `selectedIcon` | `""` (falsy) | Falsy |
+| 318 | `ordering` | `== 0` (falsy) | Falsy |
+| 345 | `expandedContexts` | empty (falsy) | Falsy |
+
+---
+
+## Reader Defaults
+
+When an XML attribute is missing, the reader provides a default via
+`.get("attr", default)`. Selected examples from `_parse_task_node()`:
+
+| XML Attribute | Reader Default | Matches Writer Skip? |
+|--------------|---------------|---------------------|
+| `subject` | `""` | Yes — writer skips `""` |
+| `plannedstartdate` | not set → `None` → `maxDateTime` | Yes |
+| `percentageComplete` | `"0"` → `0` | Yes |
+| `priority` | `"0"` → `0` | Yes |
+| `plannedDurationMode` | `"implicit"` | Yes — code default is `"implicit"` (task.py:52) |
+| `budget` | `""` → `TimeDelta()` | Yes |
+| `hourlyFee` | `"0"` → `0.0` | Yes |
+
+---
+
+## Round-Trip Consistency
+
+A value round-trips correctly when:
+
+```
+domain.getValue() → writer skips → XML has no attribute → reader defaults → domain.setValue(default)
+```
+
+...produces the same value as the original. This works today for all fields
+because the writer skip conditions and reader defaults happen to agree.
+
+**Risk:** If the writer's skip condition or the reader's default is changed
+independently, the round-trip breaks silently. There is no shared constant,
+no assertion, and no test that verifies writer/reader default agreement.
+
+---
+
+## Skip Condition Categories
+
+The writer uses several types of skip conditions, with varying levels of
+correctness:
+
+**Sentinel-based** (dates, budget, duration) — Comparing against an
+explicit "no value" marker defined by the domain (`maxDateTime`,
+`TimeDelta()`). Semantically correct — the sentinel means "not set."
+
+**Falsy-based** (strings, numbers, booleans) — Using Python truthiness
+(`if value:`). This conflates multiple concepts:
+- `""` is falsy — but `""` is a valid string value (user cleared subject)
+- `0` is falsy — but `0` is a valid numeric value (priority 0, zero fee)
+- `None` is falsy — genuinely means "not set"
+- `False` is falsy — valid boolean value
+
+These work by accident because the falsy value happens to match the
+constructor default. They'd break if any default changed to a non-falsy
+value.
+
+**Hardcoded string** (`plannedDurationMode`, `entryMode`) — Comparing
+against a string literal that the writer assumes is the default. The
+domain constructor defines the actual default separately. If they
+diverge, data is silently lost.
+
+---
+
+## Related Documentation
+
+- [ATTRIBUTE_PATTERN.md](ATTRIBUTE_PATTERN.md) — Domain Attribute model,
+  value normalization, setter/callback pattern
+- [DATETIME_PRESETS.md](DATETIME_PRESETS.md) — Preset/propose modes and
+  how they interact with persistence
+- [DURATION_CALCULATIONS.md](DURATION_CALCULATIONS.md) — Duration modes,
+  starting state documentation ("Start: Automatic mode")

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -12,6 +12,7 @@ This document tracks planned improvements and known issues to address in future 
 - [Text-to-Speech Modernization](#text-to-speech-modernization)
 - [GTK3 Widget Sizing Inconsistency](#gtk3-widget-sizing-inconsistency)
 - [BookPage Default Alignment Inconsistency](#bookpage-default-alignment-inconsistency)
+- [Preferences Dialog: Dirty-Check and Button State](#preferences-dialog-dirty-check-and-button-state)
 - [Other TODOs](#other-todos)
   - [EVT_TEXT Compatibility Shim](#evt_text-compatibility-shim-in-multilinetextctrl)
 
@@ -361,6 +362,56 @@ So when you call `addEntry(_("Label"), someControl)`:
 
 ---
 
+## Preferences Dialog: Dirty-Check and Button State
+
+### Goal
+
+Grey out Apply and OK buttons until the user has actually changed a setting.
+
+### Approach
+
+Use `EVT_CHILD_FOCUS` on each page to detect when the user leaves a control
+(blur = confirmed change, not intermediary keystrokes). On each blur, compare
+all tracked controls against the live `Settings` object (the INI file values).
+No need to store "original values" — the settings object is the baseline.
+
+**`SettingsPageBase`:**
+- Bind `EVT_CHILD_FOCUS` → `_onChildFocus`
+- Add `hasChanges()` that iterates `_booleanSettings`, `_choiceSettings`,
+  `_integerSettings`, `_pathSettings`, `_textSettings`,
+  `_multipleChoiceSettings` and compares each control's current value against
+  `self.settings.get(section, setting)`
+- Pages with custom controls (Theme, Task Appearance, working hours) override
+  `hasChanges()` to add their own comparisons
+
+**Parent dialog:**
+- On child focus event (bubbled up or polled), check
+  `any(page.hasChanges() for page in self)` and enable/disable Apply/OK
+- After Apply saves, button state is re-evaluated (settings now match controls,
+  so buttons grey out again automatically)
+
+### Comparison per control type
+
+| Method | Compare |
+|--------|---------|
+| `addBooleanSetting` | `checkBox.IsChecked() != self.getboolean(section, setting)` |
+| `addChoiceSetting` | reconstructed value != `self.gettext(section, setting)` |
+| `addIntegerSetting` | `spin.GetValue() != self.getint(section, setting)` |
+| `addPathSetting` | `pathChooser.GetPath() != self.gettext(section, setting)` |
+| `addTextSetting` | `textCtrl.GetValue() != self.gettext(section, setting)` |
+| `addMultipleChoiceSettings` | checked items != `self.getlist(section, setting)` |
+
+### Notes
+
+- One binding per page, one `hasChanges()` scan per blur — no per-control wiring
+- Custom pages override `hasChanges()` for non-standard controls
+- `EVT_CHILD_FOCUS` fires on focus transfer between any child controls,
+  which is the right granularity for confirmed-value checking
+
+**Status:** Planned
+
+---
+
 ## Other TODOs
 
 ### EVT_TEXT Compatibility Shim in MultiLineTextCtrl
@@ -369,4 +420,4 @@ So when you call `addEntry(_("Label"), someControl)`:
 
 ---
 
-**Last Updated:** January 2026
+**Last Updated:** February 2026

--- a/taskcoachlib/domain/base/object.py
+++ b/taskcoachlib/domain/base/object.py
@@ -23,6 +23,7 @@ from taskcoachlib.domain.attribute import icon
 from taskcoachlib.domain.date import DateTime, Now
 from pubsub import pub
 from . import attribute
+from .appearance import FIELD_DEFAULTS, FIELD_NO_VALUE_SOURCE
 import functools
 import sys
 import uuid
@@ -478,28 +479,28 @@ class Object(SynchronizedObject):
     # --- Derived SSOT Getters ---
 
     def derivedFgColor(self):
-        return self.__derivedFgColorValue.get()
+        return self.__derivedFgColorValue.get() or FIELD_DEFAULTS['fgColor']
 
     def derivedFgColorSource(self):
-        return self.__derivedFgColorSource.get()
+        return self.__derivedFgColorSource.get() or FIELD_NO_VALUE_SOURCE['fgColor']
 
     def derivedBgColor(self):
-        return self.__derivedBgColorValue.get()
+        return self.__derivedBgColorValue.get() or FIELD_DEFAULTS['bgColor']
 
     def derivedBgColorSource(self):
-        return self.__derivedBgColorSource.get()
+        return self.__derivedBgColorSource.get() or FIELD_NO_VALUE_SOURCE['bgColor']
 
     def derivedIcon(self):
-        return self.__derivedIconValue.get()
+        return self.__derivedIconValue.get() or FIELD_DEFAULTS['icon']
 
     def derivedIconSource(self):
-        return self.__derivedIconSource.get()
+        return self.__derivedIconSource.get() or FIELD_NO_VALUE_SOURCE['icon']
 
     def derivedFont(self):
-        return self.__derivedFontValue.get()
+        return self.__derivedFontValue.get() or FIELD_DEFAULTS['font']
 
     def derivedFontSource(self):
-        return self.__derivedFontSource.get()
+        return self.__derivedFontSource.get() or FIELD_NO_VALUE_SOURCE['font']
 
     # --- Derived SSOT Setters (for use by computeDerived) ---
 
@@ -554,37 +555,37 @@ class Object(SynchronizedObject):
     # --- Effective SSOT Getters ---
 
     def effectiveFgColor(self):
-        return self.__effectiveFgColorValue.get()
+        return self.__effectiveFgColorValue.get() or FIELD_DEFAULTS['fgColor']
 
     def effectiveFgColorSource(self):
-        return self.__effectiveFgColorSource.get()
+        return self.__effectiveFgColorSource.get() or FIELD_NO_VALUE_SOURCE['fgColor']
 
     def effectiveFgColorDefault(self):
-        return self.__effectiveFgColorDefault.get()
+        return self.__effectiveFgColorDefault.get() or FIELD_DEFAULTS['fgColor']
 
     def effectiveBgColor(self):
-        return self.__effectiveBgColorValue.get()
+        return self.__effectiveBgColorValue.get() or FIELD_DEFAULTS['bgColor']
 
     def effectiveBgColorSource(self):
-        return self.__effectiveBgColorSource.get()
+        return self.__effectiveBgColorSource.get() or FIELD_NO_VALUE_SOURCE['bgColor']
 
     def effectiveBgColorDefault(self):
-        return self.__effectiveBgColorDefault.get()
+        return self.__effectiveBgColorDefault.get() or FIELD_DEFAULTS['bgColor']
 
     def effectiveIcon(self):
-        return self.__effectiveIconValue.get()
+        return self.__effectiveIconValue.get() or FIELD_DEFAULTS['icon']
 
     def effectiveIconSource(self):
-        return self.__effectiveIconSource.get()
+        return self.__effectiveIconSource.get() or FIELD_NO_VALUE_SOURCE['icon']
 
     def effectiveFont(self):
-        return self.__effectiveFontValue.get()
+        return self.__effectiveFontValue.get() or FIELD_DEFAULTS['font']
 
     def effectiveFontSource(self):
-        return self.__effectiveFontSource.get()
+        return self.__effectiveFontSource.get() or FIELD_NO_VALUE_SOURCE['font']
 
     def effectiveFontDefault(self):
-        return self.__effectiveFontDefault.get()
+        return self.__effectiveFontDefault.get() or FIELD_DEFAULTS['font']
 
     # --- Effective SSOT Setters (for use by computeEffective) ---
 

--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -63,6 +63,11 @@ def resolve_color(value):
     elif isinstance(value, wx.Colour):
         return value
     else:
+        import inspect
+        caller = inspect.stack()[1]
+        log_step("resolve_color: unhandled value", repr(value),
+                 "from %s:%d in %s" % (caller[1], caller[2], caller[3]),
+                 prefix="APPEARANCE-BUG")
         return wx.NullColour
 
 
@@ -70,19 +75,22 @@ def resolve_font(value):
     """Convert domain font value to wx.Font.
 
     Args:
-        value: wx.Font, symbolic constant, or None
+        value: wx.Font or symbolic constant (SYSTEM_FONT)
 
     Returns:
-        wx.Font instance
+        wx.Font instance, or wx.NullFont if value is unhandled (bug)
     """
     if value == base.SYSTEM_FONT:
         return wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT)
     elif isinstance(value, wx.Font):
         return value
-    elif value is None:
-        return wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT)
     else:
-        return value
+        import inspect
+        caller = inspect.stack()[1]
+        log_step("resolve_font: unhandled value", repr(value),
+                 "from %s:%d in %s" % (caller[1], caller[2], caller[3]),
+                 prefix="APPEARANCE-BUG")
+        return wx.NullFont
 
 
 def is_system_theme(value):
@@ -1275,6 +1283,7 @@ class DatesPage(Page):
 
         self._plannedStartDateTimeCombo = widgets.DateTimeCombo(
             self, value=value,
+            suggestedValue=task.Task.suggestedPlannedStartDateTime(),
             hourChoices=lambda: get_suggested_hour_choices(self._DatesPage__settings),
             minuteChoices=lambda: get_suggested_minute_choices(self._DatesPage__settings)
         )
@@ -1404,6 +1413,7 @@ class DatesPage(Page):
 
         self._dueDateTimeCombo = widgets.DateTimeCombo(
             self, value=value,
+            suggestedValue=task.Task.suggestedDueDateTime(),
             hourChoices=lambda: get_suggested_hour_choices(self._DatesPage__settings),
             minuteChoices=lambda: get_suggested_minute_choices(self._DatesPage__settings)
         )
@@ -1448,6 +1458,7 @@ class DatesPage(Page):
 
         self._actualStartDateTimeCombo = widgets.DateTimeCombo(
             self, value=value,
+            suggestedValue=task.Task.suggestedActualStartDateTime(),
             hourChoices=lambda: get_suggested_hour_choices(self._DatesPage__settings),
             minuteChoices=lambda: get_suggested_minute_choices(self._DatesPage__settings)
         )
@@ -1487,6 +1498,7 @@ class DatesPage(Page):
 
         self._completionDateTimeCombo = widgets.DateTimeCombo(
             self, value=value,
+            suggestedValue=task.Task.suggestedCompletionDateTime(),
             hourChoices=lambda: get_suggested_hour_choices(self._DatesPage__settings),
             minuteChoices=lambda: get_suggested_minute_choices(self._DatesPage__settings)
         )
@@ -1695,11 +1707,11 @@ class DatesPage(Page):
         ).do()
 
     def __activateStartDate(self):
-        """Activate Start-Date combo (step 2.1). Uses internally stored value."""
+        """Activate Start-Date combo (step 2.2). Uses internally stored value."""
         self._plannedStartDateTimeCombo.ActivateValue()
 
     def __activateDueDate(self):
-        """Activate Due-Date combo (step 3.1). Uses internally stored value."""
+        """Activate Due-Date combo (step 3.2). Uses internally stored value."""
         self._dueDateTimeCombo.ActivateValue()
 
     def __adjStartDate(self):
@@ -1748,89 +1760,91 @@ class DatesPage(Page):
         mode = self._currentPlannedDurationMode
 
         if mode == "automatic":
-            # 1.1 If Start-Date exists, Then set Adj-Due mode, Loop
+            # 1.1 Note: Mode changes away never come back here
+            # 1.2 If Start-Date exists, Then set Adj-Due mode, Loop
             if self.__startDateExists():
                 self.__setDurationMode("adjdue")
                 return self.__syncTaskStateImpl(None, depth=depth + 1)  # 0.3.2
-            # 1.2 If Due-Date exists, Then set Adj-Start mode, Loop
+            # 1.3 If Due-Date exists, Then set Adj-Start mode, Loop
             if self.__dueDateExists():
                 self.__setDurationMode("adjstart")
                 return self.__syncTaskStateImpl(None, depth=depth + 1)  # 0.3.2
-            # 1.3-1.5: Mode chosen by user — callers set mode before calling sync,
-            #          so sync enters the target branch directly.
 
         elif mode == "adjdue":
-            # 2.1 Activate Start-Date, If not Unset-Action [Ref2, 0.1.1]
+            # 2.1 Note: Mode changes away never come back here
+            # 2.2 Activate Start-Date, If not Unset-Action [Ref2, 0.1.1]
             if sourceField != 'start' and not self.__startDateExists():
                 self.__activateStartDate()
-            # 2.2 Activate Due-Date (Read-Only) [Ref2]
+            # 2.3 Activate Due-Date (Read-Only) [Ref2]
             #     On first entry (sourceField=None), adj if due doesn't exist yet.
             if not self.__dueDateExists():
                 self.__adjDueDate()
-            # 2.3 Disable Automatic mode option in dropdown [Ref1]
+            # 2.4 Disable Automatic mode option in dropdown [Ref1]
             #     (handled by __updateDurationModeDropdown on focus loss)
-            # 2.4 If Duration changed, Then adj Due-Date
+            # 2.5 If Duration changed, Then adj Due-Date
             if sourceField == 'duration':
                 self.__adjDueDate()
-            # 2.5 If Start-Date Unset-Action, Then
+            # 2.6 If Start-Date Unset-Action, Then
             if sourceField == 'start' and not self.__startDateExists():
-                # 2.5.1 Set Sync-Mode [0.4] — handled by outer guard
-                # 2.5.2 Deactivate Due-Date
+                # 2.6.1 Set Sync-Mode [0.4] — handled by outer guard
+                # 2.6.2 Deactivate Due-Date
                 self.__deactivateDueDate()
-                # 2.5.3 Reactivate Automatic mode option in dropdown
+                # 2.6.3 Reactivate Automatic mode option in dropdown
                 #        (handled by __updateDurationModeDropdown on focus loss)
-                # 2.5.4 Set Automatic mode
+                # 2.6.4 Set Automatic mode
                 self.__setDurationMode("automatic")
-                # 2.5.5 Unset Sync-Mode — handled by outer guard
-                # 2.5.6 Loop
+                # 2.6.5 Unset Sync-Mode — handled by outer guard
+                # 2.6.6 Loop
                 return self.__syncTaskStateImpl(None, depth=depth + 1)  # 0.3.2
-            # 2.6 If Start-Date changed, Then adj Due-Date
+            # 2.7 If Start-Date changed, Then adj Due-Date
             if sourceField == 'start':
                 self.__adjDueDate()
 
         elif mode == "adjstart":
-            # 3.1 Activate Due-Date, If not Unset-Action [Ref2, 0.1.2]
+            # 3.1 Note: Mode changes away never come back here
+            # 3.2 Activate Due-Date, If not Unset-Action [Ref2, 0.1.2]
             if sourceField != 'due' and not self.__dueDateExists():
                 self.__activateDueDate()
-            # 3.2 Activate Start-Date (Read-Only) [Ref2]
+            # 3.3 Activate Start-Date (Read-Only) [Ref2]
             #     On first entry (sourceField=None), adj if start doesn't exist.
             if not self.__startDateExists():
                 self.__adjStartDate()
-            # 3.3 Disable Automatic mode option in dropdown [Ref1]
+            # 3.4 Disable Automatic mode option in dropdown [Ref1]
             #     (handled by __updateDurationModeDropdown on focus loss)
-            # 3.4 If Duration changed, Then adj Start-Date
+            # 3.5 If Duration changed, Then adj Start-Date
             if sourceField == 'duration':
                 self.__adjStartDate()
-            # 3.5 If Due-Date Unset-Action, Then
+            # 3.6 If Due-Date Unset-Action, Then
             if sourceField == 'due' and not self.__dueDateExists():
-                # 3.5.1 Set Sync-Mode [0.4] — handled by outer guard
-                # 3.5.2 Deactivate Start-Date
+                # 3.6.1 Set Sync-Mode [0.4] — handled by outer guard
+                # 3.6.2 Deactivate Start-Date
                 self.__deactivateStartDate()
-                # 3.5.3 Reactivate Automatic mode option in dropdown
+                # 3.6.3 Reactivate Automatic mode option in dropdown
                 #        (handled by __updateDurationModeDropdown on focus loss)
-                # 3.5.4 Set Automatic mode
+                # 3.6.4 Set Automatic mode
                 self.__setDurationMode("automatic")
-                # 3.5.5 Unset Sync-Mode — handled by outer guard
-                # 3.5.6 Loop
+                # 3.6.5 Unset Sync-Mode — handled by outer guard
+                # 3.6.6 Loop
                 return self.__syncTaskStateImpl(None, depth=depth + 1)  # 0.3.2
-            # 3.6 If Due-Date changed, Then adj Start-Date
+            # 3.7 If Due-Date changed, Then adj Start-Date
             if sourceField == 'due':
                 self.__adjStartDate()
 
         elif mode == "implicit":
-            # 4.1 Disable Automatic mode option in dropdown [Ref1]
+            # 4.1 Note: Mode changes away never come back here
+            # 4.2 Disable Automatic mode option in dropdown [Ref1]
             #     (handled by __updateDurationModeDropdown on focus loss)
-            # 4.2 If Start-Date exists
+            # 4.3 If Start-Date exists
             if self.__startDateExists():
-                # 4.2.1 If Due-Date exists
+                # 4.3.1 If Due-Date exists
                 if self.__dueDateExists():
-                    # 4.2.1.1 Enable Duration (Read-Only)
-                    # 4.2.1.2 Adj Duration
+                    # 4.3.1.1 Enable Duration (Read-Only)
+                    # 4.3.1.2 Adj Duration
                     self.__adjDuration()
-                    # 4.2.1.3 Negative Durations permitted
-                # 4.2.2 If Due-Date Unset-Action, Then disable Duration
+                    # 4.3.1.3 Negative Durations permitted
+                # 4.3.2 If Due-Date Unset-Action, Then disable Duration
                 #        -- handled by __updateFieldStates
-            # 4.3 If Start-Date Unset-Action, Then disable Duration
+            # 4.4 If Start-Date Unset-Action, Then disable Duration
             #     -- handled by __updateFieldStates
 
         # 5. Update Field States (See: UI Field States section)
@@ -1955,7 +1969,7 @@ class DatesPage(Page):
         due = self._dueDateTimeCombo.GetDateTime()
 
         if start is not None and due is not None:
-            new_duration = due - start  # 4.2.1.3 Negative Durations permitted
+            new_duration = due - start  # 4.3.1.3 Negative Durations permitted
             new_timedelta = date.TimeDelta(days=new_duration.days, seconds=new_duration.seconds)
             command.EditPlannedDurationCommand(
                 items=self.items, newValue=new_timedelta
@@ -2010,6 +2024,7 @@ class DatesPage(Page):
 
         self._reminderDateTimeCombo = widgets.DateTimeCombo(
             self, value=value,
+            suggestedValue=task.Task.suggestedReminderDateTime(),
             hourChoices=lambda: get_suggested_hour_choices(self._DatesPage__settings),
             minuteChoices=lambda: get_suggested_minute_choices(self._DatesPage__settings)
         )

--- a/taskcoachlib/gui/dialog/preferences.py
+++ b/taskcoachlib/gui/dialog/preferences.py
@@ -129,7 +129,7 @@ class FontColorSyncer(object):
             self._fontButton.SetSelectedColour(self._fgColorButton.GetColour())
 
 
-class SettingsPageBase(widgets.BookPage):
+class SettingsPageBase(widgets.ScrolledBookPage):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._booleanSettings = []
@@ -199,7 +199,7 @@ class SettingsPageBase(widgets.BookPage):
             text,
             multipleChoice,
             helpText=helpText,
-            growable=True,
+            growable=kwargs.get("growable", True),
             flags=kwargs.get("flags", None),
         )
         self._multipleChoiceSettings.append(
@@ -276,11 +276,6 @@ class SettingsPageBase(widgets.BookPage):
             text,
             panel,
             helpText=helpText,
-            flags=(
-                wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_RIGHT,
-                wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_LEFT,
-                wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_LEFT,
-            ),
         )
 
     def _onWorkingHourStartChanged(self, event):
@@ -615,10 +610,23 @@ class SettingsPageBase(widgets.BookPage):
 
 
 class SettingsPage(SettingsPageBase):
+    _labelWidth = 300
+    _helpWidth = None  # Subclasses can set to wrap help text at fixed width
+
     def __init__(self, settings=None, taskFile=None, *args, **kwargs):
         self.settings = settings
         self.taskFile = taskFile
         super().__init__(*args, **kwargs)
+
+    def fit(self):
+        """Wrap column 0 labels at fixed width before layout."""
+        for item in self._sizer.GetChildren():
+            pos = item.GetPos()
+            if pos.GetCol() == 0 and item.GetSpan().GetColspan() == 1:
+                window = item.GetWindow()
+                if window and isinstance(window, wx.StaticText):
+                    window.Wrap(self._labelWidth)
+        super().fit()
 
     def addEntry(self, text, *controls, **kwargs):  # pylint: disable=W0221
         helpText = kwargs.pop("helpText", "")
@@ -629,13 +637,15 @@ class SettingsPage(SettingsPageBase):
             )
         elif helpText == "override":
             helpText = _(
-                "This setting can be overridden for individual tasks\n"
+                "This setting can be overridden for individual tasks "
                 "in the task edit dialog."
             )
         if helpText:
             helpCtrl = wx.StaticText(self, label=helpText)
             helpCtrl.SetForegroundColour(
                 wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
+            if self._helpWidth:
+                helpCtrl.Wrap(self._helpWidth)
             controls = controls + (helpCtrl,)
         super().addEntry(text, *controls, **kwargs)
 
@@ -682,6 +692,7 @@ class SavePage(SettingsPage):
     pageName = "save"
     pageTitle = _("Files")
     pageIcon = "save"
+    _helpWidth = 500
 
     def __init__(self, *args, **kwargs):
         super().__init__(columns=3, *args, **kwargs)
@@ -689,57 +700,38 @@ class SavePage(SettingsPage):
             "file",
             "autosave",
             _("Auto save after every change"),
-            flags=(wx.ALIGN_RIGHT | wx.ALIGN_CENTRE_VERTICAL, wx.ALIGN_LEFT),
         )
         self.addBooleanSetting(
             "file",
             "autoload",
             _("Auto load when the file changes on disk"),
-            flags=(wx.ALIGN_RIGHT | wx.ALIGN_CENTRE_VERTICAL, wx.ALIGN_LEFT),
         )
         self.addBooleanSetting(
             "file",
             "fspoll",
             _("Use polling for file monitoring"),
             _(
-                "Use slow polling (every 10s) instead of efficient OS notifications.\nEnable this if your task file is on a network share.\nYou must restart %s after changing this."
+                "Use slow polling (every 10s) instead of efficient OS notifications. Enable this if your task file is on a network share. You must restart %s after changing this."
             )
             % meta.name,
-            flags=(
-                wx.ALIGN_RIGHT | wx.ALIGN_TOP,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-            ),
         )
         self.addBooleanSetting(
             "file",
             "saveinifileinprogramdir",
             _(
-                "Save settings (%s.ini) in the same\n"
+                "Save settings (%s.ini) in the same "
                 "directory as the program"
             )
             % meta.filename,
             _("For running %s from a removable medium") % meta.name,
-            flags=(
-                wx.ALIGN_RIGHT | wx.ALIGN_CENTRE_VERTICAL,
-                wx.ALIGN_LEFT | wx.ALIGN_CENTRE_VERTICAL,
-                wx.ALIGN_LEFT,
-            ),
         )
         self.addPathSetting(
             "file",
             "attachmentbase",
             _("Attachment base directory"),
             _(
-                "When adding an attachment, try to make\n"
+                "When adding an attachment, try to make "
                 "its path relative to this one."
-            ),
-            flags=(
-                wx.ALIGN_RIGHT | wx.ALIGN_TOP,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
             ),
         )
         self.addMultipleChoiceSettings(
@@ -748,18 +740,12 @@ class SavePage(SettingsPage):
             _("Before saving, automatically import from"),
             [("Todo.txt", _("Todo.txt format"))],
             helpText=_(
-                "Before saving, %s automatically imports tasks\n"
-                "from a Todo.txt file with the same name as the task file,\n"
+                "Before saving, %s automatically imports tasks "
+                "from a Todo.txt file with the same name as the task file, "
                 "but with extension .txt"
             )
             % meta.name,
-            flags=(
-                wx.ALIGN_RIGHT | wx.ALIGN_TOP,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-            ),
+            growable=False,
         )
         self.addMultipleChoiceSettings(
             "file",
@@ -767,25 +753,19 @@ class SavePage(SettingsPage):
             _("When saving, automatically export to"),
             [("Todo.txt", _("Todo.txt format"))],
             helpText=_(
-                "When saving, %s automatically exports tasks\n"
-                "to a Todo.txt file with the same name as the task file,\n"
+                "When saving, %s automatically exports tasks "
+                "to a Todo.txt file with the same name as the task file, "
                 "but with extension .txt"
             )
             % meta.name,
-            flags=(
-                wx.ALIGN_RIGHT | wx.ALIGN_TOP,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-            ),
+            growable=False,
         )
         self.fit()
 
 
 class WindowBehaviorPage(SettingsPage):
     pageName = "window"
-    pageTitle = _("Window behavior")
+    pageTitle = _("Windows")
     pageIcon = "windows"
 
     def __init__(self, *args, **kwargs):
@@ -794,7 +774,6 @@ class WindowBehaviorPage(SettingsPage):
             "window",
             "tips",
             _("Show tips window on startup"),
-            flags=[wx.ALIGN_RIGHT, wx.EXPAND],
         )
         self.addChoiceSetting(
             "window",
@@ -806,39 +785,33 @@ class WindowBehaviorPage(SettingsPage):
                 ("Always", _("Always")),
                 ("WhenClosedIconized", _("If it was iconized last session")),
             ],
-            flags=[wx.ALIGN_RIGHT, wx.EXPAND],
         )
         self.addBooleanSetting(
             "version",
             "notify",
-            _("Check for new version " "of %(name)s on startup")
+            _("Check for new version of %(name)s on startup")
             % meta.data.metaDict,
-            flags=[wx.ALIGN_RIGHT, wx.EXPAND],
         )
         self.addBooleanSetting(
             "view",
             "developermessages",
-            _("Check for " "messages from the %(name)s developers on startup")
+            _("Check for messages from the %(name)s developers on startup")
             % meta.data.metaDict,
-            flags=[wx.ALIGN_RIGHT, wx.EXPAND],
         )
         self.addBooleanSetting(
             "window",
             "hidewheniconized",
             _("Hide main window when iconized"),
-            flags=[wx.ALIGN_RIGHT, wx.EXPAND],
         )
         self.addBooleanSetting(
             "window",
             "hidewhenclosed",
             _("Minimize main window when closed"),
-            flags=[wx.ALIGN_RIGHT, wx.EXPAND],
         )
         self.addBooleanSetting(
             "window",
             "blinktaskbariconwhentrackingeffort",
             _("Make clock in the task bar tick when tracking effort"),
-            flags=[wx.ALIGN_RIGHT, wx.EXPAND],
         )
         self.fit()
 
@@ -1292,7 +1265,7 @@ class LanguagePage(SettingsPage):
         self._restartWarning = wx.StaticText(self, label=self._restartWarningBase)
         self._restartWarningDefaultColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
         self._restartWarning.SetForegroundColour(self._restartWarningDefaultColor)
-        self.addEntry("", self._restartWarning, flags=(None, wx.ALIGN_LEFT))
+        self.addEntry("", self._restartWarning)
 
         languages = [
             ("ar", "الْعَرَبيّة (Arabic)"),
@@ -1372,10 +1345,6 @@ class LanguagePage(SettingsPage):
             _("Language"),
             "",
             choices,
-            flags=(
-                wx.ALIGN_RIGHT,
-                wx.ALIGN_LEFT,
-            ),
             sep="-",
         )
 
@@ -1386,7 +1355,7 @@ class LanguagePage(SettingsPage):
         # Locale warning - only shown when selected locale is not installed
         self._localeWarning = wx.StaticText(
             panel,
-            label=_("WARNING: The selected language's locale is not installed on your system.\n"
+            label=_("WARNING: The selected language's locale is not installed on your system. "
                     "Some date and time formats may appear in your system's format instead.")
         )
         self._localeWarning.SetForegroundColour(wx.Colour(180, 0, 0))
@@ -1405,7 +1374,7 @@ class LanguagePage(SettingsPage):
         urlCtrl = HyperLinkCtrl(panel, -1, label=url, URL=url)
         sizer.Add(urlCtrl, 0, wx.TOP, 2)
         panel.SetSizer(sizer)
-        self.addEntry("", panel, flags=(None, wx.ALIGN_LEFT))
+        self.addEntry("", panel)
 
         # Store original language to detect changes
         self._originalLanguage = self._getSelectedLanguageCode()
@@ -1460,8 +1429,7 @@ class LanguagePage(SettingsPage):
         dateFormatSizer.Add(self._detectedFormatLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 15)
 
         dateFormatPanel.SetSizer(dateFormatSizer)
-        self.addEntry(_("Date format:"), dateFormatPanel,
-                      flags=(wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, wx.ALIGN_LEFT))
+        self.addEntry(_("Date format"), dateFormatPanel)
 
         # Demo DateCtrl4 showing the selected format (interactive, starts with today)
         from taskcoachlib.widgets.maskedtimectrl import DateCtrl4
@@ -1478,7 +1446,7 @@ class LanguagePage(SettingsPage):
         )
         demoSizer.Add(self._demoDateCtrl, 0, wx.ALIGN_CENTER_VERTICAL)
         demoPanel.SetSizer(demoSizer)
-        self.addEntry("", demoPanel, flags=(None, wx.ALIGN_LEFT))
+        self.addEntry("", demoPanel)
 
         # === TIME FORMAT SECTION ===
         # Time format dropdown with detected format label
@@ -1515,8 +1483,7 @@ class LanguagePage(SettingsPage):
 
         timeFormatPanel.SetSizer(timeFormatSizer)
         self._timeFormatChoice.Bind(wx.EVT_CHOICE, self._onTimeFormatChange)
-        self.addEntry(_("Time format:"), timeFormatPanel,
-                      flags=(wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, wx.ALIGN_LEFT))
+        self.addEntry(_("Time format"), timeFormatPanel)
 
         # Demo TimeCtrl showing the selected format (interactive, starts with current time)
         # TimeCtrl now has built-in defaults from settings, so no need to pass choices
@@ -1535,7 +1502,7 @@ class LanguagePage(SettingsPage):
         )
         timeDemoSizer.Add(self._demoTimeCtrl, 0, wx.ALIGN_CENTER_VERTICAL)
         timeDemoPanel.SetSizer(timeDemoSizer)
-        self.addEntry("", timeDemoPanel, flags=(None, wx.ALIGN_LEFT))
+        self.addEntry("", timeDemoPanel)
 
         # Note about 12-hour mode and working hours
         timeFormatNote = wx.StaticText(
@@ -1545,7 +1512,7 @@ class LanguagePage(SettingsPage):
         timeFormatNote.SetForegroundColour(
             wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
         )
-        self.addEntry("", timeFormatNote, flags=(None, wx.ALIGN_LEFT))
+        self.addEntry("", timeFormatNote)
 
         # Separator line between time format and spell check sections
         self.addLine()
@@ -1568,10 +1535,7 @@ class LanguagePage(SettingsPage):
         self._spellCheckEnabledCheck = wx.CheckBox(self, label=_("Enable spell checking"))
         self._spellCheckEnabledCheck.SetValue(self._spellCheckEnabled)
         self._spellCheckEnabledCheck.Bind(wx.EVT_CHECKBOX, self._onSpellCheckEnabledChange)
-        self.addEntry(
-            _("Spell check:"), self._spellCheckEnabledCheck,
-            flags=(wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, wx.ALIGN_LEFT)
-        )
+        self.addEntry(_("Spell check"), self._spellCheckEnabledCheck)
 
         # Show warning if enchant is not available
         if not ENCHANT_AVAILABLE:
@@ -1580,7 +1544,7 @@ class LanguagePage(SettingsPage):
                 label=_("Warning: Spell checking is not available. Install pyenchant to enable this feature.")
             )
             warningText.SetForegroundColour(wx.Colour(180, 0, 0))
-            self.addEntry("", warningText, flags=(None, wx.ALIGN_LEFT))
+            self.addEntry("", warningText)
             self._spellCheckEnabledCheck.Enable(False)
 
         # Language dropdown for spell check
@@ -1619,10 +1583,7 @@ class LanguagePage(SettingsPage):
             spellLangSizer.Add(detectedLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 15)
 
         spellLangPanel.SetSizer(spellLangSizer)
-        self.addEntry(
-            _("Spell check language:"), spellLangPanel,
-            flags=(wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, wx.ALIGN_LEFT)
-        )
+        self.addEntry(_("Spell check language"), spellLangPanel)
 
         # Note about dropdown and how to install more dictionaries
         if ENCHANT_AVAILABLE:
@@ -1636,7 +1597,7 @@ class LanguagePage(SettingsPage):
                     label=_("Language missing? Install hunspell packages for your language.")
                 )
                 helpText.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
-                self.addEntry("", helpText, flags=(None, wx.ALIGN_LEFT))
+                self.addEntry("", helpText)
 
             # Platform-specific note combining dropdown info and install instructions
             if system == "Linux":
@@ -1649,7 +1610,7 @@ class LanguagePage(SettingsPage):
             dictNote = wx.StaticText(self, label=noteText)
             dictNote.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
             dictNote.Wrap(500)
-            self.addEntry("", dictNote, flags=(None, wx.ALIGN_LEFT))
+            self.addEntry("", dictNote)
 
     def _onSpellCheckEnabledChange(self, event):
         """Handle spell check enabled checkbox change."""
@@ -1865,59 +1826,46 @@ class FeaturesPage(SettingsPage):
     pageName = "features"
     pageTitle = _("Features")
     pageIcon = "cogwheel_icon"
+    _helpWidth = 500
 
     def __init__(self, *args, **kwargs):
         super().__init__(columns=3, growableColumn=-1, *args, **kwargs)
-        self.addEntry(
-            _(
-                "All settings on this tab require a restart of %s "
-                "to take effect"
-            )
-            % meta.name,
-            flags=(wx.ALIGN_CENTER,),
-        )
+        self._restartWarningBase = _("All settings on this tab require a restart of %s to take effect.") % meta.name
+        self._restartWarning = wx.StaticText(self, label=self._restartWarningBase)
+        self._restartWarningDefaultColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
+        self._restartWarning.SetForegroundColour(self._restartWarningDefaultColor)
+        self.addEntry("", self._restartWarning)
         self.addChoiceSetting(
             "view",
             "weekstart",
             _("Start of work week"),
             " ",
             [("monday", _("Monday")), ("sunday", _("Sunday"))],
-            flags=(
-                wx.ALIGN_RIGHT | wx.ALIGN_CENTRE_VERTICAL,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-            ),
         )
         self.addWorkingHoursSetting(_("Working hours"))
-        # Note about working hours and 12-hour mode
         workingHoursNote = wx.StaticText(
             self,
             label=_("Note: Working hours are not used for hour suggestions when 12-hour (AM/PM) time format is selected in Regional settings.")
         )
         workingHoursNote.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
-        workingHoursNote.Wrap(600)
-        self.addEntry("", workingHoursNote, flags=(wx.ALIGN_LEFT, wx.EXPAND))
+        workingHoursNote.Wrap(700)
+        self.addEntry("", workingHoursNote)
 
         self.addBooleanSetting(
             "calendarviewer",
             "gradient",
-            _(
-                "Use gradients in calendar views.\n"
-                "This may slow down Task Coach."
-            ),
-            flags=(wx.ALIGN_RIGHT | wx.ALIGN_CENTRE_VERTICAL, wx.EXPAND),
+            _("Gradients in calendar views"),
+            _("Using gradients in calendar views may slow down Task Coach"),
         )
         self.addChoiceSetting(
             "view",
             "effortminuteinterval",
             _("Minutes between suggested times"),
             _(
-                "In popup-menus for time selection (e.g. for setting the start \n"
-                "time of an effort) %(name)s will suggest times using this \n"
-                "setting. The smaller the number of minutes, the more times \n"
-                "are suggested. Of course, you can also enter any time you \n"
+                "In popup-menus for time selection (e.g. for setting the start "
+                "time of an effort) %(name)s will suggest times using this "
+                "setting. The smaller the number of minutes, the more times "
+                "are suggested. Of course, you can also enter any time you "
                 "want beside the suggested times."
             )
             % meta.data.metaDict,
@@ -1925,18 +1873,13 @@ class FeaturesPage(SettingsPage):
                 (minutes, minutes)
                 for minutes in ("1", "2", "3", "4", "5", "6", "10", "12", "15", "20", "30")
             ],
-            flags=(
-                wx.ALL | wx.ALIGN_TOP | wx.ALIGN_RIGHT,
-                wx.ALL | wx.ALIGN_TOP,
-                wx.ALL | wx.ALIGN_CENTER_VERTICAL,
-            ),
         )
         self.addChoiceSetting(
             "view",
             "effortsecondinterval",
             _("Seconds between suggested times"),
             _(
-                "In effort dialogs where seconds are shown, %(name)s will \n"
+                "In effort dialogs where seconds are shown, %(name)s will "
                 "suggest second values using this setting."
             )
             % meta.data.metaDict,
@@ -1944,40 +1887,85 @@ class FeaturesPage(SettingsPage):
                 (seconds, seconds)
                 for seconds in ("1", "2", "3", "4", "5", "6", "10", "12", "15", "20", "30")
             ],
-            flags=(
-                wx.ALL | wx.ALIGN_TOP | wx.ALIGN_RIGHT,
-                wx.ALL | wx.ALIGN_TOP,
-                wx.ALL | wx.ALIGN_CENTER_VERTICAL,
-            ),
         )
         self.addIntegerSetting(
             "feature",
             "minidletime",
             _("Idle time notice"),
             helpText=_(
-                "If there is no user input for this amount of time\n"
+                "If there is no user input for this amount of time "
                 "(in minutes), %(name)s will ask what to do about current "
                 "efforts."
             )
             % meta.data.metaDict,
-            flags=(
-                wx.ALL | wx.ALIGN_CENTRE_VERTICAL | wx.ALIGN_RIGHT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-            ),
         )
         self.addBooleanSetting(
             "view",
             "descriptionpopups",
-            _(
-                "Show a popup with the description of an item\n"
-                "when hovering over it"
-            ),
-            flags=(wx.ALIGN_RIGHT | wx.ALIGN_CENTRE_VERTICAL, wx.EXPAND),
+            _("Hoverover popups"),
+            _("Show a popup with the description of an item when hovering over it"),
         )
+
+        # Store original values to detect changes
+        self._originalValues = {}
+        for section, setting, checkBox in self._booleanSettings:
+            self._originalValues[(section, setting)] = checkBox.IsChecked()
+            checkBox.Bind(wx.EVT_CHECKBOX, self._onSettingChange)
+        for section, setting, choiceCtrls in self._choiceSettings:
+            self._originalValues[(section, setting)] = tuple(
+                c.GetSelection() for c in choiceCtrls
+            )
+            for c in choiceCtrls:
+                c.Bind(wx.EVT_CHOICE, self._onSettingChange)
+        for section, setting, spinCtrl in self._integerSettings:
+            self._originalValues[(section, setting)] = spinCtrl.GetValue()
+            spinCtrl.Bind(wx.EVT_SPINCTRL, self._onSettingChange)
+        # Working hours
+        self._originalValues[("view", "efforthourstart")] = self._workingHourStartChoice.GetSelection()
+        self._originalValues[("view", "efforthourend")] = self._workingHourEndChoice.GetSelection()
+        self._originalValues[("view", "efforthourend_endofday")] = self._workingHourEndOfDayCheck.IsChecked()
+        self._workingHourStartChoice.Bind(wx.EVT_CHOICE, self._onSettingChange)
+        self._workingHourEndChoice.Bind(wx.EVT_CHOICE, self._onSettingChange)
+        self._workingHourEndOfDayCheck.Bind(wx.EVT_CHECKBOX, self._onSettingChange)
+
         self.fit()
+
+    def _onSettingChange(self, event):
+        self._updateRestartWarning()
+        event.Skip()
+
+    def _updateRestartWarning(self):
+        changed = False
+        for section, setting, checkBox in self._booleanSettings:
+            if checkBox.IsChecked() != self._originalValues.get((section, setting)):
+                changed = True
+                break
+        if not changed:
+            for section, setting, choiceCtrls in self._choiceSettings:
+                current = tuple(c.GetSelection() for c in choiceCtrls)
+                if current != self._originalValues.get((section, setting)):
+                    changed = True
+                    break
+        if not changed:
+            for section, setting, spinCtrl in self._integerSettings:
+                if spinCtrl.GetValue() != self._originalValues.get((section, setting)):
+                    changed = True
+                    break
+        if not changed:
+            if (self._workingHourStartChoice.GetSelection() != self._originalValues[("view", "efforthourstart")]
+                or self._workingHourEndChoice.GetSelection() != self._originalValues[("view", "efforthourend")]
+                or self._workingHourEndOfDayCheck.IsChecked() != self._originalValues[("view", "efforthourend_endofday")]):
+                changed = True
+
+        if changed:
+            self._restartWarning.SetLabel(
+                self._restartWarningBase + " " + _("Change detected, restart required!")
+            )
+            self._restartWarning.SetForegroundColour(wx.Colour(180, 0, 0))
+        else:
+            self._restartWarning.SetLabel(self._restartWarningBase)
+            self._restartWarning.SetForegroundColour(self._restartWarningDefaultColor)
+        self._restartWarning.Refresh()
 
     def ok(self):
         super().ok()
@@ -1991,6 +1979,7 @@ class TaskDatesPage(SettingsPage):
     pageName = "task"
     pageTitle = _("Task dates")
     pageIcon = "calendar_icon"
+    _helpWidth = 700
 
     def __init__(self, *args, **kwargs):
         super().__init__(columns=4, growableColumn=-1, *args, **kwargs)
@@ -1999,11 +1988,6 @@ class TaskDatesPage(SettingsPage):
             "markparentcompletedwhenallchildrencompleted",
             _("Mark parent task completed when all children are completed"),
             helpText="override",
-            flags=(
-                wx.ALIGN_RIGHT,
-                wx.ALIGN_LEFT,
-                wx.EXPAND,
-            ),
         )
         self.addIntegerSetting(
             "behavior",
@@ -2011,7 +1995,6 @@ class TaskDatesPage(SettingsPage):
             _("Number of hours that tasks are considered to be 'due soon'"),
             minimum=0,
             maximum=9999,
-            flags=(wx.ALIGN_RIGHT, wx.ALL | wx.ALIGN_LEFT),
         )
         choices = [
             ("", _("Nothing")),
@@ -2032,8 +2015,18 @@ class TaskDatesPage(SettingsPage):
             ),
             "",
             choices,
-            flags=(wx.ALIGN_RIGHT, wx.ALL | wx.ALIGN_LEFT),
         )
+        datestied_hint = wx.StaticText(
+            self,
+            label=_(
+                'Deprecated: replaced by the duration mode in the task editor. '
+                'Inline editing in the task list has not yet been refactored '
+                'and still uses this legacy option. It will be removed eventually.'
+            ),
+        )
+        datestied_hint.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
+        datestied_hint.Wrap(700)
+        self.addText("", datestied_hint)
 
         check_choices = [("preset", _("Preset")), ("propose", _("Propose"))]
         day_choices = [
@@ -2058,12 +2051,6 @@ class TaskDatesPage(SettingsPage):
             check_choices,
             day_choices,
             time_choices,
-            flags=(
-                wx.ALIGN_RIGHT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-            ),
         )
         self.addChoiceSetting(
             "view",
@@ -2073,12 +2060,6 @@ class TaskDatesPage(SettingsPage):
             check_choices,
             day_choices,
             time_choices,
-            flags=(
-                wx.ALIGN_RIGHT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-            ),
         )
         self.addChoiceSetting(
             "view",
@@ -2088,12 +2069,6 @@ class TaskDatesPage(SettingsPage):
             check_choices,
             day_choices,
             time_choices,
-            flags=(
-                wx.ALIGN_RIGHT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-            ),
         )
         self.addChoiceSetting(
             "view",
@@ -2103,12 +2078,6 @@ class TaskDatesPage(SettingsPage):
             [check_choices[1]],
             day_choices,
             time_choices,
-            flags=(
-                wx.ALIGN_RIGHT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-            ),
         )
         self.addChoiceSetting(
             "view",
@@ -2118,12 +2087,6 @@ class TaskDatesPage(SettingsPage):
             check_choices,
             day_choices,
             time_choices,
-            flags=(
-                wx.ALIGN_RIGHT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-                wx.ALIGN_LEFT,
-            ),
         )
         self.__add_help_text()
         self.fit()
@@ -2141,13 +2104,14 @@ class TaskDatesPage(SettingsPage):
             )
             % meta.data.metaDict,
         )
-        help_text.Wrap(460)
+        help_text.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
+        help_text.Wrap(700)
         self.addText("", help_text)
 
 
 class TaskReminderPage(SettingsPage):
     pageName = "reminder"
-    pageTitle = _("Task reminders")
+    pageTitle = _("Reminders")
     pageIcon = "clock_alarm_icon"
 
     def __init__(self, *args, **kwargs):
@@ -2158,11 +2122,6 @@ class TaskReminderPage(SettingsPage):
                 "sayreminder",
                 _("Let the computer say the reminder"),
                 _("(Needs espeak)") if operating_system.isGTK() else "",
-                flags=(
-                    wx.ALIGN_RIGHT | wx.ALIGN_CENTRE_VERTICAL,
-                    wx.ALL | wx.ALIGN_LEFT,
-                    wx.ALL | wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL,
-                ),
             )
         snoozeChoices = [
             (str(choice[0]), choice[1]) for choice in date.snoozeChoices
@@ -2173,17 +2132,13 @@ class TaskReminderPage(SettingsPage):
             _("Default snooze time to use after reminder"),
             "",
             snoozeChoices,
-            flags=(
-                wx.ALIGN_RIGHT | wx.ALIGN_CENTRE_VERTICAL,
-                wx.ALL | wx.ALIGN_LEFT,
-            ),
         )
         self.addMultipleChoiceSettings(
             "view",
             "snoozetimes",
             _("Snooze times to offer in task reminder dialog"),
             date.snoozeChoices[1:],
-            flags=(wx.ALIGN_TOP | wx.ALIGN_RIGHT, wx.ALL | wx.EXPAND),
+            flags=(None, wx.ALL | wx.EXPAND),
         )  # Don't offer "Don't snooze" as a choice
         self.fit()
 
@@ -2225,10 +2180,7 @@ class DurationPresetsPage(SettingsPage):
             self.__fieldChoice.Append(display_name)
         self.__fieldChoice.SetSelection(0)
         self.__fieldChoice.Bind(wx.EVT_CHOICE, self.__onFieldChanged)
-        self.addEntry(
-            _("Configure presets for:"), self.__fieldChoice,
-            flags=(wx.ALIGN_RIGHT | wx.ALIGN_CENTRE_VERTICAL, wx.ALIGN_LEFT)
-        )
+        self.addEntry(_("Configure presets for"), self.__fieldChoice)
 
         # Add row: DurationEntry + Add button
         self.__addPanel = wx.Panel(self)
@@ -2236,7 +2188,7 @@ class DurationPresetsPage(SettingsPage):
 
         # Create duration control - initially without seconds (Task Due Date is default)
         self.__durationEntry = self.__createDurationCtrl(showSeconds=False)
-        self.__addSizer.Add(self.__durationEntry, 0, wx.RIGHT | wx.ALIGN_CENTRE_VERTICAL, 10)
+        self.__addSizer.Add(self.__durationEntry, 0, wx.RIGHT | wx.ALIGN_CENTRE_VERTICAL, 5)
 
         self.__addBtn = wx.Button(self.__addPanel, wx.ID_ANY, _("Add"))
         self.__addBtn.SetBitmap(
@@ -2246,10 +2198,7 @@ class DurationPresetsPage(SettingsPage):
         self.__addSizer.Add(self.__addBtn, 0, wx.ALIGN_CENTRE_VERTICAL)
 
         self.__addPanel.SetSizer(self.__addSizer)
-        self.addEntry(
-            _("Add new preset:"), self.__addPanel,
-            flags=(wx.ALIGN_RIGHT | wx.ALIGN_CENTRE_VERTICAL, wx.ALIGN_LEFT)
-        )
+        self.addEntry(_("Add new preset"), self.__addPanel)
 
         # Preset list with 3 columns: short value, description, delete button
         # Using UltimateListCtrl to support embedded Delete buttons
@@ -2260,23 +2209,20 @@ class DurationPresetsPage(SettingsPage):
         self.__listCtrl.InsertColumn(0, _("Short"), width=80, format=wx.LIST_FORMAT_RIGHT)
         self.__listCtrl.InsertColumn(1, _("Description"), width=310)
         self.__listCtrl.InsertColumn(2, _("Delete"), width=110)
-        # Fixed width 500px, growable height with scrollbars as needed
         self.__listCtrl.SetMinSize((500, 120))
-        self.__listCtrl.SetMaxSize((500, -1))  # -1 means no max height
+        self.__listCtrl.SetMaxSize((500, -1))
         # Track delete buttons for cleanup
         self.__deleteButtons = []
         self.addEntry(
-            _("Current presets:"), self.__listCtrl, growable=True,
-            flags=(wx.ALIGN_TOP | wx.ALIGN_RIGHT, wx.EXPAND | wx.ALL)
+            _("Current presets"), self.__listCtrl, growable=True,
+            flags=(None, wx.EXPAND | wx.ALL)
         )
 
         # Help text
         self.__helpText = wx.StaticText(self, label="")
+        self.__helpText.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
         self.__helpText.Wrap(500)
-        self.addEntry(
-            "", self.__helpText,
-            flags=(wx.ALIGN_RIGHT, wx.ALIGN_LEFT | wx.EXPAND)
-        )
+        self.addEntry("", self.__helpText)
 
         # Populate initial list
         self.__populateList()

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,8 +41,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "58"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.1.58
+patch = "59"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.1.59
 
 release_day = "1"  # Day of the release (1-31)
 release_month = "February"  # Month of the release

--- a/taskcoachlib/widgets/maskedtimectrl.py
+++ b/taskcoachlib/widgets/maskedtimectrl.py
@@ -3585,14 +3585,15 @@ class DateTimeCombo2:
         secondChoices: Dropdown choices for seconds field
     """
 
-    def __init__(self, parent, value=None,
+    def __init__(self, parent, value=None, suggestedValue=None,
                  hourChoices=None, minuteChoices=None,
                  showSeconds=False, secondChoices=None):
         self._parent = parent
         self._showSeconds = showSeconds
+        self._suggestedValue = suggestedValue
 
         checked = value is not None
-        display_value = value if value is not None else datetime.datetime.now()
+        display_value = value if value is not None else (suggestedValue or datetime.datetime.now())
 
         self._checkbox = wx.CheckBox(parent)
         self._checkbox.SetValue(checked)
@@ -3749,10 +3750,19 @@ class DateTimeCombo2:
         Used by duration calc logic (steps 2.1, 3.1) to activate a missing
         date without specifying a value. Also used by SetValue() to set a
         specific datetime and activate in one call.
+
+        On first activation with no explicit value, uses the suggestedValue
+        from preferences (if provided at construction). After first use the
+        suggestedValue is cleared so subsequent activations keep the last
+        user-set value.
         """
         if value is not None:
             self._dateCtrl.SetDate(value.date())
             self._timeCtrl.SetTime(value.time())
+        elif self._suggestedValue is not None:
+            self._dateCtrl.SetDate(self._suggestedValue.date())
+            self._timeCtrl.SetTime(self._suggestedValue.time())
+            self._suggestedValue = None
         self._setCheckboxState(True)
         self._updateEnabled()
 

--- a/taskcoachlib/widgets/notebook.py
+++ b/taskcoachlib/widgets/notebook.py
@@ -79,14 +79,9 @@ class BookPage(wx.Panel):
 
     def __defaultFlags(self, controls):
         """Return the default flags for placing a list of controls."""
-        labelInFirstColumn = type(controls[0]) in [type(""), type("")]
         flags = []
         for columnIndex in range(len(controls)):
-            flag = wx.ALL | wx.ALIGN_CENTER_VERTICAL
-            if columnIndex == 0 and labelInFirstColumn:
-                flag |= wx.ALIGN_LEFT
-            else:
-                flag |= wx.ALIGN_RIGHT | wx.EXPAND
+            flag = wx.ALL | wx.ALIGN_TOP | wx.ALIGN_LEFT
             flags.append(flag)
         return flags
 
@@ -194,19 +189,14 @@ class ScrolledBookPage(scrolledpanel.ScrolledPanel):
             self._outerSizer = wx.BoxSizer(wx.VERTICAL)
             self._outerSizer.Add(self._sizer, 1, wx.EXPAND | wx.ALL, self._outerMargin)
             self.SetSizer(self._outerSizer)
-        self.SetupScrolling(scroll_x=False, scroll_y=True)
+        self.SetupScrolling(scroll_x=True, scroll_y=True)
         self.Layout()
 
     def __defaultFlags(self, controls):
         """Return the default flags for placing a list of controls."""
-        labelInFirstColumn = type(controls[0]) in [type(""), type("")]
         flags = []
         for columnIndex in range(len(controls)):
-            flag = wx.ALL | wx.ALIGN_CENTER_VERTICAL
-            if columnIndex == 0 and labelInFirstColumn:
-                flag |= wx.ALIGN_LEFT
-            else:
-                flag |= wx.ALIGN_RIGHT | wx.EXPAND
+            flag = wx.ALL | wx.ALIGN_TOP | wx.ALIGN_LEFT
             flags.append(flag)
         return flags
 
@@ -234,6 +224,8 @@ class ScrolledBookPage(scrolledpanel.ScrolledPanel):
                 columnIndex, control, flags[columnIndex],
                 columnIndex == lastColumnIndex
             )
+        if kwargs.get("growable", False):
+            self._sizer.AddGrowableRow(self._position.maxRow())
         # Add growable column once, when first entry has been added
         if (
             self._growableColumn >= 0


### PR DESCRIPTION
Propose mode for default dates on new tasks was broken. Through various refactorings the suggested datetime from user preferences stopped being passed to the date picker widgets. Propose mode silently fell back to datetime.now(), ignoring the configured defaults (e.g. "tomorrow at start of working day"). Preset mode worked but through a constructor bypass that skipped normal domain callbacks.

Fix: wire suggested datetime from preferences through to all five date picker widgets so propose mode shows the correct default values.

preference for proposed/preset dates needs more flexibility #340

Also:
- Fix GTK NULL assertion crash on new objects (appearance getters return safe defaults before first SSOT poll)
- Clean up preferences dialog layout (Files, Windows, Features, Task Dates tabs: hint wrapping, default alignment, restart warning)
- Add architecture docs (DATETIME_PRESETS.md, PERSISTENCE_XML.md)
- Update DURATION_CALCULATIONS.md (correct starting mode, add mode-change notes, renumber rules)
- Bump version to 2.0.1.59

Also, Added plan for preferences dirty check in TODO.md
https://github.com/taskcoach/taskcoach/blob/master/docs/TODO.md#preferences-dialog-dirty-check-and-button-state
minor: "apply" in prefs ought to be greyed out if nothing has changed #329



