### PR TITLE
Refactor duration/datetime event model and clean up dead code

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.59-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.59-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.59_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.59_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.59_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.59-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.60-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.60-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.60_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.60_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.60_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.60-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.59-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.59-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.59_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.59_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.59-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.59-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.60-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.60-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.60_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.60_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.60-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.60-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.59_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.59_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.60_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.60_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.59-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.59-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.60-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.60-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.59-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.59-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.60-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.60-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.59-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.59-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.60-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.60-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.59-x86_64.AppImage
+./TaskCoach-2.0.1.60-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/docs/ATTRIBUTE_PATTERN.md
+++ b/docs/ATTRIBUTE_PATTERN.md
@@ -4,6 +4,7 @@ The domain model's change-detection and event-notification pattern.
 
 ## Index
 
+- [TODO](#todo)
 - [Overview](#overview)
 - [Attribute Class API](#attribute-class-api)
 - [SetAttribute Class API](#setattribute-class-api)
@@ -12,6 +13,46 @@ The domain model's change-detection and event-notification pattern.
 - [Event Batching During Load](#event-batching-during-load)
 - [Volatile vs Persisted Attributes](#volatile-vs-persisted-attributes)
 - [Three-Layer Relationship](#three-layer-relationship)
+
+---
+
+## TODO
+
+1. **Migrate remaining `EVT_KILL_FOCUS` AttributeSync sites to
+   `EVT_VALUE_CHANGED`.** The legacy pattern binds AttributeSync to
+   `EVT_KILL_FOCUS` (blur). This works for user edits (commit on focus
+   loss), but is invisible to programmatic writes — widget methods like
+   `SetDuration()` fire `EVT_VALUE_CHANGED`, not `EVT_KILL_FOCUS`, so
+   the AttributeSync never sees them and the domain is never updated.
+   **Done:** DurationCtrl (task and effort) and all DateTimeCombo fields
+   now use plain `EVT_VALUE_CHANGED` with immediate commit — no
+   `commit_on_focus_loss` needed because `FieldsCtrl` fires only on
+   blur (user) or `SetDuration()` (programmatic). See TODO #2.
+   **Remaining:** monetary controls (budget, hourly fee, fixed fee) are
+   FieldsCtrl-based and should follow the same pattern. Subject,
+   description, and attachment location use `wx.TextCtrl` (fires
+   per-keystroke `EVT_TEXT`) — different migration path. See
+   [Three-Layer Relationship](#three-layer-relationship), Layer 2.
+
+2. **Remove `commit_on_focus_loss` from AttributeSync.** The
+   `commit_on_focus_loss` mechanism was added to batch per-keystroke
+   `EVT_VALUE_CHANGED` events into a single command on blur. This is
+   the wrong separation of concerns — whether events fire per-keystroke
+   or on blur is the **control's** responsibility, not the sync layer's.
+   `FieldsCtrl` now handles this correctly: `NumericField.SetValue()`
+   no longer fires `NotifyValueChanged()`; instead, `FieldsCtrl` fires
+   `EVT_VALUE_CHANGED` only on `_onKillFocus` (user finished typing)
+   and from `SetDuration()`/`SetTime()`/`SetDate()` (programmatic
+   complete-value writes). Every `EVT_VALUE_CHANGED` that reaches
+   `AttributeSync` represents a final value — immediate commit is
+   always correct. The `commit_on_focus_loss` parameter, the
+   `__editSessionValue`/`__hasChanges` tracking, the `__onSetFocus`/
+   `__onKillFocus` handlers, and the `commit()` method can all be
+   removed. All `AttributeSync` sites should use plain
+   `EVT_VALUE_CHANGED` with immediate commit (the default).
+   **Status:** `commit_on_focus_loss` has zero callers (the only caller,
+   `addDateEntry`, was dead code and has been deleted). The mechanism in
+   `attributesync.py` can be removed now.
 
 ---
 
@@ -181,8 +222,12 @@ with the same value only fires an event on the first actual change.
 **Layer 2: AttributeSync (UI↔Domain)** — Bidirectional sync between a UI
 control and a domain object. User edits control → executes command → domain
 updated. Domain changes → `control.SetValue()` → UI updated. Expects
-controls to implement `GetValue()`/`SetValue()`. Typically uses
-`wx.EVT_KILL_FOCUS` for commit-on-focus-loss.
+controls to implement `GetValue()`/`SetValue()`. Standard pattern:
+`EVT_VALUE_CHANGED` with immediate commit — the control decides when to fire
+(on blur for user edits, immediately for programmatic writes). Composite
+controls like `DateTimeCombo` inherit `wx.EvtHandler` and own the event,
+firing on sub-control blur and state transitions. Legacy sites still use
+`EVT_KILL_FOCUS` (see [TODO #1](#todo)).
 **File:** `taskcoachlib/gui/dialog/attributesync.py`
 **Usage:** See DATETIME_CONTROLS.md, MONETARY_CONTROLS.md
 

--- a/docs/DATETIME_CONTROLS.md
+++ b/docs/DATETIME_CONTROLS.md
@@ -28,8 +28,7 @@ Simple time and duration input controls with explicit subfields and translatable
   - [DurationCtrlVerbose](#durationctrlverbose)
   - [TimeCtrl](#timectrl)
   - [TimeWithSecondsCtrl](#timewithsecondsctrl)
-  - [DateCtrl](#datectrl)
-  - [DateTimeCombo](#datetimecombo)
+  - [Locale and Date Format Settings](#locale-and-date-format-settings)
 - [Events](#events)
 - [Creating Custom Controls](#creating-custom-controls)
 - [Translation](#translation)
@@ -45,7 +44,8 @@ Simple time and duration input controls with explicit subfields and translatable
   - [Popup Toggle Logic](#popup-toggle-logic)
   - [Dropdown Width and Position](#dropdown-width-and-position)
   - [Events from Popup](#events-from-popup)
-  - [Sync Pattern: EVT_VALUE_CHANGED (DateTimeCombo2)](#sync-pattern-evt_value_changed-datetimecombo2)
+  - [Sync Pattern: EVT_VALUE_CHANGED (DateTimeCombo)](#sync-pattern-evt_value_changed-datetimecombo2)
+  - [Sub-Control Stash Model](#sub-control-stash-model)
 - [Wayland](#wayland)
   - [Problem](#problem)
   - [Why GDK_BACKEND=x11 Is Not Viable](#why-gdk_backendx11-is-not-viable)
@@ -65,26 +65,45 @@ Self-contained module with custom-painted single field and navigable subfields.
 ## TODO
 
 1. ~~Add `Activate()` method to DateTimeCombo~~ — **Done.** `ActivateValue()` on
-   DateTimeCombo2. Editor uses it in `__activateStartDate()` / `__activateDueDate()`.
+   DateTimeCombo. Editor uses it in `__activateStartDate()` / `__activateDueDate()`.
 2. ~~Add `Deactivate()` method to DateTimeCombo~~ — **Done.** `DeactivateValue()` on
-   DateTimeCombo2. Editor deactivation goes through commands (domain write →
-   pubsub → SetValue(sentinel) → unchecks). `DeactivateValue()` available for
-   direct UI use (e.g. entry.py recurrence stop date).
+   DateTimeCombo. Editor deactivation goes through `DeactivateValue()` →
+   widget fires event → AttributeSync → command → domain. ~~Previously went
+   through commands directly (domain write → pubsub → SetValue(sentinel) →
+   unchecks), violating widget-as-UI-SSOT principle.~~ Fixed: all editor
+   helpers now go through the widget API.
 3. ~~Checkbox toggle EVT_KILL_FOCUS gap~~ — **Resolved.** ~~Editor binds
    `EVT_CHECKBOX` via `combo.Bind(wx.EVT_CHECKBOX, handler)` and calls
    `sync.commit()` explicitly.~~
-   **Update:** EVT_CHECKBOX is no longer exposed by DateTimeCombo2. The
+   **Update:** EVT_CHECKBOX is no longer exposed by DateTimeCombo. The
    checkbox is an internal implementation detail. All AttributeSync instances
    now use `EVT_VALUE_CHANGED` as `editedEventType`, which fires on checkbox
    toggle AND date/time edits — no external EVT_CHECKBOX handlers needed.
    See [DURATION_CALCULATIONS.md](DURATION_CALCULATIONS.md) TODO item 9.
-   **Bug found & fixed:** `_onCheckboxChanged` was posting `EVT_VALUE_CHANGED`
-   to `DateCtrl4` via `wx.PostEvent()`, but `DateCtrl4.Bind()` forwards
-   `EVT_VALUE_CHANGED` to the inner `_EmbeddedDateCtrl`. Event posted on
-   parent, handler on child — command events propagate up, not down — event
-   lost. Fix: `DateCtrl4._fireValueChanged()` delegates to inner control.
-   `_onCheckboxChanged` now calls `self._dateCtrl._fireValueChanged()` instead
-   of `wx.PostEvent()`.
+   **Superseded:** DateTimeCombo now inherits `wx.EvtHandler` and posts
+   `EVT_VALUE_CHANGED` on itself. See
+   [DateTimeCombo Event Ownership](#datetimecombo-event-ownership).
+4. **Sub-control stash model and event contract** — The sub-controls are the
+   stash for DateTimeCombo. `ActivateValue()` and `DeactivateValue()` must
+   each fire `EVT_VALUE_CHANGED` when they change the control's
+   externally-visible state. Sub-control events alone are not sufficient —
+   they don't fire when only the checkbox changes. See
+   [Sub-Control Stash Model](#sub-control-stash-model).
+6. ~~**Editor helpers must go through widget API**~~ — **Done.** All task
+   calc helpers (`__deactivateStartDate`, `__deactivateDueDate`,
+   `__adjDueDate`, `__adjStartDate`, `__adjDuration`, etc.) have been
+   inlined into `__syncTaskState` using `ActivateValue()`/`DeactivateValue()`
+   /`SetDuration()` on the widget. The effort calc was already inline.
+7. **Migrate remaining `EVT_KILL_FOCUS` AttributeSync sites to
+   `EVT_VALUE_CHANGED`.** DurationCtrl (both task and effort) and all
+   DateTimeCombo fields are done — they use plain `EVT_VALUE_CHANGED` with
+   immediate commit (no `commit_on_focus_loss`). The control fires only on
+   blur or programmatic complete-value write, so every event is a final
+   value. Remaining `EVT_KILL_FOCUS` sites: budget, hourly fee, fixed fee
+   (FieldsCtrl-based monetary controls). Subject, description, and
+   attachment location use `wx.TextCtrl` (per-keystroke `EVT_TEXT`) — a
+   different migration. See
+   [ATTRIBUTE_PATTERN.md TODO #1](ATTRIBUTE_PATTERN.md#todo).
 
 ## Location
 
@@ -248,57 +267,34 @@ Controls must update automatically when the underlying data changes from externa
 - `SetValue(newValue)` - sets value from domain type
 - `Bind(eventType, handler)` - binds to control's change event
 
-### Sync on Focus Loss (Same as Subject Field)
+### Sync via EVT_VALUE_CHANGED
 
-DateTimeCombo uses `wx.EVT_KILL_FOCUS` for synchronization, matching the subject field pattern. This prevents sorted lists from jumping around during edits - changes only sync when focus leaves the control.
+Controls fire `EVT_VALUE_CHANGED` when a value changes. AttributeSync listens
+to this event, calls `GetValue()`, and commits immediately.
 
-**Code reference:** `taskcoachlib/gui/dialog/editor.py` (example usage)
-```python
-self._plannedStartDateTimeSync = attributesync.AttributeSync(
-    "plannedStartDateTime",           # Attribute getter name on domain object
-    self._plannedStartDateTimeCombo,  # Control with GetValue/SetValue
-    plannedStartDateTime,             # Current value
-    self.items,                       # Domain objects being edited
-    command.EditPlannedStartDateTimeCommand,  # Command class
-    wx.EVT_KILL_FOCUS,                # Sync when focus leaves (same as subject)
-    self.items[0].plannedStartDateTimeChangedEventType(),  # Domain change event
-    callback=self.__onPlannedStartChanged,
-)
-```
+Controls provide `GetValue()` / `SetValue()` that work with domain types
+(`date.DateTime`, `date.TimeDelta`), making them compatible with AttributeSync.
 
-**Why EVT_KILL_FOCUS:**
-- Standard wx event that fires when focus leaves the control
-- List reorders only when edit is complete, not during typing
-- Same pattern as subject field (SingleLineTextCtrl)
+See ATTRIBUTE_PATTERN.md for the full three-layer relationship.
 
-DateTimeCombo's `Bind()` method forwards `EVT_KILL_FOCUS` to all three sub-widgets (checkbox, date, time), so focus moving between them triggers sync - which is acceptable since each field change is a complete edit.
+### DateTimeCombo Event Ownership
 
-**Domain-compatible GetValue/SetValue:**
+`DateTimeCombo` is the composite control and **owns** the change event. It
+inherits from `wx.EvtHandler` so it can host event handlers directly —
+external code binds `EVT_VALUE_CHANGED` on the DTC itself, not on sub-controls.
 
-DateTimeCombo provides `GetValue()` and `SetValue()` that work with `date.DateTime` domain objects:
+**DTC fires `EVT_VALUE_CHANGED` in two cases:**
 
-**Code reference:** `taskcoachlib/widgets/maskedtimectrl.py:1687-1717`
-```python
-def GetValue(self):
-    """Returns date.DateTime() (sentinel) when unchecked, or
-    date.DateTime.fromDateTime(dt) when checked."""
-    if not self._checkbox.GetValue():
-        return date.DateTime()  # Sentinel for "no value"
-    dt = datetime.datetime.combine(self._dateCtrl.GetDate(), self._timeCtrl.GetTime())
-    return date.DateTime.fromDateTime(dt)
+1. **Sub-control blur** — user edits date or time, leaves focus. DTC listens
+   to `EVT_KILL_FOCUS` on sub-controls and fires its own `EVT_VALUE_CHANGED`.
+2. **State transitions** — `ActivateValue()`, `DeactivateValue()`, checkbox
+   click. These call `NotifyValueChanged()` at the end.
 
-def SetValue(self, newValue):
-    """If newValue == date.DateTime() (sentinel), unchecks.
-    Otherwise sets the value and checks."""
-    if newValue == date.DateTime():
-        self._checkbox.SetValue(False)
-        self._updateEnabled()
-    else:
-        self._checkbox.SetValue(True)
-        self._dateCtrl.SetDate(newValue.date())
-        self._timeCtrl.SetTime(datetime.time(newValue.hour, newValue.minute, newValue.second))
-        self._updateEnabled()
-```
+**Sub-control `EVT_VALUE_CHANGED` is trapped and dropped.** DTC binds a handler
+on sub-control `EVT_VALUE_CHANGED` that explicitly consumes the event without
+propagating. Sub-control change events are an implementation detail. This trap
+also serves as a debug log point: if it fires, something is writing directly
+to sub-controls instead of going through DTC's public API, which is a bug.
 
 ## Design
 
@@ -555,112 +551,23 @@ ctrl = TimeWithSecondsCtrl(parent, hours=14, minutes=30, seconds=0,
     hourChoices=False, minuteChoices=False, secondChoices=False)
 ```
 
-### DateCtrl
-Locale-aware date control with automatic field ordering and separators.
+### Locale and Date Format Settings
 
-The control automatically detects the system locale's date format using `strftime("%x")` and arranges the year/month/day fields accordingly:
+All date controls detect the system locale's date format using `strftime("%x")` and arrange year/month/day fields accordingly:
 - **US locale**: `01/18/2026` (month/day/year with `/`)
 - **European locales**: `18/01/2026` (day/month/year with `/`)
 - **ISO/Canadian locale**: `2026-01-18` (year-month-day with `-`)
-
-Click or Enter opens a calendar popup for date selection. Arrow keys in the calendar navigate by day (left/right) or week (up/down). Navigation buttons allow month changes and jumping to today.
-
-```python
-ctrl = DateCtrl(parent, year=2026, month=1, day=18)
-ctrl = DateCtrl(parent)  # Defaults to today's date
-ctrl = DateCtrl(parent, minDate=datetime.date(2020, 1, 1), maxDate=datetime.date(2030, 12, 31))
-date = ctrl.GetDate()  # datetime.date
-ctrl.SetDate(datetime.date(2026, 6, 15))
-```
-
-Individual date fields can still be edited with Up/Down arrows and typed digits.
-
-**Locale Detection:** The `getLocaleDateFormat()` helper function parses `strftime("%x")` output to determine field order and separator, matching the behavior of the old `smartdatetimectrl.py`.
 
 **User Override:** Users can override the automatic locale detection in **Preferences → Regional**:
 - **Date format**: Automatic, YYYY-MM-DD (ISO), YYYY/MM/DD (East Asian), MM/DD/YYYY (US), DD/MM/YYYY (European), DD.MM.YYYY (German)
 - **Time format**: Automatic, 24-hour, 12-hour with AM/PM
 
-**Note:** When "Automatic" time format is selected, the default is 24-hour format (matching the old `smartdatetimectrl` behavior, which was hardcoded to 24-hour). Users can explicitly select "12-hour" to enable AM/PM display.
+**Note:** When "Automatic" time format is selected, the default is 24-hour format. Users can explicitly select "12-hour" to enable AM/PM display.
 
 The settings are stored in `TaskCoach.ini` under `[view]` as `dateformat` and `timeformat`. Helper functions:
 - `getEffectiveDateFormat()` - Returns format tuple respecting user settings
 - `getEffectiveTimeFormat()` - Returns "24" or "12" respecting user settings (defaults to "24" when automatic)
 - `getDateFormatFromSettings()` - Raw setting value
-- `getDateFormatFunctionForOldControl()` - Format function for legacy smartdatetimectrl
-
-### DateTimeCombo
-Flexible combo providing checkbox, DateCtrl, and TimeCtrl as separate widgets for table layout alignment.
-
-**Constructor:**
-```python
-DateTimeCombo(parent, value=None, hourChoices=None, minuteChoices=None, showSeconds=False, secondChoices=None)
-```
-
-**Parameters:**
-- `parent`: Parent window
-- `value`: `datetime.datetime` object (checked) or `None` (unchecked)
-- `hourChoices`: List of hour values for dropdown, or `None` for no dropdown
-- `minuteChoices`: List of minute values for dropdown, or `None` for no dropdown
-- `showSeconds`: If `True`, use TimeWithSecondsCtrl instead of TimeCtrl
-- `secondChoices`: List of second values for dropdown (only used if `showSeconds=True`)
-
-**Checkbox State Determined by Value:**
-- `value=datetime` → checkbox checked, fields show that datetime
-- `value=None` → checkbox unchecked, fields disabled
-
-**Three States:**
-1. **Active + Editable** (normal): checkbox ON, fields enabled and editable
-2. **Inactive** (unchecked): checkbox OFF, fields show "N/A", `GetDateTime()` returns `None`
-3. **Active + Read-only** (`SetReadOnly()`): checkbox ON but disabled, fields greyed
-
-**Default to "Now":** When unchecked and user checks the checkbox, "now" is used as the initial value.
-
-```python
-import datetime
-
-# Checked combo with specific datetime (value=datetime means checked)
-combo = DateTimeCombo(panel,
-    value=datetime.datetime(2026, 1, 20, 9, 0),
-    hourChoices=[8, 9, 10, 11, 12],
-    minuteChoices=[0, 15, 30, 45])
-
-# Unchecked combo (value=None means unchecked)
-combo = DateTimeCombo(panel, value=None)  # Check to see "now"
-
-# Initialization pattern for domain objects:
-# The value alone determines the checked state
-# Note: date.DateTime is a datetime.datetime subclass
-value = existingValue if existingValue != date.DateTime() else None
-
-combo = DateTimeCombo(panel, value=value,
-    hourChoices=list(range(8, 18)),
-    minuteChoices=[0, 15, 30, 45])
-
-# Get individual widgets for flexible table layout
-grid.Add(wx.StaticText(panel, label="Due date:"))  # Column 1: label
-grid.Add(combo.GetCheckBox())   # Column 2: checkbox only
-grid.Add(combo.GetDateCtrl())   # Column 3: date
-grid.Add(combo.GetTimeCtrl())   # Column 4: time
-
-# Or get all widgets as tuple
-checkbox, dateCtrl, timeCtrl = combo.GetWidgets()
-
-# Value access
-dt = combo.GetDateTime()  # datetime or None if unchecked
-combo.SetDateTime(datetime.datetime(2026, 1, 18, 14, 30))
-combo.SetDateTime(None)  # Unchecks the checkbox
-
-# State control
-combo.SetReadOnly()       # Values visible but greyed, not editable
-combo.SetEditable()       # Normal editable mode
-combo.IsEditable()        # Check if editable
-combo.IsActive()          # Check if has a value (non-null)
-
-# Value activation
-combo.ActivateValue()     # Activate (uses internally stored value)
-combo.DeactivateValue()   # Deactivate (values preserved internally)
-```
 
 ## Events
 
@@ -927,9 +834,9 @@ The popup fires three events:
 - `EVT_CHOICE_SELECTED`: Enter key or click selection (confirms value)
 - `EVT_POPUP_DISMISS`: Popup closed for any reason (Escape, click outside, selection)
 
-### Sync Pattern: EVT_VALUE_CHANGED (DateTimeCombo2)
+### Sync Pattern: EVT_VALUE_CHANGED (DateTimeCombo)
 
-DateTimeCombo2 uses `EVT_VALUE_CHANGED` for AttributeSync synchronization.
+DateTimeCombo uses `EVT_VALUE_CHANGED` for AttributeSync synchronization.
 This single event fires on all value changes: checkbox toggle, date edit,
 and time edit. The checkbox is an internal implementation detail — external
 code never binds to `EVT_CHECKBOX`.
@@ -982,6 +889,58 @@ self.__observer.Update()   # Force immediate repaint
 ```
 
 `Update()` is necessary because `Refresh()` only schedules a repaint for the next event loop iteration. During synchronous pubsub callbacks, this may not happen quickly enough, causing visual lag. `Update()` forces immediate processing of pending paint events.
+
+### Sub-Control Stash Model
+
+The sub-controls (DateCtrl, TimeCtrl) are the stash for DateTimeCombo. They
+always hold a datetime value — they cannot be empty. When the checkbox is
+unchecked, the sub-controls are hidden behind the "N/A" overlay but retain
+their values. When the checkbox is checked, those same values become visible
+and are returned by `GetValue()`. The checkbox is the gate; the sub-controls
+are the stash.
+
+At construction, the sub-controls are initialized with either:
+- The domain value (`value` parameter), if the field is active (preset mode), or
+- The preference-suggested datetime (`suggestedValue` parameter), if the field
+  is inactive (propose mode), or
+- `datetime.now()` as a fallback
+
+See [DATETIME_PRESETS.md](DATETIME_PRESETS.md) for how `suggestedValue` is
+computed from user preferences and passed at editor construction time
+([Propose Mode](DATETIME_PRESETS.md#propose-mode),
+[Suggested DateTime Computation](DATETIME_PRESETS.md#suggested-datetime-computation)).
+
+The `_suggestedValue` constructor parameter is a one-time injection point.
+Once the sub-controls are initialized, they are the single holder of the
+datetime value regardless of checked/unchecked state. No separate stash
+variable is needed for activate/deactivate cycles — the sub-controls
+survive naturally.
+
+**State Transition Event Contract:**
+
+`ActivateValue()` and `DeactivateValue()` toggle the checkbox, which changes
+the widget's externally-visible value (`GetValue()` returns real datetime vs
+domain sentinel). Every such toggle must fire `EVT_VALUE_CHANGED` — this is
+the contract that keeps AttributeSync in sync with the widget.
+
+- **`ActivateValue(value=None)`**: If `value` provided, write to sub-controls
+  via `SetDate`/`SetTime`. Check checkbox. Fire `EVT_VALUE_CHANGED`.
+- **`DeactivateValue()`**: Uncheck checkbox. Fire `EVT_VALUE_CHANGED`.
+  Sub-controls retain their values (they are the stash).
+
+**Why explicit event firing is needed:**
+
+Sub-controls fire their own events via `NotifyValueChanged()` when
+`SetDate`/`SetTime` are called. But a checkbox toggle alone — without writing
+to sub-controls — produces no sub-control event. The state transition methods
+must fire explicitly to cover this case. Redundant events from sub-control
+writes are harmless — AttributeSync's same-value guard deduplicates.
+
+**User click path:** `_onCheckboxChanged` → `ActivateValue()`/`DeactivateValue()`
+→ event fires from within the method.
+
+**Programmatic path:** Editor calls `ActivateValue()`/`DeactivateValue()`
+directly. Same event contract — the widget is self-contained.
 
 ## Wayland
 
@@ -1039,23 +998,24 @@ Use `wx.ComboCtrl` which provides a **native dropdown button** and manages popup
 - Custom `_onPaint` using `IsThisEnabled()` (own state) so parent ComboCtrl's disabled state for read-only mode shows greyed values, not "N/A"
 - Same date validation, GetDate/SetDate, locale-aware format as DateCtrl
 
-**`DateCtrl4(wx.ComboCtrl)`** — ComboCtrl wrapper around `_EmbeddedDateCtrl`:
+**`DateCtrl(wx.ComboCtrl)`** — ComboCtrl wrapper around `_EmbeddedDateCtrl`:
 - Native dropdown button and popup management
 - `_CalendarComboPopup` for the calendar dropdown
 - `SetReadOnly(True)` disables the ComboCtrl (greys button) + sets inner control read-only
 - `Enable(False)` disables both ComboCtrl and inner control (shows "N/A")
 - `HasOpenPopup()` — public API using `IsPopupShown()`
-- `Bind()` override forwards UI events (EVT_VALUE_CHANGED, EVT_KEY_DOWN, EVT_KILL_FOCUS, EVT_SET_FOCUS) to inner control
-- `_fireValueChanged()` delegates to inner `_EmbeddedDateCtrl._fireValueChanged()` — needed because `wx.PostEvent()` to the ComboCtrl won't reach handlers bound on the inner control (command events propagate up, not down)
+- `Bind()` override forwards UI events (EVT_KEY_DOWN, EVT_KILL_FOCUS, EVT_SET_FOCUS) to inner control
 - Focus redirection from ComboCtrl's text control to inner DateCtrl
 
-**`DateTimeCombo2`** — Clean replacement for `DateTimeCombo`, using `DateCtrl4`:
-- Uses `DateCtrl4` instead of `DateCtrl` for the date field
-- Clean `HasOpenPopup()` using DateCtrl4's public API
-- Single `Bind()` method (DateTimeCombo had two shadowing definitions)
-- EVT_VALUE_CHANGED wrapping sets event object to the combo (for AttributeSync)
+**`DateTimeCombo(wx.EvtHandler)`** — Composite date/time control:
+- Inherits from `wx.EvtHandler` so it can host event handlers directly
+- Composes checkbox + `DateCtrl` + `TimeCtrl`
+- Owns the change event: fires `EVT_VALUE_CHANGED` on sub-control blur
+  and from `ActivateValue()`/`DeactivateValue()`
+- Traps and drops sub-control `EVT_VALUE_CHANGED` (debug log point)
+- See [DateTimeCombo Event Ownership](#datetimecombo-event-ownership)
 
-**DateTimeCombo2 States:**
+**DateTimeCombo States:**
 
 | State | Visual | Entered Via |
 |-------|--------|------------|
@@ -1063,17 +1023,17 @@ Use `wx.ComboCtrl` which provides a **native dropdown button** and manages popup
 | **Inactive** | Checkbox unchecked/enabled, fields show "N/A" | `DeactivateValue()`, construct with `value=None` |
 | **Active + Read-only** | Checkbox checked/disabled, fields greyed | `SetReadOnly()` |
 
-**DateTimeCombo2 State Transition Methods:**
+**DateTimeCombo State Transition Methods:**
 
 | Method | Effect | Duration Calc Ref |
 |--------|--------|-------------------|
-| `ActivateValue(value=None)` | Activate with given datetime, or internally stored value if None. | Steps 2.1, 3.1 |
-| `DeactivateValue()` | Active → Inactive. Values preserved internally. | Steps 2.5.2, 3.5.2 |
+| `ActivateValue(value=None)` | Inactive → Active. If `value` provided, writes to sub-controls. Checks checkbox. Fires `EVT_VALUE_CHANGED`. See [Sub-Control Stash Model](#sub-control-stash-model). | Steps 2.1, 3.1 |
+| `DeactivateValue()` | Active → Inactive. Unchecks checkbox. Sub-controls retain values (they are the stash). Fires `EVT_VALUE_CHANGED`. See [Sub-Control Stash Model](#sub-control-stash-model). | Steps 2.5.2, 3.5.2 |
 | `SetEditable()` | Make combo editable (no args) | UI Field States |
 | `SetReadOnly()` | Make combo read-only (no args) | UI Field States |
 | `HideCheckBox()` | Hide checkbox for always-active controls | Effort start |
 
-**DateTimeCombo2 State Query Methods:**
+**DateTimeCombo State Query Methods:**
 
 | Method | Returns |
 |--------|---------|
@@ -1081,7 +1041,7 @@ Use `wx.ComboCtrl` which provides a **native dropdown button** and manages popup
 | `IsEditable()` | True if editable (not read-only) |
 | `IsReadOnly()` | True if read-only |
 
-**DateTimeCombo2 Value Access:**
+**DateTimeCombo Value Access:**
 
 | Method | Type |
 |--------|------|
@@ -1090,12 +1050,12 @@ Use `wx.ComboCtrl` which provides a **native dropdown button** and manages popup
 | `GetDate()` | `datetime.date` (read-only) |
 | `GetTime()` | `datetime.time` (read-only) |
 
-**DateTimeCombo2 Layout Accessors** (for sizer arrangement, not state logic):
+**DateTimeCombo Layout Accessors** (for sizer arrangement, not state logic):
 
 | Method | Returns |
 |--------|---------|
 | `GetCheckBox()` | `wx.CheckBox` |
-| `GetDateCtrl()` | `DateCtrl4` |
+| `GetDateCtrl()` | `DateCtrl` |
 | `GetTimeCtrl()` | `TimeCtrl` / `TimeWithSecondsCtrl` |
 | `GetWidgets()` | Tuple of all three |
 | `CreateRowPanel(parent)` | `wx.Panel` with all three arranged horizontally |
@@ -1116,12 +1076,12 @@ Use `wx.ComboCtrl` which provides a **native dropdown button** and manages popup
 - `Create()` — creates interior panel, binds paint/mouse/key events
 - `GetAdjustedSize()` — returns calendar dimensions
 - `GetStringValue()` — returns selected date as ISO string
-- `OnPopup()` — syncs selection from parent DateCtrl4
+- `OnPopup()` — syncs selection from parent DateCtrl
 - Duck-typed `_getDateCtrl2()` finds parent via `hasattr` checks
 
-### Focus Management in DateCtrl4
+### Focus Management in DateCtrl
 
-The ComboCtrl's internal text control is hidden behind the overlaid `_EmbeddedDateCtrl`. DateCtrl4 handles this by:
+The ComboCtrl's internal text control is hidden behind the overlaid `_EmbeddedDateCtrl`. DateCtrl handles this by:
 
 1. **Focus redirection**: `EVT_SET_FOCUS` on the ComboCtrl's text control redirects focus to the inner DateCtrl, with a `_redirectingFocus` guard to prevent recursion.
 2. **Text interception**: `EVT_TEXT` handler clears any text the ComboCtrl auto-inserts.
@@ -1129,20 +1089,18 @@ The ComboCtrl's internal text control is hidden behind the overlaid `_EmbeddedDa
 
 ### Wiring
 
-`__init__.py` exports aliases so existing app code works unchanged:
-- `DateCtrl4 as MaskedDateCtrl`
-- `DateTimeCombo2 as DateTimeCombo`
+`__init__.py` exports aliases:
+- `DateCtrl as MaskedDateCtrl`
+- `DateTimeCombo as DateTimeCombo`
 
-Old `DateCtrl`, `DateTimeCombo` remain in `maskedtimectrl.py` for transition.
+Old `DateCtrl` (FieldsCtrl-based), `_CalendarPopup`, and `DateTimeCombo` v1
+have been removed. `DateCtrl` and `DateTimeCombo` are the only implementations.
 
 ### Demo
 
-Demo rows in `docs/scripts/datetime_controls_demo.py`:
-- **Section 2**: Old `DateTimeCombo` (regression reference)
-- **3.0**: Standard `wx.ComboBox` baseline
-- **3.1**: `DateCtrl4` standalone
-- **3.2**: `DateCtrl4` standalone read-only
-- **3.3**: `DateTimeCombo2` — Planned Start (checked, with dropdowns)
-- **3.4**: `DateTimeCombo2` — Due Date (unchecked)
-- **3.5**: `DateTimeCombo2` — Completed (SetReadOnly(), toggle button)
-- **3.6**: `DateTimeCombo2` — Reminder (checked, no dropdowns)
+Interactive demo showing all controls (duration, time, date, datetime combos)
+with various configurations. Run from the project root:
+
+```
+python3 docs/scripts/datetime_controls_demo.py
+```

--- a/docs/DATETIME_PRESETS.md
+++ b/docs/DATETIME_PRESETS.md
@@ -14,7 +14,7 @@ Default date/time values for new tasks, configured in Preferences.
   - [Reminder Preset](#reminder-preset)
 - [Propose Mode](#propose-mode)
   - [Old Behavior (DateTimeEntry)](#old-behavior-datetimeentry)
-  - [Current Bug (DateTimeCombo2)](#current-bug-datetimecombo2)
+  - [Initial Bug (DateTimeCombo)](#initial-bug-datetimecombo2)
   - [Fix](#fix)
 - [Duration Mode Interaction](#duration-mode-interaction)
 - [Suggested DateTime Computation](#suggested-datetime-computation)
@@ -26,7 +26,7 @@ Default date/time values for new tasks, configured in Preferences.
 ## TODO
 
 1. **Unify preset and propose paths through the Attribute model or
-   DateTimeCombo2 public API.** Currently, preset mode writes directly to
+   DateTimeCombo public API.** Currently, preset mode writes directly to
    the Task constructor kwargs (`uicommand.py:1693-1708`), bypassing both
    the Attribute setter/callback chain and the editor widget API. Propose
    mode relies on the editor widget to pre-fill a display value. These two
@@ -34,7 +34,7 @@ Default date/time values for new tasks, configured in Preferences.
    public interface — either:
    - The Attribute model (setter + callback), so all domain invariants
      (recurrence, reminder clearing, child completion) fire correctly; or
-   - A new `DateTimeCombo2` method such as
+   - A new `DateTimeCombo` method such as
      `ActivateValue(value, proposed=True)` + `DeactivateValue()`, where
      `proposed=True` means: set the internal display value and mark the
      checkbox checked, but flag the value as "proposed" so the editor
@@ -50,8 +50,9 @@ Default date/time values for new tasks, configured in Preferences.
    completion cascade does not happen. The task is born in an inconsistent
    state. See [Constructor Bypass Problem](#constructor-bypass-problem).
 
-3. **Fix propose mode for DateTimeCombo2** — the immediate minimal fix.
-   See [Fix](#fix) section.
+3. ~~**Fix propose mode for DateTimeCombo**~~ — **Done.** `suggestedValue`
+   parameter added to `DateTimeCombo.__init__()`. Editor passes preference-
+   computed datetime at construction. See [Fix](#fix) section.
 
 4. **Duration mode interaction with presets needs resolution.** New tasks
    start in Implicit mode for legacy and preset/propose compatibility
@@ -137,7 +138,7 @@ When the preference starts with `"preset"`:
    in the Attribute via `Attribute.__init__()`, NOT via `.set()`.
 
 3. **Editor opens**: Reads from domain object. Value is non-None, so
-   `DateTimeCombo2` is constructed with `value=datetime`, checkbox starts
+   `DateTimeCombo` is constructed with `value=datetime`, checkbox starts
    checked, fields show the preset datetime.
 
 ### Constructor Bypass Problem
@@ -191,7 +192,7 @@ its "already shown" set when a reminder is snoozed.
 
 ### Old Behavior (DateTimeEntry)
 
-The old `DateTimeEntry` control (removed in the DateTimeCombo2 refactor)
+The old `DateTimeEntry` control (removed in the DateTimeCombo refactor)
 accepted a `suggestedDateTime` parameter:
 
 ```python
@@ -220,28 +221,16 @@ Result: The display fields showed the suggested datetime (hidden behind
 The value was **never persisted** until the user checked the box and the
 editor committed it through a command.
 
-### Current Bug (DateTimeCombo2)
+### Initial Bug (DateTimeCombo)
 
-`DateTimeCombo2` was never given suggested datetime support. When
-`value=None` (propose mode), the constructor defaults to `datetime.now()`:
-
-```python
-# maskedtimectrl.py:3594-3595
-checked = value is not None
-display_value = value if value is not None else datetime.datetime.now()
-```
-
-When the user checks the checkbox, `ActivateValue()` (no args) reveals the
-internally stored `datetime.now()` from construction time, ignoring the
-user's preference setting entirely.
+`DateTimeCombo` was originally created without suggested datetime support.
+When `value=None` (propose mode), the constructor defaulted to
+`datetime.now()`, ignoring the user's preference setting entirely.
 
 ### Fix
 
-Minimal one-line change in `DateTimeCombo2.__init__()`:
-
-**File:** `taskcoachlib/widgets/maskedtimectrl.py:3588`
-
-Add `suggestedValue=None` parameter:
+**Done.** `suggestedValue` parameter added to `DateTimeCombo.__init__()`.
+The editor passes the preference-computed datetime at construction time:
 
 ```python
 def __init__(self, parent, value=None, suggestedValue=None, ...):
@@ -249,19 +238,23 @@ def __init__(self, parent, value=None, suggestedValue=None, ...):
     display_value = value if value is not None else (suggestedValue or datetime.datetime.now())
 ```
 
-Pass `suggestedValue` at each `DateTimeCombo2(...)` construction in the editor:
+The sub-controls are initialized with the suggested datetime and hold it
+while the checkbox is unchecked. In preset mode, `value` is already
+non-None, so `suggestedValue` is ignored.
 
-**File:** `taskcoachlib/gui/dialog/editor.py`
+For how the sub-controls serve as the stash for DateTimeCombo (retaining
+the proposed value through activate/deactivate cycles), see
+[DATETIME_CONTROLS.md — Sub-Control Stash Model](DATETIME_CONTROLS.md#sub-control-stash-model).
 
-| Date Field | Line | suggestedValue |
-|-----------|------|---------------|
-| Planned start | ~1276 | `task.Task.suggestedPlannedStartDateTime()` |
-| Due date | ~1405 | `task.Task.suggestedDueDateTime()` |
-| Actual start | ~1449 | `task.Task.suggestedActualStartDateTime()` |
-| Completion | ~1488 | `task.Task.suggestedCompletionDateTime()` |
-| Reminder | ~2011 | `task.Task.suggestedReminderDateTime()` |
+**Editor construction sites** (`taskcoachlib/gui/dialog/editor.py`):
 
-In preset mode, `value` is already non-None, so `suggestedValue` is ignored.
+| Date Field | suggestedValue |
+|-----------|---------------|
+| Planned start | `task.Task.suggestedPlannedStartDateTime()` |
+| Due date | `task.Task.suggestedDueDateTime()` |
+| Actual start | `task.Task.suggestedActualStartDateTime()` |
+| Completion | `task.Task.suggestedCompletionDateTime()` |
+| Reminder | `task.Task.suggestedReminderDateTime()` |
 
 ---
 
@@ -348,7 +341,7 @@ new snooze time.
 
 ## Related Documentation
 
-- [DATETIME_CONTROLS.md](DATETIME_CONTROLS.md) — DateTimeCombo2 widget API,
+- [DATETIME_CONTROLS.md](DATETIME_CONTROLS.md) — DateTimeCombo widget API,
   ActivateValue/DeactivateValue, suggested datetime old behavior reference
 - [ATTRIBUTE_PATTERN.md](ATTRIBUTE_PATTERN.md) — Attribute model, setter/callback
   pattern, constructor vs `.set()` behavior, three-layer relationship

--- a/docs/DURATION_CALCULATIONS.md
+++ b/docs/DURATION_CALCULATIONS.md
@@ -16,6 +16,7 @@ Duration calculations for Edit Task Dates and Edit Effort windows.
   - [Entry Modes](#entry-modes)
   - [Field Change Effects](#field-change-effects)
   - [Action Sequence](#action-sequence-1)
+- [Preset Dropdown Sync](#preset-dropdown-sync)
 - [Persistence](#persistence)
 
 ---
@@ -42,7 +43,7 @@ Duration calculations for Edit Task Dates and Edit Effort windows.
 9. ~~DateTimeCombo Checkbox toggle EVT_KILL_FOCUS gap~~ — **Resolved.**
    ~~Editor binds `EVT_CHECKBOX` via `combo.Bind(wx.EVT_CHECKBOX, handler)`
    and calls `sync.commit()` explicitly.~~
-   **Update:** EVT_CHECKBOX is no longer exposed by DateTimeCombo2. All
+   **Update:** EVT_CHECKBOX is no longer exposed by DateTimeCombo. All
    AttributeSync instances use `EVT_VALUE_CHANGED` as `editedEventType`,
    which fires on checkbox toggle AND date/time edits. External
    EVT_CHECKBOX handlers and `sync.commit()` hacks removed.
@@ -319,7 +320,7 @@ Start: Standard mode, Duration 0, Stop-Date disabled
        1.9.1 If Duration > 0, Then
            1.9.1.1 Set Sync-Mode [0.4]
            1.9.1.2 Adj Stop-Date
-           1.9.1.3 Adj Duration
+           1.9.1.3 Adj Duration *Impossible* TODO remove step? remove sync-mode?
            1.9.1.4 Unset Sync-Mode
        1.9.2 If Duration = 0, Then do nothing
    1.10 If Duration changed and exists, Then
@@ -329,7 +330,7 @@ Start: Standard mode, Duration 0, Stop-Date disabled
        1.10.2 If Duration = 0, Then disable Stop-Date
    1.11 If Stop-Date changed and exists, Then adj Duration
    1.12 If Duration = 0, Then Autoheal, Thus
-       1.12.1 Disable Stop-Date
+       1.12.1 Not possible: Disable Stop-Date Conflicts [Ref3]
    1.13 If Duration > 0, Then Autoheal, Thus
        1.13.1 Enable Stop-Date
        1.13.2 Adj Stop-Date
@@ -350,7 +351,7 @@ Start: Standard mode, Duration 0, Stop-Date disabled
            2.9.1.2 Adj Start-Date
        2.9.2 If Duration = 0, Then disable Stop-Date
    2.10 If Duration = 0, Then Autoheal, Thus
-       2.10.1 Disable Stop-Date
+       2.10.1 Not possible: Disable Stop-Date Conflicts [Ref2]
    2.11 If Duration > 0, Then Autoheal, Thus
        2.11.1 Enable Stop-Date
        2.11.2 Adj Start-Date
@@ -377,6 +378,12 @@ Glossary:
 
 References:
    [Ref1] Covered by "UI Field States" section
+   [Ref2] 2.10.1 Not possible to Disable Stop-Date because it can conflict
+          with 2.9.1.1 and 2.11.1 if the Stop-Date is the same as the
+          Start-Date and we won't modify the values, leave as-is
+   [Ref3] 1.12.1 Not possible to Disable Stop-Date because it can conflict
+          with 1.10.1.1 and 1.13.1 if the Stop-Date is the same as the
+          Start-Date and we won't modify the values, leave as-is
 ```
 
 ```
@@ -466,6 +473,41 @@ Called on: After main calc logic, every change of Start-Date, Stop-Date, Duratio
 | Implicit | ✅ | ✅ | Uncheck Stop | Duration disabled |
 | Implicit | ✅ | ✅ | Set Standard | Duration editable |
 | Implicit | ✅ | ✅ | Set Retroactive | Start read-only, Duration editable |
+
+---
+
+## Preset Dropdown Sync
+
+Both the task and effort editors have a "Presets" dropdown next to the duration
+control. The dropdown must stay aligned with the current duration value:
+selecting a matching preset when the duration matches, or resetting to the
+"Presets..." placeholder when it doesn't.
+
+### Sync Pattern
+
+The preset dropdown subscribes directly to the domain's duration-changed
+pubsub event. This decouples it from the source of the change — whether the
+user typed a value, selected a preset, or an external source updated the
+domain, the dropdown updates itself.
+
+**Task editor:**
+- Subscribes to `plannedDurationChangedEventType()` → `__updatePresetSelection()`
+
+**Effort editor:**
+- Subscribes to `durationChangedEventType()` → `__updateEffortPresetSelection()`
+
+### Why Not a Callback?
+
+The alternative is calling the preset update from the duration change handler
+or `AttributeSync` callback. This couples the preset to the commit path —
+any code that changes duration must remember to also update the preset.
+Pubsub subscription ensures the preset is always correct regardless of how
+the duration changed.
+
+### Lifecycle
+
+Subscriptions are created during `addEntries()` / `addDurationEntry()` and
+unsubscribed in `close()` / `close_edit_book()`.
 
 ---
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13,8 +13,7 @@ This document tracks planned improvements and known issues to address in future 
 - [GTK3 Widget Sizing Inconsistency](#gtk3-widget-sizing-inconsistency)
 - [BookPage Default Alignment Inconsistency](#bookpage-default-alignment-inconsistency)
 - [Preferences Dialog: Dirty-Check and Button State](#preferences-dialog-dirty-check-and-button-state)
-- [Other TODOs](#other-todos)
-  - [EVT_TEXT Compatibility Shim](#evt_text-compatibility-shim-in-multilinetextctrl)
+- [EVT_TEXT Compatibility Shim in MultiLineTextCtrl](#evt_text-compatibility-shim-in-multilinetextctrl)
 
 ---
 
@@ -412,9 +411,7 @@ No need to store "original values" — the settings object is the baseline.
 
 ---
 
-## Other TODOs
-
-### EVT_TEXT Compatibility Shim in MultiLineTextCtrl
+## EVT_TEXT Compatibility Shim in MultiLineTextCtrl
 
 `MultiLineTextCtrl` (StyledTextCtrl/Scintilla) overrides `Bind()` to remap `wx.EVT_TEXT` to `stc.EVT_STC_CHANGE` for compatibility with code written for `wx.TextCtrl`. If we keep Scintilla long-term, refactor all callers to use `EVT_STC_CHANGE` directly and remove the shim. File: `taskcoachlib/widgets/textctrl.py`.
 

--- a/docs/scripts/datetime_controls_demo.py
+++ b/docs/scripts/datetime_controls_demo.py
@@ -20,7 +20,7 @@ app = wx.App()
 from taskcoachlib.widgets import maskedtimectrl
 from taskcoachlib.widgets.maskedtimectrl import (
     DurationCtrl, DurationCtrlVerbose, TimeCtrl, TimeWithSecondsCtrl,
-    DateCtrl, DateCtrl4, DateTimeCombo, DateTimeCombo2, _PopupWindow,
+    DateCtrl, DateTimeCombo, _PopupWindow,
     PopupDismissEvent, _CalendarComboPopup
 )
 
@@ -110,7 +110,6 @@ if _is_wayland():
     # the original subclasses.
 
     _OrigChoicesPopup = maskedtimectrl._ChoicesPopup
-    _OrigCalendarPopup = maskedtimectrl._CalendarPopup
 
     # Collect all methods/attrs defined directly on each original class
     def _get_class_attrs(cls):
@@ -124,12 +123,6 @@ if _is_wayland():
         '_ChoicesPopup',
         (_WaylandPopupWindow,),
         _get_class_attrs(_OrigChoicesPopup)
-    )
-
-    maskedtimectrl._CalendarPopup = type(
-        '_CalendarPopup',
-        (_WaylandPopupWindow,),
-        _get_class_attrs(_OrigCalendarPopup)
     )
 
     print("[Wayland] Patch applied. Test dropdown positioning below.")
@@ -229,125 +222,23 @@ class DemoFrame(wx.Frame):
         grid.Add(self.ctrl7, 0, wx.ALIGN_CENTER_VERTICAL)
         grid.Add(wx.StaticText(panel, label="WITH choices: [0-30], [0-23], [0,15,30,45]"), 0, wx.ALIGN_CENTER_VERTICAL)
 
-        # 1.8 DateCtrl (calendar popup)
-        grid.Add(wx.StaticText(panel, label="1.8 DateCtrl:"), 0, wx.ALIGN_CENTER_VERTICAL)
-        self.ctrl8 = DateCtrl(panel)
-        grid.Add(self.ctrl8, 0, wx.ALIGN_CENTER_VERTICAL)
-        grid.Add(wx.StaticText(panel, label="calendar popup (click or Enter)"), 0, wx.ALIGN_CENTER_VERTICAL)
-
         mainSizer.Add(grid, 0, wx.ALL | wx.EXPAND, 20)
 
         # Separator
         mainSizer.Add(wx.StaticLine(panel), 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 20)
 
-        # =============================================================
-        # Section 2: DateTimeCombo - Flexible Table Layout
-        # =============================================================
-        comboTitle = wx.StaticText(panel, label="2. DateTimeCombo - Flexible Table Layout")
-        comboTitle.SetFont(comboTitle.GetFont().Bold().Scaled(1.3))
-        mainSizer.Add(comboTitle, 0, wx.ALL | wx.EXPAND, 10)
-
-        # Create a table grid showing aligned DateTimeCombos
-        # 5 columns: Label, Checkbox, Date, Time, Description
-        comboGrid = wx.FlexGridSizer(cols=5, hgap=10, vgap=8)
-
-        # Header row
-        comboGrid.Add(wx.StaticText(panel, label=""), 0)
-        comboGrid.Add(wx.StaticText(panel, label=""), 0)
-        hdrDate = wx.StaticText(panel, label="Date")
-        hdrDate.SetFont(hdrDate.GetFont().Bold())
-        comboGrid.Add(hdrDate, 0, wx.ALIGN_CENTER)
-        hdrTime = wx.StaticText(panel, label="Time")
-        hdrTime.SetFont(hdrTime.GetFont().Bold())
-        comboGrid.Add(hdrTime, 0, wx.ALIGN_CENTER)
-        comboGrid.Add(wx.StaticText(panel, label=""), 0)
-
-        # 2.1 Planned Start (value=datetime means checked)
-        import datetime
-        self.plannedStartCombo = DateTimeCombo(
-            panel,
-            value=datetime.datetime(2026, 1, 20, 9, 0),
-            hourChoices=[8, 9, 10, 11, 12],
-            minuteChoices=[0, 15, 30, 45]
-        )
-        comboGrid.Add(wx.StaticText(panel, label="2.1 Planned Start:"), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(self.plannedStartCombo.GetCheckBox(), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(self.plannedStartCombo.GetDateCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(self.plannedStartCombo.GetTimeCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(wx.StaticText(panel, label="(value=datetime -> checked)"), 0, wx.ALIGN_CENTER_VERTICAL)
-
-        # 2.2 Due Date (value=None means unchecked)
-        self.dueDateCombo = DateTimeCombo(
-            panel,
-            value=None,  # None = unchecked, defaults to "now" when user checks it
-            hourChoices=[17, 18, 19, 20, 21],
-            minuteChoices=[0, 30]
-        )
-        comboGrid.Add(wx.StaticText(panel, label="2.2 Due Date:"), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(self.dueDateCombo.GetCheckBox(), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(self.dueDateCombo.GetDateCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(self.dueDateCombo.GetTimeCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(wx.StaticText(panel, label="(value=None -> unchecked)"), 0, wx.ALIGN_CENTER_VERTICAL)
-
-        # 2.3 Actual Start (another checked example)
-        self.actualStartCombo = DateTimeCombo(
-            panel,
-            value=datetime.datetime(2026, 6, 15, 9, 30)
-        )
-        comboGrid.Add(wx.StaticText(panel, label="2.3 Actual Start:"), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(self.actualStartCombo.GetCheckBox(), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(self.actualStartCombo.GetDateCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(self.actualStartCombo.GetTimeCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(wx.StaticText(panel, label="(value=2026-06-15 09:30)"), 0, wx.ALIGN_CENTER_VERTICAL)
-
-        # 2.4 Completed (inactive/read-only - values visible but greyed)
-        self.completedCombo = DateTimeCombo(
-            panel,
-            value=datetime.datetime(2026, 1, 19, 14, 30)
-        )
-        self.completedCombo.SetEditable(False)  # Inactive: values visible but greyed
-        comboGrid.Add(wx.StaticText(panel, label="2.4 Completed:"), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(self.completedCombo.GetCheckBox(), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(self.completedCombo.GetDateCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(self.completedCombo.GetTimeCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
-        lbl_inactive = wx.StaticText(panel, label="(Read-Only / Editable - Toggle Button below)")
-        lbl_inactive.SetForegroundColour(wx.RED)
-        comboGrid.Add(lbl_inactive, 0, wx.ALIGN_CENTER_VERTICAL)
-
-        # 2.5 Reminder (enabled, no time dropdowns)
-        self.reminderCombo = DateTimeCombo(
-            panel,
-            value=datetime.datetime(2026, 1, 21, 8, 0)
-            # No hourChoices/minuteChoices = no dropdowns
-        )
-        comboGrid.Add(wx.StaticText(panel, label="2.5 Reminder:"), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(self.reminderCombo.GetCheckBox(), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(self.reminderCombo.GetDateCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(self.reminderCombo.GetTimeCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
-        comboGrid.Add(wx.StaticText(panel, label="(no time dropdowns)"), 0, wx.ALIGN_CENTER_VERTICAL)
-
-        mainSizer.Add(comboGrid, 0, wx.ALL | wx.EXPAND, 20)
-
-        # Toggle button to test read-only/editable state
-        toggleBtn = wx.Button(panel, label="Toggle 2.4 'Completed' Read-Only / Editable")
-        toggleBtn.Bind(wx.EVT_BUTTON, self._onToggleCompleted)
-        mainSizer.Add(toggleBtn, 0, wx.ALL | wx.ALIGN_CENTER, 10)
-
-        # Separator
-        mainSizer.Add(wx.StaticLine(panel), 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 20)
-
         # =====================================================================
-        # Section 3: ComboCtrl-Based Date Controls
+        # Section 2: ComboCtrl-Based Date Controls
         # =====================================================================
-        dc2Title = wx.StaticText(panel, label="3. ComboCtrl-Based Date Controls")
+        dc2Title = wx.StaticText(panel, label="2. ComboCtrl-Based Date Controls")
         dc2Title.SetFont(dc2Title.GetFont().Bold().Scaled(1.3))
         mainSizer.Add(dc2Title, 0, wx.ALL | wx.EXPAND, 10)
 
         dc2Grid = wx.FlexGridSizer(cols=3, hgap=15, vgap=10)
         dc2Grid.AddGrowableCol(2)
 
-        # 3.0 Standard ComboBox baseline reference
-        dc2Grid.Add(wx.StaticText(panel, label="3.0 Baseline:"), 0,
+        # 2.0 Standard ComboBox baseline reference
+        dc2Grid.Add(wx.StaticText(panel, label="2.0 Baseline:"), 0,
                      wx.ALIGN_CENTER_VERTICAL)
         self.dc2Baseline = wx.ComboBox(panel, value="Standard ComboBox (reference)",
             choices=["Standard ComboBox (reference)", "Option 2", "Option 3"],
@@ -357,30 +248,30 @@ class DemoFrame(wx.Frame):
         lbl_baseline.SetForegroundColour(wx.Colour(128, 128, 128))
         dc2Grid.Add(lbl_baseline, 0, wx.ALIGN_CENTER_VERTICAL)
 
-        # 3.1 DateCtrl4 standalone (no checkbox, no time)
-        self.dc2EmbedDate = DateCtrl4(panel,
+        # 2.1 DateCtrl standalone (no checkbox, no time)
+        self.dc2EmbedDate = DateCtrl(panel,
             year=2026, month=1, day=31)
-        dc2Grid.Add(wx.StaticText(panel, label="3.1 DateCtrl4:"), 0,
+        dc2Grid.Add(wx.StaticText(panel, label="2.1 DateCtrl:"), 0,
                      wx.ALIGN_CENTER_VERTICAL)
         dc2Grid.Add(self.dc2EmbedDate, 0, wx.ALIGN_CENTER_VERTICAL)
-        lbl_31 = wx.StaticText(panel, label="(standalone DateCtrl4, no checkbox/time)")
+        lbl_31 = wx.StaticText(panel, label="(standalone DateCtrl, no checkbox/time)")
         lbl_31.SetForegroundColour(wx.Colour(0, 128, 0))
         dc2Grid.Add(lbl_31, 0, wx.ALIGN_CENTER_VERTICAL)
 
-        # 3.2 DateCtrl4 standalone read-only
-        self.dc2EmbedDateRO = DateCtrl4(panel,
+        # 2.2 DateCtrl standalone read-only
+        self.dc2EmbedDateRO = DateCtrl(panel,
             year=2026, month=1, day=19)
         self.dc2EmbedDateRO.SetReadOnly(True)
-        dc2Grid.Add(wx.StaticText(panel, label="3.2 DateCtrl4:"), 0,
+        dc2Grid.Add(wx.StaticText(panel, label="2.2 DateCtrl:"), 0,
                      wx.ALIGN_CENTER_VERTICAL)
         dc2Grid.Add(self.dc2EmbedDateRO, 0, wx.ALIGN_CENTER_VERTICAL)
-        lbl_32 = wx.StaticText(panel, label="(standalone DateCtrl4, read-only)")
+        lbl_32 = wx.StaticText(panel, label="(standalone DateCtrl, read-only)")
         lbl_32.SetForegroundColour(wx.Colour(128, 128, 128))
         dc2Grid.Add(lbl_32, 0, wx.ALIGN_CENTER_VERTICAL)
 
         mainSizer.Add(dc2Grid, 0, wx.ALL | wx.EXPAND, 20)
 
-        # --- 3.3-3.6 DateTimeCombo2 (DateCtrl4-based, same API as section 2) ---
+        # --- 3.3-3.6 DateTimeCombo (DateCtrl-based, same API as section 1) ---
         dc3Grid = wx.FlexGridSizer(cols=5, hgap=10, vgap=8)
 
         # Header row
@@ -394,14 +285,14 @@ class DemoFrame(wx.Frame):
         dc3Grid.Add(hdrTime3, 0, wx.ALIGN_CENTER)
         dc3Grid.Add(wx.StaticText(panel, label=""), 0)
 
-        # 3.3 Planned Start (checked, with dropdowns)
-        self.dc3PlannedStartCombo = DateTimeCombo2(
+        # 2.3 Planned Start (checked, with dropdowns)
+        self.dc3PlannedStartCombo = DateTimeCombo(
             panel,
             value=datetime.datetime(2026, 1, 20, 9, 0),
             hourChoices=[8, 9, 10, 11, 12],
             minuteChoices=[0, 15, 30, 45]
         )
-        dc3Grid.Add(wx.StaticText(panel, label="3.3 Planned Start:"), 0,
+        dc3Grid.Add(wx.StaticText(panel, label="2.3 Planned Start:"), 0,
                      wx.ALIGN_CENTER_VERTICAL)
         dc3Grid.Add(self.dc3PlannedStartCombo.GetCheckBox(), 0, wx.ALIGN_CENTER_VERTICAL)
         dc3Grid.Add(self.dc3PlannedStartCombo.GetDateCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
@@ -409,14 +300,14 @@ class DemoFrame(wx.Frame):
         dc3Grid.Add(wx.StaticText(panel, label="(checked, with time dropdowns)"), 0,
                      wx.ALIGN_CENTER_VERTICAL)
 
-        # 3.4 Due Date (unchecked)
-        self.dc3DueDateCombo = DateTimeCombo2(
+        # 2.4 Due Date (unchecked)
+        self.dc3DueDateCombo = DateTimeCombo(
             panel,
             value=None,
             hourChoices=[17, 18, 19, 20, 21],
             minuteChoices=[0, 30]
         )
-        dc3Grid.Add(wx.StaticText(panel, label="3.4 Due Date:"), 0,
+        dc3Grid.Add(wx.StaticText(panel, label="2.4 Due Date:"), 0,
                      wx.ALIGN_CENTER_VERTICAL)
         dc3Grid.Add(self.dc3DueDateCombo.GetCheckBox(), 0, wx.ALIGN_CENTER_VERTICAL)
         dc3Grid.Add(self.dc3DueDateCombo.GetDateCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
@@ -424,13 +315,13 @@ class DemoFrame(wx.Frame):
         dc3Grid.Add(wx.StaticText(panel, label="(unchecked, fields disabled)"), 0,
                      wx.ALIGN_CENTER_VERTICAL)
 
-        # 3.5 Completed (read-only / editable toggle)
-        self.dc3CompletedCombo = DateTimeCombo2(
+        # 2.5 Completed (read-only / editable toggle)
+        self.dc3CompletedCombo = DateTimeCombo(
             panel,
             value=datetime.datetime(2026, 1, 19, 14, 30)
         )
         self.dc3CompletedCombo.SetReadOnly()
-        dc3Grid.Add(wx.StaticText(panel, label="3.5 Completed:"), 0,
+        dc3Grid.Add(wx.StaticText(panel, label="2.5 Completed:"), 0,
                      wx.ALIGN_CENTER_VERTICAL)
         dc3Grid.Add(self.dc3CompletedCombo.GetCheckBox(), 0, wx.ALIGN_CENTER_VERTICAL)
         dc3Grid.Add(self.dc3CompletedCombo.GetDateCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
@@ -439,12 +330,12 @@ class DemoFrame(wx.Frame):
         lbl_dc3_ro.SetForegroundColour(wx.RED)
         dc3Grid.Add(lbl_dc3_ro, 0, wx.ALIGN_CENTER_VERTICAL)
 
-        # 3.6 Reminder (checked, no time dropdowns)
-        self.dc3ReminderCombo = DateTimeCombo2(
+        # 2.6 Reminder (checked, no time dropdowns)
+        self.dc3ReminderCombo = DateTimeCombo(
             panel,
             value=datetime.datetime(2026, 1, 21, 8, 0)
         )
-        dc3Grid.Add(wx.StaticText(panel, label="3.6 Reminder:"), 0,
+        dc3Grid.Add(wx.StaticText(panel, label="2.6 Reminder:"), 0,
                      wx.ALIGN_CENTER_VERTICAL)
         dc3Grid.Add(self.dc3ReminderCombo.GetCheckBox(), 0, wx.ALIGN_CENTER_VERTICAL)
         dc3Grid.Add(self.dc3ReminderCombo.GetDateCtrl(), 0, wx.ALIGN_CENTER_VERTICAL)
@@ -455,7 +346,7 @@ class DemoFrame(wx.Frame):
         mainSizer.Add(dc3Grid, 0, wx.ALL | wx.EXPAND, 20)
 
         # Toggle button to test read-only/editable state on 3.5
-        dc3ToggleBtn = wx.Button(panel, label="Toggle 3.5 'Completed' Read-Only / Editable")
+        dc3ToggleBtn = wx.Button(panel, label="Toggle 2.5 'Completed' Read-Only / Editable")
         dc3ToggleBtn.Bind(wx.EVT_BUTTON, self._onToggleDc3Completed)
         mainSizer.Add(dc3ToggleBtn, 0, wx.ALL | wx.ALIGN_CENTER, 10)
 
@@ -463,25 +354,25 @@ class DemoFrame(wx.Frame):
         mainSizer.Add(wx.StaticLine(panel), 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 20)
 
         # =====================================================================
-        # Section 4: Standard wxPython Date/Calendar Controls
+        # Section 3: Standard wxPython Date/Calendar Controls
         # =====================================================================
-        stdTitle = wx.StaticText(panel, label="4. Standard wxPython Date/Calendar Controls")
+        stdTitle = wx.StaticText(panel, label="3. Standard wxPython Date/Calendar Controls")
         stdTitle.SetFont(stdTitle.GetFont().Bold().Scaled(1.3))
         mainSizer.Add(stdTitle, 0, wx.ALL | wx.EXPAND, 10)
 
         stdGrid = wx.FlexGridSizer(cols=3, hgap=15, vgap=10)
         stdGrid.AddGrowableCol(2)
 
-        # 4.1 DatePickerCtrl - Native dropdown (week start from locale)
-        stdGrid.Add(wx.StaticText(panel, label="4.1 DatePickerCtrl:"), 0,
+        # 3.1 DatePickerCtrl - Native dropdown (week start from locale)
+        stdGrid.Add(wx.StaticText(panel, label="3.1 DatePickerCtrl:"), 0,
                      wx.ALIGN_CENTER_VERTICAL)
         self.stdDatePickerDD = wx.adv.DatePickerCtrl(panel, style=wx.adv.DP_DROPDOWN)
         stdGrid.Add(self.stdDatePickerDD, 0, wx.ALIGN_CENTER_VERTICAL)
         stdGrid.Add(wx.StaticText(panel, label="DP_DROPDOWN — native popup, week start from locale"), 0,
                      wx.ALIGN_CENTER_VERTICAL)
 
-        # 4.2 DatePickerCtrlGeneric - locale week start
-        stdGrid.Add(wx.StaticText(panel, label="4.2 DatePickerCtrlGeneric:"), 0,
+        # 3.2 DatePickerCtrlGeneric - locale week start
+        stdGrid.Add(wx.StaticText(panel, label="3.2 DatePickerCtrlGeneric:"), 0,
                      wx.ALIGN_CENTER_VERTICAL)
         self.stdDatePickerGen = wx.adv.DatePickerCtrlGeneric(
             panel, style=wx.adv.DP_DROPDOWN)
@@ -509,13 +400,8 @@ class DemoFrame(wx.Frame):
         panel.SetSizer(mainSizer)
         self.Centre()
 
-    def _onToggleCompleted(self, event):
-        """Toggle the editable state of the 'Completed' DateTimeCombo."""
-        currentState = self.completedCombo.IsEditable()
-        self.completedCombo.SetEditable(not currentState)
-
     def _onToggleDc3Completed(self, event):
-        """Toggle read-only/editable on the 3.5 Completed DateTimeCombo2."""
+        """Toggle read-only/editable on the 2.5 Completed DateTimeCombo."""
         if self.dc3CompletedCombo.IsEditable():
             self.dc3CompletedCombo.SetReadOnly()
         else:

--- a/taskcoachlib/gui/dialog/attributesync.py
+++ b/taskcoachlib/gui/dialog/attributesync.py
@@ -27,11 +27,7 @@ class AttributeSync(object):
     a control in a dialog. If the user edits the value using the control,
     the domain object is changed, using the appropriate command. If the
     attribute of the domain object is changed (e.g. in another dialog) the
-    value of the control is updated.
-
-    When commit_on_focus_loss=True, command execution is delayed until focus
-    leaves the control. This creates a single undo entry for the entire edit
-    session (e.g., typing a complete date)."""
+    value of the control is updated."""
 
     def __init__(
         self,
@@ -43,7 +39,6 @@ class AttributeSync(object):
         editedEventType,
         changedEventType,
         callback=None,
-        commit_on_focus_loss=False,
         **kwargs
     ):
         self._getter = attributeGetterName
@@ -54,148 +49,31 @@ class AttributeSync(object):
         self.__commandKwArgs = kwargs
         self.__changedEventType = changedEventType
         self.__callback = callback
-        self.__commit_on_focus_loss = commit_on_focus_loss
-        self.__editSessionValue = None  # Value at start of edit session
-        self.__hasChanges = False  # Track if any changes during this focus session
 
         entry.Bind(editedEventType, self.onAttributeEdited)
 
-        if commit_on_focus_loss:
-            # For composite widgets like DateTimeCombo, we need to track focus
-            # on the widget and all its children
-            self.__bindFocusEvents(entry)
-
         if len(items) == 1:
             self.__start_observing_attribute(changedEventType, items[0])
-
-    def __bindFocusEvents(self, widget):
-        """Bind focus events to widget and all its children recursively."""
-        widget.Bind(wx.EVT_SET_FOCUS, self.__onSetFocus)
-        widget.Bind(wx.EVT_KILL_FOCUS, self.__onKillFocus)
-        for child in widget.GetChildren():
-            self.__bindFocusEvents(child)
-
-    def __onSetFocus(self, event):
-        """Called when any part of the widget gains focus."""
-        event.Skip()
-        if self.__editSessionValue is None:
-            # Starting a new edit session - remember the initial value
-            self.__editSessionValue = self._currentValue
-            self.__hasChanges = False
-
-    def __onKillFocus(self, event):
-        """Called when any part of the widget loses focus."""
-        event.Skip()
-
-        # Guard against destroyed widgets (e.g., when dialog is closing)
-        try:
-            if not self._entry:
-                self.__editSessionValue = None
-                self.__hasChanges = False
-                return
-        except RuntimeError:
-            self.__editSessionValue = None
-            self.__hasChanges = False
-            return
-
-        # Check if focus is moving to another child of the same parent widget
-        new_focus = event.GetWindow()
-
-        if new_focus is not None:
-            try:
-                # Check if new focus is within the same entry widget
-                parent = new_focus
-                while parent is not None:
-                    if parent is self._entry:
-                        return  # Still within the same widget, don't commit yet
-                    parent = parent.GetParent()
-            except RuntimeError:
-                self.__editSessionValue = None
-                self.__hasChanges = False
-                return
-
-        # If dialog is closing (new_focus is None), we still need to save any pending changes
-        # to the domain model, but skip the callback to avoid UI updates on destroyed widgets.
-        if new_focus is None:
-            self.__stop_observing_attribute()
-            # Still commit pending changes to domain model, but skip callback
-            if self.__hasChanges and self.__editSessionValue is not None:
-                try:
-                    new_value = self.getValue()
-                    if new_value != self.__editSessionValue:
-                        self.__executeCommand(new_value, skip_callback=True)
-                except RuntimeError:
-                    pass  # Widget already destroyed
-            self.__editSessionValue = None
-            self.__hasChanges = False
-            return
-
-        # Focus is leaving the widget entirely - commit if there are changes
-        if self.__hasChanges and self.__editSessionValue is not None:
-            try:
-                new_value = self.getValue()
-                if new_value != self.__editSessionValue:
-                    self.__executeCommand(new_value, skip_callback=False)
-                    # Only reset edit session after successful commit
-                    self.__editSessionValue = None
-                    self.__hasChanges = False
-            except RuntimeError:
-                pass  # Widget deleted, can't get value or execute command
-        # NOTE: Don't reset __editSessionValue if no changes committed.
-        # This preserves the session state when focus goes to popup dropdowns.
-
-    def commit(self):
-        """Force-commit current widget value to domain model.
-
-        Use when the value changes without focus loss, e.g., checkbox toggle
-        on a DateTimeCombo field. Equivalent to focus-loss commit behavior.
-        """
-        try:
-            new_value = self.getValue()
-        except RuntimeError:
-            return  # Widget destroyed
-        if new_value != self._currentValue:
-            self.__executeCommand(new_value)
-            self.__editSessionValue = None
-            self.__hasChanges = False
 
     def onAttributeEdited(self, event):
         event.Skip()
         new_value = self.getValue()
         if new_value != self._currentValue:
-            if self.__commit_on_focus_loss:
-                # Just track that we have changes, don't commit yet
-                self.__hasChanges = True
-                # Update internal state but don't execute command
-                self._currentValue = new_value
-            else:
-                # Immediate: execute command now
-                self.__executeCommand(new_value)
+            self.__executeCommand(new_value)
 
-    def __executeCommand(self, new_value, skip_callback=False):
-        """Execute the command to update the model.
-
-        Args:
-            new_value: The new value to set
-            skip_callback: If True, skip the callback invocation. This is used
-                when the dialog is closing to avoid queuing UI events that would
-                crash after the dialog is destroyed.
-        """
+    def __executeCommand(self, new_value):
         self._currentValue = new_value
         commandKwArgs = self.commandKwArgs(new_value)
         self._commandClass(
             None, self._items, **commandKwArgs
         ).do()  # pylint: disable=W0142
-        if not skip_callback:
-            self.__invokeCallback(new_value)
+        self.__invokeCallback(new_value)
 
     def onAttributeChanged_Deprecated(self, event):  # pylint: disable=W0613
         if self._entry:
             new_value = getattr(self._items[0], self._getter)()
             if new_value != self._currentValue:
                 self._currentValue = new_value
-                self.__editSessionValue = None  # Cancel any pending edit session
-                self.__hasChanges = False
                 self.setValue(new_value)
                 self.__invokeCallback(new_value)
         else:
@@ -217,8 +95,6 @@ class AttributeSync(object):
 
             if newValue != self._currentValue:
                 self._currentValue = newValue
-                self.__editSessionValue = None  # Cancel any pending edit session
-                self.__hasChanges = False
                 try:
                     self.setValue(newValue)
                     self.__invokeCallback(newValue)

--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -1132,7 +1132,7 @@ class DatesPage(Page):
             except Exception:
                 pass
             try:
-                pub.unsubscribe(self._onDomainPlannedDurationChanged,
+                pub.unsubscribe(self.__onTaskDurationDomainChanged,
                                 self.items[0].plannedDurationChangedEventType())
             except Exception:
                 pass
@@ -1166,14 +1166,14 @@ class DatesPage(Page):
         self.__updateDurationModeDropdown()
         self.__syncTaskState()
 
-    def _onDomainPlannedDurationChanged(self, newValue, sender):
-        """Layer 2: Domain plannedDuration changed."""
-        if sender not in self.items:
-            return
-        self._currentPlannedDuration = newValue
-        self._plannedDurationCtrl.SetDuration(newValue)
-        self.__updatePresetSelection()
+    def __onPlannedDurationSyncCallback(self, value):
+        """AttributeSync callback: duration committed or changed externally."""
         self.__syncTaskState(sourceField='duration')
+
+    def __onTaskDurationDomainChanged(self, newValue, sender):
+        """Domain duration changed — update preset dropdown to match."""
+        if sender in self.items:
+            self.__updatePresetSelection()
 
     def addEntries(self):
         self.addStatusEntry()
@@ -1332,19 +1332,28 @@ class DatesPage(Page):
         self._plannedDurationCtrl = widgets.MaskedDurationCtrl(
             self, days=days, hours=hours, minutes=minutes
         )
-        # Duration is always enabled - mode is auto-determined by which date is activated first
-        self._plannedDurationCtrl.Bind(
-            wx.EVT_KILL_FOCUS, self.__onPlannedDurationChanged
-        )
         # Rebuild dropdown when focus leaves this field
         self._plannedDurationCtrl.Bind(wx.EVT_KILL_FOCUS, self.__onDurationFieldKillFocus)
 
-        # Layer 2: Subscribe to domain changes BEFORE __syncTaskState()
-        # so that duration changes during init sync trigger UI updates.
+        # Layer 2: AttributeSync for duration (user edits → command,
+        # domain changes → widget update). Callback triggers sync cascade.
+        self._plannedDurationSync = attributesync.AttributeSync(
+            "plannedDuration",
+            self._plannedDurationCtrl,
+            plannedDuration,
+            self.items,
+            command.EditPlannedDurationCommand,
+            widgets.EVT_VALUE_CHANGED,
+            self.items[0].plannedDurationChangedEventType(),
+            callback=self.__onPlannedDurationSyncCallback,
+        )
+
+        # Subscribe to domain changes BEFORE __syncTaskState()
+        # so that changes during init sync trigger UI updates.
         if len(self.items) == 1:
             pub.subscribe(self._onDomainPlannedDurationModeChanged,
                           self.items[0].plannedDurationModeChangedEventType())
-            pub.subscribe(self._onDomainPlannedDurationChanged,
+            pub.subscribe(self.__onTaskDurationDomainChanged,
                           self.items[0].plannedDurationChangedEventType())
 
         # Presets dropdown
@@ -1369,7 +1378,6 @@ class DatesPage(Page):
             self._durationModeChoice.Append(label, key)
         self._durationModeChoice.Bind(wx.EVT_CHOICE, self.__onDurationModeChanged)
 
-        self._currentPlannedDuration = plannedDuration
         # Get stored mode from task, default to "automatic"
         storedMode = (
             self.items[0].plannedDurationMode()
@@ -1403,7 +1411,7 @@ class DatesPage(Page):
             _("Planned duration"),
             self._plannedDurationCtrl,
             durationRestPanel,
-            flags=[None, None, wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL],
+            flags=[None, wx.ALL | wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL],
         )
 
         # Row 3: Due date (value already retrieved above)
@@ -1521,45 +1529,6 @@ class DatesPage(Page):
             wx.StaticText(self, label=""),
         )
 
-    def addDateEntry(self, label, taskMethodName):
-        """Add a date entry using the old DateTimeEntry control (for comparison)."""
-        TaskMethodName = taskMethodName[0].capitalize() + taskMethodName[1:]
-        dateTime = (
-            getattr(self.items[0], taskMethodName)()
-            if len(self.items) == 1
-            else date.DateTime()
-        )
-        setattr(self, "_current%s" % TaskMethodName, dateTime)
-        suggestedDateTimeMethodName = "suggested" + TaskMethodName
-        suggestedDateTime = getattr(
-            self.items[0], suggestedDateTimeMethodName
-        )()
-        dateTimeEntry = entry.DateTimeEntry(
-            self,
-            self.__settings,
-            dateTime,
-            suggestedDateTime=suggestedDateTime,
-            showRelative=taskMethodName == "dueDateTime",
-            adjustEndOfDay=taskMethodName == "dueDateTime",
-        )
-        setattr(self, "_%sEntry" % taskMethodName, dateTimeEntry)
-        commandClass = getattr(command, "Edit%sCommand" % TaskMethodName)
-        eventType = getattr(
-            self.items[0], "%sChangedEventType" % taskMethodName
-        )()
-        datetimeSync = attributesync.AttributeSync(
-            taskMethodName,
-            dateTimeEntry,
-            dateTime,
-            self.items,
-            commandClass,
-            entry.EVT_DATETIMEENTRY,
-            eventType,
-            commit_on_focus_loss=True,
-        )
-        setattr(self, "_%sSync" % taskMethodName, datetimeSync)
-        self.addEntry(label, dateTimeEntry, flags=[wx.ALIGN_RIGHT, wx.EXPAND])
-
     def __populateDurationPresets(self):
         """Populate the duration presets dropdown from settings."""
         self._durationPresetsChoice.Clear()
@@ -1660,11 +1629,8 @@ class DatesPage(Page):
 
         new_duration = date.TimeDelta(minutes=total_minutes)
 
-        # Command → pubsub → _onDomainPlannedDurationChanged → sync
-        cmd = command.EditPlannedDurationCommand(
-            items=self.items, newValue=new_duration
-        )
-        cmd.do()
+        # SetDuration → EVT_VALUE_CHANGED → AttributeSync → command → pubsub → preset update
+        self._plannedDurationCtrl.SetDuration(new_duration)
 
 
 
@@ -1674,56 +1640,6 @@ class DatesPage(Page):
         event.Skip()
 
     # --- Existence checks: read from widgets (domain-synced by Layer 2) ---
-
-    def __startDateExists(self):
-        return self._plannedStartDateTimeCombo.GetDateTime() is not None
-
-    def __dueDateExists(self):
-        return self._dueDateTimeCombo.GetDateTime() is not None
-
-    # --- Domain writes: through commands (same pattern as subject/icon) ---
-
-    def __deactivateStartDate(self):
-        """Clear start date. Command -> domain -> pubsub -> Layer 2 unchecks widget."""
-        command.EditPlannedStartDateTimeCommand(
-            None, self.items, newValue=date.DateTime()
-        ).do()
-
-    def __deactivateDueDate(self):
-        """Clear due date. Command -> domain -> pubsub -> Layer 2 unchecks widget."""
-        command.EditDueDateTimeCommand(
-            None, self.items, newValue=date.DateTime()
-        ).do()
-
-    def __adjDueDate(self):
-        """due = start + duration. Reads widgets, writes through command."""
-        start = self._plannedStartDateTimeCombo.GetDateTime()
-        duration = self._plannedDurationCtrl.GetDuration()
-        if start is None or duration is None:
-            return
-        new_due = date.DateTime.fromDateTime(start + duration)
-        command.EditDueDateTimeCommand(
-            None, self.items, newValue=new_due
-        ).do()
-
-    def __activateStartDate(self):
-        """Activate Start-Date combo (step 2.2). Uses internally stored value."""
-        self._plannedStartDateTimeCombo.ActivateValue()
-
-    def __activateDueDate(self):
-        """Activate Due-Date combo (step 3.2). Uses internally stored value."""
-        self._dueDateTimeCombo.ActivateValue()
-
-    def __adjStartDate(self):
-        """start = due - duration. Reads widgets, writes through command."""
-        due = self._dueDateTimeCombo.GetDateTime()
-        duration = self._plannedDurationCtrl.GetDuration()
-        if due is None or duration is None:
-            return
-        new_start = date.DateTime.fromDateTime(due - duration)
-        command.EditPlannedStartDateTimeCommand(
-            None, self.items, newValue=new_start
-        ).do()
 
     def __syncTaskState(self, sourceField=None, depth=0):
         """Sync duration state based on Logic Flow.
@@ -1742,106 +1658,115 @@ class DatesPage(Page):
         task = self.items[0]
         if getattr(task, '_durationSyncInProgress', False):
             return
-        task._durationSyncInProgress = True
-        try:
-            self.__syncTaskStateImpl(sourceField, depth)
-        finally:
-            task._durationSyncInProgress = False
 
-    def __syncTaskStateImpl(self, sourceField, depth):
+        # 0.3 Recursive safety
         # 0.3.4 Depth > 1 should never occur, log error, exit
         if depth > 1:
-            log_step("ERROR: __syncTaskState depth > 1 (%d), exiting" % depth, prefix="DURATION")
+            log_step("ERROR: __syncTaskState depth > 1 (%d), exiting" % depth, prefix="SYNC")
             return
         # 0.3.3 depth == 1 should never receive a user action, log error, continue
         if depth == 1 and sourceField is not None:
-            log_step("ERROR: __syncTaskState depth==1 received sourceField=%s, expected None" % sourceField, prefix="DURATION")
+            log_step("ERROR: __syncTaskState depth==1 received sourceField=%s, expected None" % sourceField, prefix="SYNC")
 
+        # Read current widget state once — no step in a single pass
+        # depends on values changed by a prior step in the same pass.
         mode = self._currentPlannedDurationMode
+        start = self._plannedStartDateTimeCombo.GetDateTime()
+        due = self._dueDateTimeCombo.GetDateTime()
+        duration = self._plannedDurationCtrl.GetDuration()
 
         if mode == "automatic":
             # 1.1 Note: Mode changes away never come back here
             # 1.2 If Start-Date exists, Then set Adj-Due mode, Loop
-            if self.__startDateExists():
+            if start is not None:
                 self.__setDurationMode("adjdue")
-                return self.__syncTaskStateImpl(None, depth=depth + 1)  # 0.3.2
+                return self.__syncTaskState(None, depth=depth + 1)  # 0.3.2
             # 1.3 If Due-Date exists, Then set Adj-Start mode, Loop
-            if self.__dueDateExists():
+            if due is not None:
                 self.__setDurationMode("adjstart")
-                return self.__syncTaskStateImpl(None, depth=depth + 1)  # 0.3.2
+                return self.__syncTaskState(None, depth=depth + 1)  # 0.3.2
 
         elif mode == "adjdue":
             # 2.1 Note: Mode changes away never come back here
             # 2.2 Activate Start-Date, If not Unset-Action [Ref2, 0.1.1]
-            if sourceField != 'start' and not self.__startDateExists():
-                self.__activateStartDate()
+            if sourceField != 'start' and start is None:
+                self._plannedStartDateTimeCombo.ActivateValue()
             # 2.3 Activate Due-Date (Read-Only) [Ref2]
             #     On first entry (sourceField=None), adj if due doesn't exist yet.
-            if not self.__dueDateExists():
-                self.__adjDueDate()
+            if due is None and start is not None and duration is not None:
+                self._dueDateTimeCombo.ActivateValue(start + duration)
             # 2.4 Disable Automatic mode option in dropdown [Ref1]
             #     (handled by __updateDurationModeDropdown on focus loss)
             # 2.5 If Duration changed, Then adj Due-Date
-            if sourceField == 'duration':
-                self.__adjDueDate()
+            if sourceField == 'duration' and start is not None and duration is not None:
+                self._dueDateTimeCombo.ActivateValue(start + duration)
             # 2.6 If Start-Date Unset-Action, Then
-            if sourceField == 'start' and not self.__startDateExists():
-                # 2.6.1 Set Sync-Mode [0.4] — handled by outer guard
-                # 2.6.2 Deactivate Due-Date
-                self.__deactivateDueDate()
-                # 2.6.3 Reactivate Automatic mode option in dropdown
-                #        (handled by __updateDurationModeDropdown on focus loss)
-                # 2.6.4 Set Automatic mode
-                self.__setDurationMode("automatic")
-                # 2.6.5 Unset Sync-Mode — handled by outer guard
+            if sourceField == 'start' and start is None:
+                # 2.6.1 Set Sync-Mode [0.4]
+                task._durationSyncInProgress = True
+                try:
+                    # 2.6.2 Deactivate Due-Date
+                    self._dueDateTimeCombo.DeactivateValue()
+                    # 2.6.3 Reactivate Automatic mode option in dropdown
+                    #        (handled by __updateDurationModeDropdown on focus loss)
+                    # 2.6.4 Set Automatic mode
+                    self.__setDurationMode("automatic")
+                finally:
+                    # 2.6.5 Unset Sync-Mode
+                    task._durationSyncInProgress = False
                 # 2.6.6 Loop
-                return self.__syncTaskStateImpl(None, depth=depth + 1)  # 0.3.2
+                return self.__syncTaskState(None, depth=depth + 1)  # 0.3.2
             # 2.7 If Start-Date changed, Then adj Due-Date
-            if sourceField == 'start':
-                self.__adjDueDate()
+            if sourceField == 'start' and start is not None and duration is not None:
+                self._dueDateTimeCombo.ActivateValue(start + duration)
 
         elif mode == "adjstart":
             # 3.1 Note: Mode changes away never come back here
             # 3.2 Activate Due-Date, If not Unset-Action [Ref2, 0.1.2]
-            if sourceField != 'due' and not self.__dueDateExists():
-                self.__activateDueDate()
+            if sourceField != 'due' and due is None:
+                self._dueDateTimeCombo.ActivateValue()
             # 3.3 Activate Start-Date (Read-Only) [Ref2]
             #     On first entry (sourceField=None), adj if start doesn't exist.
-            if not self.__startDateExists():
-                self.__adjStartDate()
+            if start is None and due is not None and duration is not None:
+                self._plannedStartDateTimeCombo.ActivateValue(due - duration)
             # 3.4 Disable Automatic mode option in dropdown [Ref1]
             #     (handled by __updateDurationModeDropdown on focus loss)
             # 3.5 If Duration changed, Then adj Start-Date
-            if sourceField == 'duration':
-                self.__adjStartDate()
+            if sourceField == 'duration' and due is not None and duration is not None:
+                self._plannedStartDateTimeCombo.ActivateValue(due - duration)
             # 3.6 If Due-Date Unset-Action, Then
-            if sourceField == 'due' and not self.__dueDateExists():
-                # 3.6.1 Set Sync-Mode [0.4] — handled by outer guard
-                # 3.6.2 Deactivate Start-Date
-                self.__deactivateStartDate()
-                # 3.6.3 Reactivate Automatic mode option in dropdown
-                #        (handled by __updateDurationModeDropdown on focus loss)
-                # 3.6.4 Set Automatic mode
-                self.__setDurationMode("automatic")
-                # 3.6.5 Unset Sync-Mode — handled by outer guard
+            if sourceField == 'due' and due is None:
+                # 3.6.1 Set Sync-Mode [0.4]
+                task._durationSyncInProgress = True
+                try:
+                    # 3.6.2 Deactivate Start-Date
+                    self._plannedStartDateTimeCombo.DeactivateValue()
+                    # 3.6.3 Reactivate Automatic mode option in dropdown
+                    #        (handled by __updateDurationModeDropdown on focus loss)
+                    # 3.6.4 Set Automatic mode
+                    self.__setDurationMode("automatic")
+                finally:
+                    # 3.6.5 Unset Sync-Mode
+                    task._durationSyncInProgress = False
                 # 3.6.6 Loop
-                return self.__syncTaskStateImpl(None, depth=depth + 1)  # 0.3.2
+                return self.__syncTaskState(None, depth=depth + 1)  # 0.3.2
             # 3.7 If Due-Date changed, Then adj Start-Date
-            if sourceField == 'due':
-                self.__adjStartDate()
+            if sourceField == 'due' and due is not None and duration is not None:
+                self._plannedStartDateTimeCombo.ActivateValue(due - duration)
 
         elif mode == "implicit":
             # 4.1 Note: Mode changes away never come back here
             # 4.2 Disable Automatic mode option in dropdown [Ref1]
             #     (handled by __updateDurationModeDropdown on focus loss)
             # 4.3 If Start-Date exists
-            if self.__startDateExists():
+            if start is not None:
                 # 4.3.1 If Due-Date exists
-                if self.__dueDateExists():
+                if due is not None:
                     # 4.3.1.1 Enable Duration (Read-Only)
-                    # 4.3.1.2 Adj Duration
-                    self.__adjDuration()
-                    # 4.3.1.3 Negative Durations permitted
+                    # 4.3.1.2 Adj Duration (duration = due - start)
+                    new_duration = due - start  # 4.3.1.3 Negative Durations permitted
+                    self._plannedDurationCtrl.SetDuration(
+                        date.TimeDelta(days=new_duration.days, seconds=new_duration.seconds))
                 # 4.3.2 If Due-Date Unset-Action, Then disable Duration
                 #        -- handled by __updateFieldStates
             # 4.4 If Start-Date Unset-Action, Then disable Duration
@@ -1853,6 +1778,8 @@ class DatesPage(Page):
     def __updateFieldStates(self):
         """Set field states per UI Field States table in DURATION_CALCULATIONS.md."""
         mode = self._currentPlannedDurationMode
+        start = self._plannedStartDateTimeCombo.GetDateTime()
+        due = self._dueDateTimeCombo.GetDateTime()
 
         if mode == "automatic":
             # Automatic | Editable | Editable | Editable
@@ -1863,9 +1790,9 @@ class DatesPage(Page):
 
         elif mode == "adjdue":
             # Adjust Due | Editable | Editable | Read-only
-            if not self.__startDateExists():
+            if start is None:
                 log_step("WARNING: adjdue mode but Start-Date does not exist", prefix="DURATION")
-            if not self.__dueDateExists():
+            if due is None:
                 log_step("WARNING: adjdue mode but Due-Date does not exist", prefix="DURATION")
             self._plannedStartDateTimeCombo.SetEditable()
             self._plannedDurationCtrl.Enable(True)
@@ -1874,9 +1801,9 @@ class DatesPage(Page):
 
         elif mode == "adjstart":
             # Adjust Start | Read-only | Editable | Editable
-            if not self.__startDateExists():
+            if start is None:
                 log_step("WARNING: adjstart mode but Start-Date does not exist", prefix="DURATION")
-            if not self.__dueDateExists():
+            if due is None:
                 log_step("WARNING: adjstart mode but Due-Date does not exist", prefix="DURATION")
             self._plannedStartDateTimeCombo.SetReadOnly()
             self._plannedDurationCtrl.Enable(True)
@@ -1887,7 +1814,7 @@ class DatesPage(Page):
             # Start and Due always Editable
             self._plannedStartDateTimeCombo.SetEditable()
             self._dueDateTimeCombo.SetEditable()
-            if self.__startDateExists() and self.__dueDateExists():
+            if start is not None and due is not None:
                 # Both dates exist: Duration Read-only
                 self._plannedDurationCtrl.Enable(True)
                 self._plannedDurationCtrl.SetReadOnly(True)
@@ -1962,53 +1889,6 @@ class DatesPage(Page):
 
         # Always update dropdown to show actual mode (may differ from selection)
         self.__updateDurationModeDropdown()
-
-    def __adjDuration(self):
-        """Adj Duration: duration = due - start. Writes through command (Attribute pattern)."""
-        start = self._plannedStartDateTimeCombo.GetDateTime()
-        due = self._dueDateTimeCombo.GetDateTime()
-
-        if start is not None and due is not None:
-            new_duration = due - start  # 4.3.1.3 Negative Durations permitted
-            new_timedelta = date.TimeDelta(days=new_duration.days, seconds=new_duration.seconds)
-            command.EditPlannedDurationCommand(
-                items=self.items, newValue=new_timedelta
-            ).do()
-            self._currentPlannedDuration = new_timedelta
-        else:
-            command.EditPlannedDurationCommand(
-                items=self.items, newValue=date.TimeDelta()
-            ).do()
-            self._currentPlannedDuration = date.TimeDelta()
-
-    def __onPlannedDurationChanged(self, event):
-        """Handle duration value change from the duration control."""
-        self.__onPlannedDurationChangedInternal()
-        event.Skip()  # Allow event to propagate to control's _onKillFocus
-
-    def __onPlannedDurationChangedInternal(self):
-        """Handle duration value change (called from event or preset selection).
-
-        Fires command only — pubsub callback (_onDomainPlannedDurationChanged)
-        handles widget update, preset alignment, and sync."""
-        # In implicit mode, duration is calculated, not edited
-        if self._currentPlannedDurationMode == "implicit":
-            return
-
-        new_duration = self._plannedDurationCtrl.GetDuration()
-        new_timedelta = date.TimeDelta(
-            days=new_duration.days,
-            seconds=new_duration.seconds
-        )
-
-        if new_timedelta == self._currentPlannedDuration:
-            return
-
-        # Command → pubsub → _onDomainPlannedDurationChanged → sync
-        cmd = command.EditPlannedDurationCommand(
-            items=self.items, newValue=new_timedelta
-        )
-        cmd.do()
 
     def addReminderEntry(self):
         """Add reminder entry using DateTimeCombo."""
@@ -3735,7 +3615,7 @@ class EffortEditBook(Page):
             _("Start"),
             self._startDateTimeCombo.CreateRowPanel(self),
             self._startFromLastEffortButton,
-            flags=[None, None, wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL],
+            flags=[wx.ALL | wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL, wx.ALL | wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, wx.ALL | wx.ALIGN_CENTER_VERTICAL],
         )
 
         # --- Time Spent row (display only) ---
@@ -3776,7 +3656,7 @@ class EffortEditBook(Page):
             _("Time spent"),
             self._timeSpentCtrl,
             self._timeSpentLabel,
-            flags=[None, None, wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL],
+            flags=[wx.ALL | wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL, wx.ALL | wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, wx.ALL | wx.ALIGN_CENTER_VERTICAL],
         )
 
         # --- Duration row ---
@@ -3805,7 +3685,7 @@ class EffortEditBook(Page):
             current_duration,
             self.items,
             command.EditEffortDurationCommand,
-            wx.EVT_KILL_FOCUS,
+            widgets.EVT_VALUE_CHANGED,
             self.items[0].durationChangedEventType(),
             callback=self.__onEffortDurationChanged,
         )
@@ -3815,6 +3695,9 @@ class EffortEditBook(Page):
         self._effortDurationPresetsChoice.Bind(wx.EVT_CHOICE, self.__onEffortDurationPresetSelected)
 
         pub.subscribe(self.__onEffortPresetsConfigChanged, "settings.feature.effort_duration_presets")
+        if len(self.items) == 1:
+            pub.subscribe(self.__onEffortDurationDomainChanged,
+                          self.items[0].durationChangedEventType())
 
         # Entry mode dropdown (Standard / Retroactive) - placed next to presets
         self._effortEntryModeChoice = wx.Choice(self, choices=[_("Standard"), _("Retroactive"), _("Implicit")])
@@ -3830,12 +3713,12 @@ class EffortEditBook(Page):
         presetsAndModeSizer.Add(self._effortEntryModeChoice, 0, wx.ALIGN_CENTER_VERTICAL)
         presetsAndModePanel.SetSizer(presetsAndModeSizer)
 
-        # Duration row: label, duration, presets+mode (left-aligned)
+        # Duration row: label, duration (right-aligned), presets+mode (left-aligned)
         self.addEntry(
             _("Duration"),
             self._effortDurationCtrl,
             presetsAndModePanel,
-            flags=[None, None, wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL],
+            flags=[wx.ALL | wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL, wx.ALL | wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, wx.ALL | wx.ALIGN_CENTER_VERTICAL],
         )
 
         # --- Stop row: Label, DateTime row (with checkbox), Button ---
@@ -3864,7 +3747,7 @@ class EffortEditBook(Page):
             _("Stop"),
             self._stopDateTimeCombo.CreateRowPanel(self),
             self._stopNowButton,
-            flags=[None, None, wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL],
+            flags=[wx.ALL | wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL, wx.ALL | wx.ALIGN_RIGHT | wx.ALIGN_CENTER_VERTICAL, wx.ALL | wx.ALIGN_CENTER_VERTICAL],
         )
 
         # --- Warning message ---
@@ -3918,9 +3801,6 @@ class EffortEditBook(Page):
 
     # --- Effort helpers (mirroring task pattern) ---
 
-    def __stopDateExists(self):
-        """Check if stop date is active."""
-        return self._stopDateTimeCombo.IsActive()
 
     def __setEffortEntryMode(self, newMode):
         """Set entry mode, update dropdown, write through command.
@@ -3932,72 +3812,6 @@ class EffortEditBook(Page):
         self._effortEntryModeChoice.SetSelection(modeIndex)
         command.EditEffortEntryModeCommand(
             items=self.items, newValue=newMode
-        ).do()
-
-    # --- Effort domain writes: through commands (same pattern as task) ---
-
-    def __activateStopDate(self):
-        """Enable Stop-Date. Command → domain → pubsub → Layer 2 checks widget."""
-        command.EditEffortStopDateTimeCommand(
-            None, self.items, newValue=date.DateTime.now()
-        ).do()
-
-    def __deactivateStopDate(self):
-        """Disable Stop-Date. Command → domain → pubsub → Layer 2 unchecks widget."""
-        command.EditEffortStopDateTimeCommand(
-            None, self.items, newValue=date.DateTime()
-        ).do()
-
-    def __adjStopDate(self):
-        """Stop = Start + Duration. Reads widgets, writes through command."""
-        start = self._startDateTimeCombo.GetDateTime()
-        duration = self._effortDurationCtrl.GetTimeDelta()
-        if start is None or duration is None:
-            return
-        new_stop = date.DateTime.fromDateTime(start + duration)
-        command.EditEffortStopDateTimeCommand(
-            None, self.items, newValue=new_stop
-        ).do()
-
-    def __adjStartDate(self):
-        """Start = Stop - Duration. Reads widgets, writes through command."""
-        stop = self._stopDateTimeCombo.GetDateTime()
-        duration = self._effortDurationCtrl.GetTimeDelta()
-        if stop is None or duration is None:
-            return
-        new_start = date.DateTime.fromDateTime(stop - duration)
-        command.EditEffortStartDateTimeCommand(
-            None, self.items, newValue=new_start
-        ).do()
-
-    def __adjEffortDuration(self):
-        """Duration = Stop - Start. Writes through command."""
-        start = self._startDateTimeCombo.GetDateTime()
-        stop = self._stopDateTimeCombo.GetDateTime()
-        if start is None or stop is None:
-            return
-        td = stop - start
-        calc_duration = date.TimeDelta(days=td.days, seconds=td.seconds)
-        command.EditEffortDurationCommand(
-            items=self.items, newValue=calc_duration
-        ).do()
-
-    def __setEffortDuration(self, value):
-        """Set Duration to explicit value. Writes through command."""
-        command.EditEffortDurationCommand(
-            items=self.items, newValue=value
-        ).do()
-
-    def __setEffortStop(self, value):
-        """Set Stop to explicit value. Writes through command."""
-        command.EditEffortStopDateTimeCommand(
-            None, self.items, newValue=value
-        ).do()
-
-    def __setEffortStart(self, value):
-        """Set Start to explicit value. Writes through command."""
-        command.EditEffortStartDateTimeCommand(
-            None, self.items, newValue=value
         ).do()
 
     def __syncEffortState(self, sourceField=None, depth=0):
@@ -4028,9 +3842,7 @@ class EffortEditBook(Page):
         effort = self.items[0]
         if getattr(effort, '_effortSyncInProgress', False):
             return
-        self.__syncEffortStateImpl(sourceField, depth)
 
-    def __syncEffortStateImpl(self, sourceField, depth):
         # 0.3 Recursive safety
         if depth > 1:
             # 0.3.4 Depth > 1 should never occur, log error, exit
@@ -4040,7 +3852,10 @@ class EffortEditBook(Page):
             # 0.3.3 depth==1 should never receive a sourceField, log error, continue
             log_step("ERROR: __syncEffortState depth==1 received sourceField=%s, expected None" % sourceField, prefix="EFFORT")
 
-        # Read current widget state
+        # Read current widget state once — no step in a single pass
+        # depends on values changed by a prior step in the same pass.
+        start = self._startDateTimeCombo.GetDateTime()
+        stop = self._stopDateTimeCombo.GetDateTime()
         duration = self._effortDurationCtrl.GetTimeDelta()
         total_seconds = int(duration.total_seconds()) if duration else 0
 
@@ -4057,30 +3872,29 @@ class EffortEditBook(Page):
 
             # 1.6 If Duration Unset-Action, Then disable Stop-Date
             if sourceField == 'duration' and total_seconds == 0:
-                self.__deactivateStopDate()
+                self._stopDateTimeCombo.DeactivateValue()
 
             # 1.7 If Stop-Date Unset-Action, Then set Duration = 0
-            elif sourceField == 'stop' and not self.__stopDateExists():
-                self.__setEffortDuration(date.TimeDelta())
+            elif sourceField == 'stop' and stop is None:
+                self._effortDurationCtrl.SetDuration(date.TimeDelta())
 
             # 1.8 If Stop-Date Set-Action
-            elif sourceField == 'stop' and self.__stopDateExists() and total_seconds == 0:
+            elif sourceField == 'stop' and stop is not None and total_seconds == 0:
                 # 1.8.1 If Duration = 0, Then set Implicit mode, Loop
                 self.__setEffortEntryMode("implicit")
-                return self.__syncEffortStateImpl(None, depth=depth + 1)
+                return self.__syncEffortState(None, depth=depth + 1)
 
             # 1.9 If Start-Date changed
             elif sourceField == 'start':
                 # 1.9.1 If Duration > 0
                 if total_seconds > 0:
                     # 1.9.1.1 Set Sync-Mode [0.4]
-                    effort = self.items[0]
                     effort._effortSyncInProgress = True
                     try:
-                        # 1.9.1.2 Adj Stop-Date
-                        self.__adjStopDate()
-                        # 1.9.1.3 Adj Duration
-                        self.__adjEffortDuration()
+                        # 1.9.1.2 Adj Stop-Date (stop = start + duration)
+                        if start is not None and duration is not None:
+                            self._stopDateTimeCombo.ActivateValue(start + duration)
+                        # 1.9.1.3 Adj Duration *Impossible* — see spec TODO
                     finally:
                         # 1.9.1.4 Unset Sync-Mode
                         effort._effortSyncInProgress = False
@@ -4091,34 +3905,31 @@ class EffortEditBook(Page):
                 # 1.10.1 If Duration > 0
                 if total_seconds > 0:
                     # 1.10.1.1 Enable Stop-Date
-                    if not self.__stopDateExists():
-                        self.__activateStopDate()
-                    # 1.10.1.2 Adj Stop-Date
-                    self.__adjStopDate()
+                    if stop is None:
+                        self._stopDateTimeCombo.ActivateValue()
+                    # 1.10.1.2 Adj Stop-Date (stop = start + duration)
+                    if start is not None and duration is not None:
+                        self._stopDateTimeCombo.ActivateValue(start + duration)
                 # 1.10.2 If Duration = 0, Then disable Stop-Date
                 # (already handled in 1.6 above)
 
-            # 1.11 If Stop-Date changed and exists, Then adj Duration
+            # 1.11 If Stop-Date changed and exists, Then adj Duration (duration = stop - start)
             elif sourceField == 'stop':
-                self.__adjEffortDuration()
-
-            # Re-read duration after steps may have changed it
-            duration = self._effortDurationCtrl.GetTimeDelta()
-            total_seconds = int(duration.total_seconds()) if duration else 0
+                if start is not None and stop is not None:
+                    self._effortDurationCtrl.SetDuration(stop - start)
 
             # 1.12 If Duration = 0, Then Autoheal, Thus
             if total_seconds == 0:
-                # 1.12.1 Disable Stop-Date [0.1, 0.2]
-                if sourceField != 'stop' and self.__stopDateExists():
-                    self.__deactivateStopDate()
+                # 1.12.1 Not possible: Disable Stop-Date Conflicts [Ref3]
+                pass
             # 1.13 If Duration > 0, Then Autoheal, Thus
             elif total_seconds > 0:
                 # 1.13.1 Enable Stop-Date [0.1, 0.2]
-                if sourceField != 'stop' and not self.__stopDateExists():
-                    self.__activateStopDate()
-                # 1.13.2 Adj Stop-Date [0.1, 0.2]
-                if sourceField != 'stop':
-                    self.__adjStopDate()
+                if sourceField != 'stop' and stop is None:
+                    self._stopDateTimeCombo.ActivateValue()
+                # 1.13.2 Adj Stop-Date [0.1, 0.2] (stop = start + duration)
+                if sourceField != 'stop' and start is not None and duration is not None:
+                    self._stopDateTimeCombo.ActivateValue(start + duration)
             # 1.14 If Duration < 0, Then Negative Durations permitted
 
         elif self._effortEntryMode == 1:  # 2. If Mode Retroactive
@@ -4132,45 +3943,42 @@ class EffortEditBook(Page):
 
             # 2.6 If Duration Unset-Action, Then disable Stop-Date
             if sourceField == 'duration' and total_seconds == 0:
-                self.__deactivateStopDate()
+                self._stopDateTimeCombo.DeactivateValue()
 
             # 2.7 If Stop-Date Unset-Action, Then set Duration = 0
-            elif sourceField == 'stop' and not self.__stopDateExists():
-                self.__setEffortDuration(date.TimeDelta())
+            elif sourceField == 'stop' and stop is None:
+                self._effortDurationCtrl.SetDuration(date.TimeDelta())
 
-            # 2.8 If Stop-Date changed and exists, Then adj Start-Date
+            # 2.8 If Stop-Date changed and exists, Then adj Start-Date (start = stop - duration)
             elif sourceField == 'stop':
-                self.__adjStartDate()
+                if stop is not None and duration is not None:
+                    self._startDateTimeCombo.ActivateValue(stop - duration)
 
             # 2.9 If Duration changed and exists
             elif sourceField == 'duration':
                 # 2.9.1 If Duration > 0
                 if total_seconds > 0:
                     # 2.9.1.1 Enable Stop-Date
-                    if not self.__stopDateExists():
-                        self.__activateStopDate()
-                    # 2.9.1.2 Adj Start-Date
-                    self.__adjStartDate()
+                    if stop is None:
+                        self._stopDateTimeCombo.ActivateValue()
+                    # 2.9.1.2 Adj Start-Date (start = stop - duration)
+                    if stop is not None and duration is not None:
+                        self._startDateTimeCombo.ActivateValue(stop - duration)
                 # 2.9.2 If Duration = 0, Then disable Stop-Date
                 # (already handled in 2.6 above)
 
-            # Re-read duration after steps may have changed it
-            duration = self._effortDurationCtrl.GetTimeDelta()
-            total_seconds = int(duration.total_seconds()) if duration else 0
-
             # 2.10 If Duration = 0, Then Autoheal, Thus
             if total_seconds == 0:
-                # 2.10.1 Disable Stop-Date [0.1, 0.2]
-                if sourceField != 'stop' and self.__stopDateExists():
-                    self.__deactivateStopDate()
+                # 2.10.1 Not possible: Disable Stop-Date Conflicts [Ref2]
+                pass
             # 2.11 If Duration > 0, Then Autoheal, Thus
             elif total_seconds > 0:
                 # 2.11.1 Enable Stop-Date [0.1, 0.2]
-                if sourceField != 'stop' and not self.__stopDateExists():
-                    self.__activateStopDate()
-                # 2.11.2 Adj Start-Date [0.1, 0.2]
-                if sourceField != 'start':
-                    self.__adjStartDate()
+                if sourceField != 'stop' and stop is None:
+                    self._stopDateTimeCombo.ActivateValue()
+                # 2.11.2 Adj Start-Date [0.1, 0.2] (start = stop - duration)
+                if sourceField != 'start' and stop is not None and duration is not None:
+                    self._startDateTimeCombo.ActivateValue(stop - duration)
             # 2.12 If Duration < 0, Then Negative Durations permitted
 
         elif self._effortEntryMode == 2:  # 3. If Mode Implicit
@@ -4182,17 +3990,20 @@ class EffortEditBook(Page):
             )
 
             # 3.5 If Stop-Date does not exist, Disable Duration
-            if not self.__stopDateExists():
+            if stop is None:
                 self._effortDurationCtrl.Enable(False)
-                self.__setEffortDuration(date.TimeDelta())
+                self._effortDurationCtrl.SetDuration(date.TimeDelta())
+
             # 3.6 If Stop-Date exists
-            elif self.__stopDateExists():
+            elif stop is not None:
                 # 3.6.1 Enable Duration (Read-Only)
                 self._effortDurationCtrl.Enable(True)
                 self._effortDurationCtrl.SetReadOnly(True)
-                # 3.6.2 Adj Duration
+                # 3.6.2 Adj Duration (duration = stop - start)
                 # 3.6.3 Negative Durations permitted
-                self.__adjEffortDuration()
+                if start is not None and stop is not None:
+                    self._effortDurationCtrl.SetDuration(stop - start)
+    
 
         self.__update_invalid_period_message()
         self.__updateFieldStates()
@@ -4261,6 +4072,11 @@ class EffortEditBook(Page):
             return _("0 secs")
         return " ".join(parts)
 
+    def __onEffortDurationDomainChanged(self, newValue, sender):
+        """Domain duration changed — update preset dropdown to match."""
+        if sender in self.items:
+            self.__updateEffortPresetSelection()
+
     def __updateEffortPresetSelection(self):
         """Update preset dropdown to match current duration value."""
         if not hasattr(self, '_effortDurationCtrl'):
@@ -4293,12 +4109,8 @@ class EffortEditBook(Page):
         if total_seconds is None:
             return
 
-        # Wrapper fires command → pubsub → callback → sync
-        self.__setEffortDuration(date.TimeDelta(seconds=total_seconds))
-        self.__updateEffortPresetSelection()
-        # Reset-to-zero: show "Presets..." not "Reset to zero"
-        if total_seconds == 0:
-            self._effortDurationPresetsChoice.SetSelection(0)
+        # SetDuration → EVT_VALUE_CHANGED → AttributeSync → command → pubsub → preset update
+        self._effortDurationCtrl.SetDuration(date.TimeDelta(seconds=total_seconds))
 
     def __onEffortPresetsConfigChanged(self):
         """Handle changes to effort preset configuration."""
@@ -4313,7 +4125,8 @@ class EffortEditBook(Page):
         if not hasattr(self, '_timeSpentCtrl'):
             return
 
-        if self.__stopDateExists():
+        stop = self._stopDateTimeCombo.GetDateTime()
+        if stop is not None:
             # Stop exists — deactivate time spent
             self._timeSpentCtrl.Enable(False)
             self.__stopTimeSpentTimer()
@@ -4338,14 +4151,9 @@ class EffortEditBook(Page):
             self._timeSpentCtrl.SetDuration(datetime.timedelta(seconds=0))
             return
 
-        if self.__stopDateExists():
-            stop = self._stopDateTimeCombo.GetDateTime()
-        else:
-            stop = date.DateTime.now()
-
+        stop = self._stopDateTimeCombo.GetDateTime()
         if stop is None:
-            self._timeSpentCtrl.SetDuration(datetime.timedelta(seconds=0))
-            return
+            stop = date.DateTime.now()
 
         total_seconds = int((stop - start).total_seconds())
         self._timeSpentCtrl.SetDuration(datetime.timedelta(seconds=total_seconds))
@@ -4394,11 +4202,11 @@ class EffortEditBook(Page):
     def onStartFromLastEffort(self, event):  # pylint: disable=W0613
         maxDateTime = self._effortList.maxDateTime()
         if maxDateTime is not None:
-            self.__setEffortStart(maxDateTime)
+            self._startDateTimeCombo.ActivateValue(maxDateTime)
 
     def onStopNow(self, event):
         # Stop only the specific effort(s) being edited, not all efforts for the task
-        self.__activateStopDate()
+        self._stopDateTimeCombo.ActivateValue(datetime.datetime.now())
 
     def onStopDateTimeChanged(self, *args, **kwargs):
         self.onDateTimeChanged(*args, **kwargs)
@@ -4507,6 +4315,11 @@ class EffortEditBook(Page):
             pass
         if len(self.items) == 1:
             try:
+                pub.unsubscribe(self.__onEffortDurationDomainChanged,
+                                self.items[0].durationChangedEventType())
+            except Exception:
+                pass
+            try:
                 pub.unsubscribe(self._onDomainEntryModeChanged,
                                 self.items[0].entryModeChangedEventType())
             except Exception:
@@ -4560,8 +4373,8 @@ class Editor(BalloonTipManager, widgets.Dialog):
 
         # Note: We intentionally do NOT freeze viewers while the dialog is open.
         # Updates should propagate immediately so other windows stay in sync.
-        # The commit_on_focus_loss option on AttributeSync handles batching
-        # rapid edits into single commands.
+        # Controls fire EVT_VALUE_CHANGED on blur (user edits) and from
+        # programmatic setters — AttributeSync commits immediately.
 
         if operating_system.isMac():
             # Sigh. On OS X, if you open an editor, switch back to the main window, open

--- a/taskcoachlib/gui/dialog/preferences.py
+++ b/taskcoachlib/gui/dialog/preferences.py
@@ -1431,15 +1431,15 @@ class LanguagePage(SettingsPage):
         dateFormatPanel.SetSizer(dateFormatSizer)
         self.addEntry(_("Date format"), dateFormatPanel)
 
-        # Demo DateCtrl4 showing the selected format (interactive, starts with today)
-        from taskcoachlib.widgets.maskedtimectrl import DateCtrl4
+        # Demo DateCtrl showing the selected format (interactive, starts with today)
+        from taskcoachlib.widgets.maskedtimectrl import DateCtrl
         import datetime
         today = datetime.date.today()
         demoPanel = wx.Panel(self)
         demoSizer = wx.BoxSizer(wx.HORIZONTAL)
         demoLabel = wx.StaticText(demoPanel, label=_("Preview:"))
         demoSizer.Add(demoLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10)
-        self._demoDateCtrl = DateCtrl4(
+        self._demoDateCtrl = DateCtrl(
             demoPanel,
             year=today.year, month=today.month, day=today.day,
             dateFormat=currentFormat or None
@@ -1638,8 +1638,8 @@ class LanguagePage(SettingsPage):
         choice = event.GetEventObject()
         newFormat = choice.GetClientData(choice.GetSelection())
 
-        # Recreate the demo DateCtrl4 with new format, using today's date
-        from taskcoachlib.widgets.maskedtimectrl import DateCtrl4
+        # Recreate the demo DateCtrl with new format, using today's date
+        from taskcoachlib.widgets.maskedtimectrl import DateCtrl
         import datetime
         today = datetime.date.today()
         parent = self._demoDateCtrl.GetParent()
@@ -1647,7 +1647,7 @@ class LanguagePage(SettingsPage):
 
         # Destroy old and create new with today's date
         self._demoDateCtrl.Destroy()
-        self._demoDateCtrl = DateCtrl4(
+        self._demoDateCtrl = DateCtrl(
             parent,
             year=today.year,
             month=today.month,

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,10 +41,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "59"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.1.59
+patch = "60"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.1.60
 
-release_day = "1"  # Day of the release (1-31)
+release_day = "2"  # Day of the release (1-31)
 release_month = "February"  # Month of the release
 release_year = "2026"  # Year of the release
 

--- a/taskcoachlib/widgets/__init__.py
+++ b/taskcoachlib/widgets/__init__.py
@@ -33,8 +33,8 @@ from .maskedtimectrl import (
     DurationCtrlVerbose as MaskedDurationCtrlVerbose,
     TimeCtrl as MaskedTimeCtrl,
     TimeWithSecondsCtrl as MaskedTimeWithSecondsCtrl,
-    DateCtrl4 as MaskedDateCtrl,
-    DateTimeCombo2 as DateTimeCombo,
+    DateCtrl as MaskedDateCtrl,
+    DateTimeCombo,
     EVT_VALUE_CHANGED,
 )
 from .textctrl import (

--- a/taskcoachlib/widgets/maskedtimectrl.py
+++ b/taskcoachlib/widgets/maskedtimectrl.py
@@ -76,7 +76,6 @@ from pubsub import pub
 
 from taskcoachlib.i18n import _
 from taskcoachlib.domain import date
-from taskcoachlib.meta.debug import log_step
 
 
 # =============================================================================
@@ -766,337 +765,6 @@ class _ChoicesPopup(_PopupWindow):
         # Don't clear highlight when mouse leaves - standard dropdown behavior
 
 
-class _CalendarPopup(_PopupWindow):
-    """Calendar popup for date selection."""
-
-    def __init__(self, selection, font, minDate=None, maxDate=None, *args, **kwargs):
-        self.__originalDate = selection  # Value when popup opened
-        self.__highlightedDate = selection  # Currently highlighted (mouse or keys)
-        self.__year = selection.year
-        self.__month = selection.month
-        self.__minDate = minDate
-        self.__maxDate = maxDate
-        self.__maxDim = None
-        self.__font = font
-        self.__days = []
-        super().__init__(*args, **kwargs)
-        pub.subscribe(self._onColoursChanged, 'calendar.colours.changed')
-
-    def _onColoursChanged(self):
-        self.Refresh()
-
-    def Dismiss(self):
-        pub.unsubscribe(self._onColoursChanged, 'calendar.colours.changed')
-        super().Dismiss()
-
-    def HandleKey(self, event):
-        """Handle keyboard navigation within the calendar popup.
-
-        Arrow keys move the selection:
-        - Left/Right: Move by 1 day
-        - Up/Down: Move by 1 week (7 days)
-
-        Enter confirms the selection, Escape cancels.
-        """
-        keyCode = event.GetKeyCode()
-
-        if keyCode == wx.WXK_ESCAPE:
-            self.Dismiss()
-            return True
-        elif keyCode == wx.WXK_RETURN:
-            self.GetParent()._setDateFromCalendar(self.__highlightedDate)
-            self.Dismiss()
-            return True
-        elif keyCode == wx.WXK_LEFT:
-            self.__MoveHighlight(datetime.timedelta(days=-1))
-            return True
-        elif keyCode == wx.WXK_RIGHT:
-            self.__MoveHighlight(datetime.timedelta(days=1))
-            return True
-        elif keyCode == wx.WXK_UP:
-            self.__MoveHighlight(datetime.timedelta(days=-7))
-            return True
-        elif keyCode == wx.WXK_DOWN:
-            self.__MoveHighlight(datetime.timedelta(days=7))
-            return True
-        return False
-
-    def __MoveHighlight(self, delta):
-        """Move the calendar highlight by the given timedelta."""
-        newDate = self.__highlightedDate + delta
-        # Check min/max bounds
-        if self.__minDate is not None and newDate < self.__minDate:
-            wx.Bell()
-            return
-        if self.__maxDate is not None and newDate > self.__maxDate:
-            wx.Bell()
-            return
-        # Check year bounds (datetime supports 1-9999)
-        if newDate.year < 1 or newDate.year > 9999:
-            wx.Bell()
-            return
-        self.__highlightedDate = newDate
-        # Update displayed month/year if highlight moved to different month
-        if self.__highlightedDate.year != self.__year or self.__highlightedDate.month != self.__month:
-            self.__year = self.__highlightedDate.year
-            self.__month = self.__highlightedDate.month
-            self.SetClientSize(self._getExtent(wx.ClientDC(self.interior())))
-        self.Refresh()
-
-    def Fill(self, interior):
-        interior.Bind(wx.EVT_PAINT, self._onPaint)
-        interior.Bind(wx.EVT_LEFT_UP, self._onLeftUp)
-        interior.Bind(wx.EVT_MOTION, self._onMotion)
-        interior.Bind(wx.EVT_LEAVE_WINDOW, self._onLeaveWindow)
-        self.SetClientSize(self._getExtent(wx.ClientDC(interior)))
-
-    def _getExtent(self, dc):
-        dc.SetFont(self.__font)
-        W, H = 0, 0
-        for month in range(1, 13):
-            header = datetime.date(year=self.__year, month=month, day=11).strftime("%B %Y")
-            tw, th = dc.GetTextExtent(header)
-            W = max(W, tw)
-            H = max(H, th)
-        header = datetime.date(year=self.__year, month=self.__month, day=1).strftime("%B %Y")
-
-        lines = monthcalendarex(self.__year, self.__month, weeks=1)
-        self.__maxDim = 0
-        for line in lines:
-            for year, month, day in line:
-                tw, th = dc.GetTextExtent("%d" % day)
-                self.__maxDim = max(self.__maxDim, tw, th)
-
-        for hdr in calendar.weekheader(2).split():
-            tw, th = dc.GetTextExtent(hdr)
-            self.__maxDim = max(self.__maxDim, tw, th)
-
-        # Add spacing for cell content
-        self.__maxDim += 4
-        contentOffsetX, contentOffsetY = getTextCtrlContentOffset()
-        return wx.Size(
-            max(W + 48 + 4, self.__maxDim * len(lines[0])) + contentOffsetX * 2,
-            H + 2 + self.__maxDim * (len(lines) + 1) + contentOffsetY * 2,
-        )
-
-    def _onPaint(self, event):
-        win = event.GetEventObject()
-        dc = wx.PaintDC(win)
-        w, h = self.GetClientSize()
-        renderer = wx.RendererNative.Get()
-
-        # Draw text control frame with editing focus highlight (blue ring)
-        renderer.DrawTextCtrl(win, dc, wx.Rect(0, 0, w, h), wx.CONTROL_FOCUSED)
-
-        contentOffsetX, contentOffsetY = getTextCtrlContentOffset()
-        contentW = w - contentOffsetX * 2
-
-        dc.SetFont(self.__font)
-        self.__win = win  # Store for drawFocusRect calls
-        self.__contentOffsetX = contentOffsetX  # Store for content positioning
-        self.__contentOffsetY = contentOffsetY
-
-        # Get theme-aware calendar colours
-        colours = getCalendarColours()
-
-        # Header: current month/year
-        textColour = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOWTEXT)
-        dc.SetPen(wx.Pen(textColour))
-        dc.SetBrush(wx.Brush(textColour))
-        dc.SetTextForeground(textColour)
-
-        header = datetime.date(year=self.__year, month=self.__month, day=1).strftime("%B %Y")
-        tw, th = dc.GetTextExtent(header)
-        dc.DrawText(header, contentOffsetX + (contentW - 48 - tw) // 2, contentOffsetY)
-
-        buttonDim = min(th, 10)
-
-        cx = w - contentOffsetX - 24
-        cy = contentOffsetY + th // 2 + 1
-
-        gc = wx.GraphicsContext.Create(dc)
-        gc.SetPen(gc.CreatePen(wx.Pen(textColour)))
-        gc.SetBrush(gc.CreateBrush(wx.Brush(textColour)))
-
-        # Prev month button (left arrow)
-        if self.__month != 1 or self.__year != 1:
-            gp = gc.CreatePath()
-            xinf = w - contentOffsetX - 48 + 16 - buttonDim
-            xsup = w - contentOffsetX - 48 + 16
-            yinf = contentOffsetY + th / 2 + 1 - buttonDim / 2
-            ysup = contentOffsetY + th / 2 + 1 + buttonDim / 2
-
-            gp.MoveToPoint(xinf, contentOffsetY + th // 2 + 1)
-            gp.AddArc(
-                cx, cy,
-                math.sqrt((xsup - cx) * (xsup - cx) + (yinf - cy) * (yinf - cy)),
-                math.pi * 3 / 4, math.pi * 5 / 4, True,
-            )
-            gc.DrawPath(gp)
-
-        # Next month button (right arrow)
-        if self.__month != 12 or self.__year != 9999:
-            gp = gc.CreatePath()
-            xinf = w - contentOffsetX - 16
-            xsup = w - contentOffsetX - 16 + buttonDim
-            yinf = contentOffsetY + th / 2 + 1 - buttonDim / 2
-
-            gp.MoveToPoint(xsup, contentOffsetY + th // 2 + 1)
-            gp.AddArc(
-                cx, cy,
-                math.sqrt((xinf - cx) * (xinf - cx) + (yinf - cy) * (yinf - cy)),
-                math.pi / 4, -math.pi / 4, False,
-            )
-            gc.DrawPath(gp)
-
-        # Today button (circle)
-        gp = gc.CreatePath()
-        gp.AddArc(cx, cy, buttonDim * 3 / 4, 0, math.pi * 2, True)
-        gc.DrawPath(gp)
-
-        y = contentOffsetY + th + 2
-
-        # Weekday headers
-        hdrBg = colours['weekday_header_bg']
-        dc.SetPen(wx.Pen(hdrBg))
-        dc.SetBrush(wx.Brush(hdrBg))
-        dc.DrawRectangle(contentOffsetX, y, self.__maxDim * 7, self.__maxDim)
-        dc.SetTextForeground(colours['weekday_header_fg'])
-        for idx, hdr in enumerate(calendar.weekheader(2).split()):
-            tw, th_hdr = dc.GetTextExtent(hdr)
-            dc.DrawText(
-                hdr,
-                contentOffsetX + self.__maxDim * idx + int((self.__maxDim - tw) // 2),
-                y + int((self.__maxDim - th_hdr) // 2),
-            )
-
-        y += self.__maxDim
-
-        # Days
-        self.__days = []
-        for line in monthcalendarex(self.__year, self.__month, weeks=1):
-            x = contentOffsetX
-            for dayIndex, (year, month, day) in enumerate(line):
-                dt = datetime.date(year=year, month=month, day=day)
-                active = (self.__minDate is None or dt >= self.__minDate) and (
-                    self.__maxDate is None or dt <= self.__maxDate
-                )
-                thisMonth = year == self.__year and month == self.__month
-
-                dc.SetPen(wx.Pen(textColour))
-                dc.SetTextForeground(
-                    colours['weekend_day_fg'] if (dayIndex + calendar.firstweekday()) % 7 in [5, 6] else textColour
-                )
-
-                # Draw backgrounds first so highlight can paint on top
-                if not active:
-                    inactiveBg = wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE)
-                    dc.SetPen(wx.Pen(inactiveBg))
-                    dc.SetBrush(wx.Brush(inactiveBg))
-                    dc.DrawRectangle(x, y, self.__maxDim, self.__maxDim)
-                elif not thisMonth:
-                    otherMonthBg = colours['other_month_bg'] if colours['other_month_bg'] is not None else wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE)
-                    dc.SetPen(wx.Pen(otherMonthBg))
-                    dc.SetBrush(wx.Brush(otherMonthBg))
-                    dc.DrawRectangle(x, y, self.__maxDim, self.__maxDim)
-
-                isHighlighted = (dt == self.__highlightedDate and active)
-
-                if isHighlighted:
-                    # Single highlight style for both mouse hover and keyboard navigation
-                    drawFocusRect(self.__win, dc, x, y, self.__maxDim, self.__maxDim)
-                    dc.SetTextForeground(
-                        wx.SystemSettings.GetColour(wx.SYS_COLOUR_HIGHLIGHTTEXT)
-                    )
-
-                # Highlight today with border
-                now = datetime.datetime.now()
-                if (dt.year, dt.month, dt.day) == (now.year, now.month, now.day):
-                    dc.SetPen(wx.Pen(colours['today_border']))
-                    dc.SetBrush(wx.TRANSPARENT_BRUSH)
-                    dc.DrawRectangle(x, y, self.__maxDim, self.__maxDim)
-
-                label = "%d" % day
-                tw, th_day = dc.GetTextExtent(label)
-                dc.DrawText(
-                    label,
-                    x + (self.__maxDim - tw) // 2,
-                    y + (self.__maxDim - th_day) // 2,
-                )
-
-                if active:
-                    self.__days.append((x, y, (year, month, day)))
-                x += self.__maxDim
-            y += self.__maxDim
-
-    def _onLeftUp(self, event):
-        w, h = self.GetClientSize()
-        contentOffsetX, contentOffsetY = getTextCtrlContentOffset()
-
-        dc = wx.ClientDC(self.interior())
-        dc.SetFont(self.__font)
-        header = datetime.date(year=self.__year, month=self.__month, day=1).strftime("%B %Y")
-        tw, th = dc.GetTextExtent(header)
-
-        # Buttons area (top right, accounting for content offset)
-        if event.GetY() < contentOffsetY + th + 2 and event.GetX() > w - contentOffsetX - 48:
-            if event.GetX() < w - contentOffsetX - 48 + 16 and (self.__month != 1 or self.__year != 1):
-                # Prev month
-                if self.__month == 1:
-                    self.__year -= 1
-                    self.__month = 12
-                else:
-                    self.__month -= 1
-            elif event.GetX() < w - contentOffsetX - 48 + 32:
-                # Today button
-                today = datetime.datetime.now()
-                self.__year = today.year
-                self.__month = today.month
-            elif self.__month != 12 or self.__year != 9999:
-                # Next month
-                if self.__month == 12:
-                    self.__year += 1
-                    self.__month = 1
-                else:
-                    self.__month += 1
-            self.SetClientSize(self._getExtent(wx.ClientDC(self.interior())))
-            self.Refresh()
-            return
-
-        # Day selection
-        for x, y, (year, month, day) in self.__days:
-            if (
-                event.GetX() >= x
-                and event.GetX() < x + self.__maxDim
-                and event.GetY() >= y
-                and event.GetY() < y + self.__maxDim
-            ):
-                self.GetParent()._setDateFromCalendar(
-                    datetime.date(year=year, month=month, day=day)
-                )
-                self.Dismiss()
-                break
-
-    def _onMotion(self, event):
-        """Track mouse movement to highlight day under cursor."""
-        newHighlight = None
-        for x, y, (year, month, day) in self.__days:
-            if (
-                event.GetX() >= x
-                and event.GetX() < x + self.__maxDim
-                and event.GetY() >= y
-                and event.GetY() < y + self.__maxDim
-            ):
-                newHighlight = datetime.date(year=year, month=month, day=day)
-                break
-        if newHighlight is not None and newHighlight != self.__highlightedDate:
-            self.__highlightedDate = newHighlight
-            self.Refresh()
-
-    def _onLeaveWindow(self, event):
-        """Keep highlight when mouse leaves popup - standard dropdown behavior."""
-        # Don't clear highlight when mouse leaves - standard dropdown behavior
-        pass
 
 
 # =============================================================================
@@ -1150,9 +818,6 @@ class NumericField:
             self.__value = result
         self.__observer.Refresh()
         self.__observer.Update()  # Force immediate repaint
-        # Notify observer of value change (for live preview updates)
-        if hasattr(self.__observer, 'NotifyValueChanged'):
-            self.__observer.NotifyValueChanged()
 
     def GetChoices(self):
         """Get choices for dropdown. If choices is callable, call it to get fresh values.
@@ -1701,6 +1366,7 @@ class FieldsCtrl(wx.Panel):
         if self._focus:
             self._focus.ResetState()  # Clear any partial digit entry
         self.Refresh()
+        self.NotifyValueChanged()
         event.Skip()
 
     def ValidateChange(self, field, value):
@@ -1740,22 +1406,9 @@ class FieldsCtrl(wx.Panel):
         return super().AcceptsFocusFromKeyboard()
 
     def NotifyValueChanged(self):
-        """Called when a field value changes. Fires EVT_VALUE_CHANGED event."""
-        if not getattr(self, '_suppressEvents', False):
-            self._fireValueChanged()
-
-    def _fireValueChanged(self):
         """Fire EVT_VALUE_CHANGED event to notify listeners of value change."""
         event = ValueChangedEvent(self)
         wx.PostEvent(self, event)
-
-    def SetFieldValueQuiet(self, name, value):
-        """Set a field value without firing events."""
-        self._suppressEvents = True
-        try:
-            self.SetFieldValue(name, value)
-        finally:
-            self._suppressEvents = False
 
 
 class DurationCtrl(FieldsCtrl):
@@ -1867,6 +1520,7 @@ class DurationCtrl(FieldsCtrl):
         self.SetFieldValue('minute', minutes)
         if self._showSeconds:
             self.SetFieldValue('second', seconds)
+        self.NotifyValueChanged()
 
     def SetTimeDelta(self, duration):
         """Alias for SetDuration for consistency with other controls."""
@@ -1992,6 +1646,7 @@ class DurationCtrlVerbose(FieldsCtrl):
         self.SetFieldValue('minute', minutes)
         if self._showSeconds:
             self.SetFieldValue('second', seconds)
+        self.NotifyValueChanged()
 
     def SetTimeDelta(self, duration):
         """Alias for SetDuration for consistency with other controls."""
@@ -2241,235 +1896,13 @@ class TimeWithSecondsCtrl(FieldsCtrl):
         self.SetFieldValue('second', t.second)
 
 
-class DateCtrl(FieldsCtrl):
-    """Date control with locale-aware field order and separators.
-
-    Automatically detects the system locale's date format using strftime("%x")
-    and arranges year/month/day fields accordingly:
-    - US: MM/DD/YYYY
-    - Europe: DD/MM/YYYY
-    - ISO/Canada: YYYY-MM-DD
-
-    The dateFormat parameter can override the automatic detection:
-    - None or "": Use automatic locale detection
-    - "YMD-": Year-Month-Day with hyphen (ISO format)
-    - "MDY/": Month/Day/Year with slash (US format)
-    - "DMY/": Day/Month/Year with slash (European format)
-    - "DMY.": Day.Month.Year with dot (German format)
-    """
-
-    def __init__(self, parent, year=None, month=None, day=None,
-                 minDate=None, maxDate=None, dateFormat=None):
-        # Default to today's date
-        today = datetime.date.today()
-        if year is None:
-            year = today.year
-        if month is None:
-            month = today.month
-        if day is None:
-            day = today.day
-
-        self._minDate = minDate
-        self._maxDate = maxDate
-        self._calendarPopup = None
-
-        # Get date format: use explicit override, or read from settings, or detect from locale
-        if dateFormat is not None:
-            # Explicit format passed - use it directly
-            field_order, separator = getLocaleDateFormat(override=dateFormat if dateFormat else None)
-        else:
-            # No explicit format - use effective format from settings
-            field_order, separator = getEffectiveDateFormat()
-
-        # Map field names to their values
-        field_values = {
-            'year': year,
-            'month': month,
-            'date_day': day,
-        }
-
-        # Build elements list based on locale order
-        elements = []
-        for i, field_name in enumerate(field_order):
-            if i > 0:
-                elements.append(("literal", separator))
-            elements.append((field_name, field_values[field_name]))
-
-        super().__init__(parent, elements)
-
-    def _onChar(self, event):
-        """Override to show calendar popup on Enter instead of field dropdown."""
-        if not self._focus:
-            event.Skip()
-            return
-
-        keyCode = event.GetKeyCode()
-
-        # Tab exits control (always allowed, even in read-only mode)
-        if keyCode == wx.WXK_TAB:
-            self.DismissPopup()
-            self.Navigate(not event.ShiftDown())
-            return
-
-        # Block all other input in read-only mode
-        if self._readOnly:
-            return
-
-        # Escape dismisses popup
-        if keyCode == wx.WXK_ESCAPE:
-            if self._popup or self._calendarPopup:
-                self.DismissPopup()
-                return
-            event.Skip()
-            return
-
-        # Enter or F4 toggles calendar popup
-        if keyCode in (wx.WXK_RETURN, wx.WXK_NUMPAD_ENTER, wx.WXK_F4):
-            if self._calendarPopup:
-                self.DismissPopup()
-            else:
-                self._showCalendarPopup()
-            return
-
-        # Left/Right arrows navigate between subfields
-        if keyCode == wx.WXK_LEFT:
-            self._focusPrevField()
-            return
-        if keyCode == wx.WXK_RIGHT:
-            self._focusNextField()
-            return
-
-        # Let the focused field handle the key (Up/Down for increment/decrement)
-        if self._focus.HandleKey(event):
-            return
-
-        event.Skip()
-
-    def _onLeftUp(self, event):
-        """Override to show calendar popup on click."""
-        # No interaction in read-only mode
-        if self._readOnly:
-            event.Skip()
-            return
-
-        pt = event.GetPosition()
-
-        # Check if click is inside the control
-        w, h = self.GetClientSize()
-        if 0 <= pt.x <= w and 0 <= pt.y <= h:
-            # Set focus if not already focused
-            if not self.HasFocus():
-                self.SetFocus()
-                self._focusStamp = time.time()
-                self.Refresh()
-                return
-
-            # Find which field was clicked and focus it
-            for widget, x, y, fw, fh in self._widgets:
-                if isinstance(widget, NumericField):
-                    if x <= pt.x <= x + fw and y <= pt.y <= y + fh:
-                        self._focus = widget
-                        self._focus.ResetState()
-                        break
-
-            # Check for toggle behavior (click when calendar is open)
-            if self._calendarPopup is not None:
-                self.DismissPopup()
-            elif (
-                self._popupDismissedWidget is not None
-                and time.time() - self._popupDismissedTime < self.POPUP_TOGGLE_DELAY
-            ):
-                # Just closed, don't reopen
-                self._popupDismissedWidget = None
-            else:
-                # Show calendar popup
-                if time.time() - self._focusStamp >= self.FOCUS_DELAY:
-                    self._showCalendarPopup()
-
-            self.Refresh()
-            return
-
-        event.Skip()
-
-    def _showCalendarPopup(self):
-        """Show the calendar popup for date selection."""
-        if self._calendarPopup is not None:
-            return
-
-        selection = self.GetDate()
-        popup = _CalendarPopup(
-            selection, self.GetFont(),
-            minDate=self._minDate, maxDate=self._maxDate,
-            parent=self
-        )
-        self._calendarPopup = popup
-
-        # Position popup below the control, left-aligned
-        pos = self.ClientToScreen(wx.Point(0, self.GetClientSize().GetHeight()))
-        popup.Popup(pos)
-        popup.Bind(EVT_POPUP_DISMISS, self._onCalendarDismiss)
-
-    def _onCalendarDismiss(self, event):
-        """Handle calendar popup dismissal."""
-        self._popupDismissedWidget = self
-        self._popupDismissedTime = time.time()
-        self._calendarPopup = None
-        self._returningFromPopup = True
-        self.SetFocus()
-        event.Skip()
-
-    def _setDateFromCalendar(self, date):
-        """Set date from calendar popup selection."""
-        self.SetDate(date)
-
-    def DismissPopup(self):
-        """Dismiss any open popup (calendar or field dropdown)."""
-        if self._calendarPopup:
-            self._calendarPopup.Dismiss()
-            self._calendarPopup = None
-        super().DismissPopup()
-
-    def ValidateChange(self, field, value):
-        """Validate date changes, adjusting day if needed for month/year changes."""
-        # Get current values (already updated by NumericField.SetValue)
-        year = self.GetFieldValue('year')
-        month = self.GetFieldValue('month')
-        day = self.GetFieldValue('date_day')
-
-        # Clamp day to valid range for month/year
-        max_day = calendar.monthrange(year, month)[1]
-        if day > max_day:
-            day = max_day
-            self.SetFieldValue('date_day', day)
-
-        return value
-
-    def GetDate(self):
-        """Get the current date value."""
-        return datetime.date(
-            year=self.GetFieldValue('year'),
-            month=self.GetFieldValue('month'),
-            day=self.GetFieldValue('date_day')
-        )
-
-    def SetDate(self, d):
-        """Set the date value.
-
-        Args:
-            d: datetime.date or None (defaults to today)
-        """
-        if d is None:
-            d = datetime.date.today()
-        self.SetFieldValue('year', d.year)
-        self.SetFieldValue('month', d.month)
-        self.SetFieldValue('date_day', d.day)
 
 
 class _CalendarComboPopup(wx.ComboPopup):
     """ComboPopup adapter for the custom-painted calendar.
 
-    Wraps the same calendar painting/interaction logic from _CalendarPopup
-    into the wx.ComboPopup interface, so it can be used with wx.ComboCtrl.
+    Wraps the calendar painting/interaction logic into the wx.ComboPopup
+    interface, so it can be used with wx.ComboCtrl.
     The ComboCtrl provides the native dropdown button and manages the popup
     window (including Wayland-safe positioning).
     """
@@ -2520,7 +1953,7 @@ class _CalendarComboPopup(wx.ComboPopup):
         return size
 
     def _getDateCtrl2(self):
-        """Get the DateCtrl4 (ComboCtrl) that owns this popup."""
+        """Get the DateCtrl (ComboCtrl) that owns this popup."""
         combo = self.GetComboCtrl()
         if combo:
             if hasattr(combo, '_dateCtrl') and hasattr(combo, '_setDateFromCalendar'):
@@ -2603,7 +2036,7 @@ class _CalendarComboPopup(wx.ComboPopup):
             self._panel.GetParent().Layout()
         self._panel.Refresh()
 
-    # --- Calendar painting and interaction (same logic as _CalendarPopup) ---
+    # --- Calendar painting and interaction ---
 
     def _getExtent(self, dc):
         if self._font:
@@ -2904,7 +2337,7 @@ class _EmbeddedDateCtrl(FieldsCtrl):
 
         Uses IsThisEnabled() (own state) instead of IsEnabled() (parent chain)
         so that disabling the parent ComboCtrl for read-only visuals doesn't
-        trigger the "N/A" branch. Only a direct Enable(False) on DateCtrl4
+        trigger the "N/A" branch. Only a direct Enable(False) on DateCtrl
         (which propagates to this control's own state) shows "N/A".
 
         No frame drawing — the parent ComboCtrl provides the frame.
@@ -3049,7 +2482,7 @@ class _EmbeddedDateCtrl(FieldsCtrl):
         self.SetFieldValue('date_day', d.day)
 
 
-class DateCtrl4(wx.ComboCtrl):
+class DateCtrl(wx.ComboCtrl):
     """Date control: _EmbeddedDateCtrl inside a ComboCtrl.
 
     Uses _EmbeddedDateCtrl which has all popup/frame logic removed at the
@@ -3190,10 +2623,6 @@ class DateCtrl4(wx.ComboCtrl):
         """Return True if the calendar popup is currently shown."""
         return self.IsPopupShown()
 
-    def _fireValueChanged(self):
-        """Delegate to inner _EmbeddedDateCtrl."""
-        self._dateCtrl._fireValueChanged()
-
     def Bind(self, eventType, handler, source=None, id=wx.ID_ANY, id2=wx.ID_ANY):
         """Forward UI events to inner _EmbeddedDateCtrl.
 
@@ -3215,353 +2644,14 @@ class DateCtrl4(wx.ComboCtrl):
     def SetFocus(self):
         self._dateCtrl.SetFocus()
 
+class DateTimeCombo(wx.EvtHandler):
+    """Composite date/time control with checkbox, DateCtrl, and TimeCtrl.
 
-class DateTimeCombo:
-    """Flexible date/time combo providing separate widgets for table layout.
+    Inherits wx.EvtHandler so it can host event handlers directly.
+    DTC owns the change event — fires EVT_VALUE_CHANGED on sub-control
+    blur and from ActivateValue()/DeactivateValue(). Sub-control
+    EVT_VALUE_CHANGED events are trapped and dropped.
 
-    Creates a checkbox, DateCtrl, and TimeCtrl that are linked together.
-    The checkbox state is determined by the value:
-    - value=None → checkbox unchecked, fields disabled
-    - value=datetime → checkbox checked, fields show that datetime
-
-    Three states:
-    1. Checked (normal): checkbox ON, fields enabled and editable
-    2. Unchecked: checkbox OFF, fields disabled, GetDateTime() returns None
-    3. Inactive (SetEditable(False)): checkbox ON but disabled, fields show
-       values greyed out (read-only), not editable
-
-    When user checks an unchecked control, "now" is used as the initial value.
-
-    For flexible table layouts, get individual widgets with:
-    - GetCheckBox() - wx.CheckBox (no label - add label separately)
-    - GetDateCtrl() - DateCtrl
-    - GetTimeCtrl() - TimeCtrl or TimeWithSecondsCtrl
-
-    Or use GetWidgets() to get all three as a tuple.
-
-    Example usage in a table layout:
-        combo = DateTimeCombo(panel, value=datetime.datetime.now())  # checked
-        combo = DateTimeCombo(panel, value=None)  # unchecked
-        grid.Add(wx.StaticText(panel, label="Due date"))  # Column 1: label
-        grid.Add(combo.GetCheckBox())  # Column 2: checkbox only
-        grid.Add(combo.GetDateCtrl())  # Column 3: date
-        grid.Add(combo.GetTimeCtrl())  # Column 4: time
-
-    Args:
-        parent: Parent window for the widgets
-        value: datetime.datetime object, or None for unchecked state.
-               None means checkbox is unchecked; datetime means checked.
-        hourChoices, minuteChoices: Dropdown choices for time fields (None = no dropdown)
-        showSeconds: If True, use TimeWithSecondsCtrl instead of TimeCtrl (default False)
-        secondChoices: Dropdown choices for seconds field (only used if showSeconds=True)
-    """
-
-    def __init__(self, parent, value=None,
-                 hourChoices=None, minuteChoices=None,
-                 showSeconds=False, secondChoices=None):
-        self._parent = parent
-        self._showSeconds = showSeconds
-
-        # Checkbox state determined by whether value is None
-        checked = value is not None
-
-        # For display purposes, use "now" when unchecked (shown when user checks it)
-        display_value = value if value is not None else datetime.datetime.now()
-
-        # Create checkbox (no label - label is added separately by caller)
-        self._checkbox = wx.CheckBox(parent)
-        self._checkbox.SetValue(checked)
-        self._checkbox.Bind(wx.EVT_CHECKBOX, self._onCheckboxChanged)
-
-        # Create date control with values
-        self._dateCtrl = DateCtrl(parent, year=display_value.year,
-                                  month=display_value.month, day=display_value.day)
-
-        # Create time control with values
-        if showSeconds:
-            self._timeCtrl = TimeWithSecondsCtrl(
-                parent, hours=display_value.hour, minutes=display_value.minute,
-                seconds=display_value.second,
-                hourChoices=hourChoices, minuteChoices=minuteChoices, secondChoices=secondChoices
-            )
-        else:
-            self._timeCtrl = TimeCtrl(
-                parent, hours=display_value.hour, minutes=display_value.minute,
-                hourChoices=hourChoices, minuteChoices=minuteChoices
-            )
-
-        # Set initial enabled state based on checkbox
-        self._updateEnabled()
-
-    def _onCheckboxChanged(self, event):
-        """Handle checkbox state change."""
-        self._updateEnabled()
-        # Fire value changed event from date control (checkbox affects whether value is set)
-        wx.PostEvent(self._dateCtrl, ValueChangedEvent(self._dateCtrl))
-        event.Skip()
-
-    def _updateEnabled(self):
-        """Update enabled state of date/time controls based on checkbox.
-
-        When unchecked, fields show "N/A" but values are preserved internally.
-        When re-checked, previous values reappear.
-        """
-        enabled = self._checkbox.GetValue()
-        self._dateCtrl.Enable(enabled)
-        self._timeCtrl.Enable(enabled)
-        # Values are NOT reset - they are preserved internally
-
-    # Widget accessors for flexible layout
-    def GetCheckBox(self):
-        """Get the checkbox widget for layout."""
-        return self._checkbox
-
-    def GetDateCtrl(self):
-        """Get the date control widget for layout."""
-        return self._dateCtrl
-
-    def GetTimeCtrl(self):
-        """Get the time control widget for layout."""
-        return self._timeCtrl
-
-    def GetWidgets(self):
-        """Get all widgets as a tuple: (checkbox, dateCtrl, timeCtrl)."""
-        return (self._checkbox, self._dateCtrl, self._timeCtrl)
-
-    def CreateRowPanel(self, parent=None):
-        """Create a panel containing checkbox + date + time in a horizontal row.
-
-        This simplifies grid layouts by putting all datetime widgets in one cell.
-        Widgets are reparented to the new panel.
-
-        Args:
-            parent: Parent window for the panel. If None, uses the original parent.
-
-        Returns:
-            wx.Panel containing the three widgets arranged horizontally.
-        """
-        if parent is None:
-            parent = self._parent
-
-        panel = wx.Panel(parent)
-        sizer = wx.BoxSizer(wx.HORIZONTAL)
-
-        # Reparent widgets to the panel
-        self._checkbox.Reparent(panel)
-        self._dateCtrl.Reparent(panel)
-        self._timeCtrl.Reparent(panel)
-
-        # Arrange: checkbox | date | time
-        sizer.Add(self._checkbox, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
-        sizer.Add(self._dateCtrl, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
-        sizer.Add(self._timeCtrl, 0, wx.ALIGN_CENTER_VERTICAL)
-
-        panel.SetSizer(sizer)
-        return panel
-
-    def ContainsControl(self, ctrl):
-        """Return True if ctrl is one of our child controls (checkbox, dateCtrl, timeCtrl)."""
-        return ctrl in (self._checkbox, self._dateCtrl, self._timeCtrl)
-
-    def HasOpenPopup(self):
-        """Return True if any child control has an open popup (calendar or dropdown).
-
-        Used by inline editors to prevent closing while user interacts with popups.
-        """
-        # Check dateCtrl for calendar popup
-        if hasattr(self._dateCtrl, '_calendarPopup') and self._dateCtrl._calendarPopup is not None:
-            return True
-        # Check dateCtrl for field dropdown
-        if hasattr(self._dateCtrl, '_popup') and self._dateCtrl._popup is not None:
-            return True
-        # Check timeCtrl for field dropdown
-        if hasattr(self._timeCtrl, '_popup') and self._timeCtrl._popup is not None:
-            return True
-        return False
-
-    def Bind(self, eventType, handler, source=None, id=wx.ID_ANY, id2=wx.ID_ANY):
-        """Bind event handler to child controls.
-
-        For EVT_VALUE_CHANGED, binds to both dateCtrl and timeCtrl,
-        wrapping the handler so event.GetEventObject() returns this DateTimeCombo.
-        """
-        if eventType == EVT_VALUE_CHANGED:
-            # Wrap handler to set event object to this DateTimeCombo
-            combo = self  # Capture self for closure
-            def wrappedHandler(event):
-                event.SetEventObject(combo)
-                handler(event)
-            self._dateCtrl.Bind(eventType, wrappedHandler)
-            self._timeCtrl.Bind(eventType, wrappedHandler)
-        else:
-            # For other events, bind to all child controls
-            self._checkbox.Bind(eventType, handler, source, id, id2)
-            self._dateCtrl.Bind(eventType, handler, source, id, id2)
-            self._timeCtrl.Bind(eventType, handler, source, id, id2)
-
-    # Value accessors
-    def IsChecked(self):
-        """Return whether the checkbox is checked."""
-        return self._checkbox.GetValue()
-
-    def SetChecked(self, checked):
-        """Set the checkbox state and update enabled state."""
-        self._checkbox.SetValue(checked)
-        self._updateEnabled()
-
-    def GetDateTime(self):
-        """Get combined datetime value, or None if unchecked."""
-        if not self._checkbox.GetValue():
-            return None
-        d = self._dateCtrl.GetDate()
-        t = self._timeCtrl.GetTime()
-        return datetime.datetime.combine(d, t)
-
-    def SetDateTime(self, dt):
-        """Set datetime value. If None, unchecks the checkbox."""
-        if dt is None:
-            self._checkbox.SetValue(False)
-            self._updateEnabled()
-        else:
-            self._checkbox.SetValue(True)
-            self._dateCtrl.SetDate(dt.date())
-            self._timeCtrl.SetTime(dt.time())
-            self._updateEnabled()
-
-    # Domain-compatible GetValue/SetValue for AttributeSync
-    def GetValue(self):
-        """Get value as domain date.DateTime for AttributeSync compatibility.
-
-        Returns date.DateTime() (sentinel) when unchecked, or
-        date.DateTime.fromDateTime(dt) when checked.
-        This matches datectrl.py:156-171 behavior.
-        """
-        if not self._checkbox.GetValue():
-            return date.DateTime()  # Sentinel for "no value"
-        d = self._dateCtrl.GetDate()
-        t = self._timeCtrl.GetTime()
-        dt = datetime.datetime.combine(d, t)
-        return date.DateTime.fromDateTime(dt)
-
-    def SetValue(self, newValue):
-        """Set value from domain date.DateTime for AttributeSync compatibility.
-
-        If newValue is None or date.DateTime() (sentinel), unchecks the checkbox.
-        Otherwise sets the value and checks the checkbox.
-        This matches datectrl.py:173-177 behavior.
-
-        Note: Domain sends None for reminder (special case in setReminder),
-        while other date fields send date.DateTime() sentinel.
-        """
-        if newValue is None or newValue == date.DateTime():
-            # No value: None (reminder) or date.DateTime() sentinel (other dates)
-            self._checkbox.SetValue(False)
-            self._updateEnabled()
-        else:
-            self._checkbox.SetValue(True)
-            self._dateCtrl.SetDate(newValue.date())
-            self._timeCtrl.SetTime(datetime.time(newValue.hour, newValue.minute, newValue.second))
-            self._updateEnabled()
-
-    def GetDate(self):
-        """Get just the date value."""
-        return self._dateCtrl.GetDate()
-
-    def SetDate(self, d):
-        """Set just the date value."""
-        self._dateCtrl.SetDate(d)
-
-    def GetTime(self):
-        """Get just the time value."""
-        return self._timeCtrl.GetTime()
-
-    def SetTime(self, t):
-        """Set just the time value."""
-        self._timeCtrl.SetTime(t)
-
-    # Enable/disable all widgets
-    def Enable(self, enable=True):
-        """Enable or disable all widgets.
-
-        When disabled, all three widgets (checkbox, date, time) are greyed out.
-        When enabled, checkbox becomes active and date/time depend on checkbox state.
-        """
-        self._checkbox.Enable(enable)
-        if enable:
-            # Restore normal state: date/time depend on checkbox
-            self._updateEnabled()
-        else:
-            # Force disable date/time regardless of checkbox
-            self._dateCtrl.Enable(False)
-            self._timeCtrl.Enable(False)
-
-    def Disable(self):
-        """Disable all widgets."""
-        self.Enable(False)
-
-    def IsEnabled(self):
-        """Return whether the combo is enabled."""
-        return self._checkbox.IsEnabled()
-
-    def GetChildren(self):
-        """Return child widgets for AttributeSync focus binding."""
-        return [self._checkbox, self._dateCtrl, self._timeCtrl]
-
-    def GetId(self):
-        """Return ID for AttributeSync widget validity check."""
-        return self._checkbox.GetId()
-
-    def SetEditable(self, editable=True):
-        """Set whether the combo is editable (inactive mode).
-
-        When editable=False (inactive):
-        - Checkbox is disabled (shows checked state but not clickable)
-        - Date/time fields show values greyed out (read-only, not "N/A")
-        - Values are preserved and visible
-
-        This is different from Enable(False) which shows "N/A" in the fields.
-        """
-        self._checkbox.Enable(editable)
-        self._dateCtrl.SetReadOnly(not editable)
-        self._timeCtrl.SetReadOnly(not editable)
-
-    def IsEditable(self):
-        """Return whether the combo is editable."""
-        return self._checkbox.IsEnabled() and not self._dateCtrl.IsReadOnly()
-
-    def SetFocus(self):
-        """Set focus to the date control (or checkbox if date is disabled)."""
-        if self._dateCtrl.IsEnabled():
-            self._dateCtrl.SetFocus()
-        else:
-            self._checkbox.SetFocus()
-
-    # Bind events
-    def Bind(self, eventType, handler):
-        """Bind an event handler to the combo's widgets.
-
-        Event routing:
-        - EVT_KILL_FOCUS: all three (for commit-on-focus-loss pattern)
-        - EVT_CHECKBOX: checkbox only
-        - Other events: all three
-        """
-        if eventType == wx.EVT_CHECKBOX:
-            self._checkbox.Bind(eventType, handler)
-        else:
-            # Bind to all three widgets
-            self._checkbox.Bind(eventType, handler)
-            self._dateCtrl.Bind(eventType, handler)
-            self._timeCtrl.Bind(eventType, handler)
-
-
-class DateTimeCombo2:
-    """Date/time combo using DateCtrl4 (ComboCtrl-based date control).
-
-    Clean replacement for DateTimeCombo. Same API and behavior, but uses
-    DateCtrl4 instead of DateCtrl for the date field, giving native dropdown
-    button and Wayland-safe popup positioning.
-
-    Creates a checkbox, DateCtrl4, and TimeCtrl that are linked together.
     The checkbox state is determined by the value:
     - value=None -> checkbox unchecked, fields disabled (show "N/A")
     - value=datetime -> checkbox checked, fields show that datetime
@@ -3574,7 +2664,7 @@ class DateTimeCombo2:
 
     For flexible table layouts, get individual widgets with:
     - GetCheckBox() - wx.CheckBox (no label)
-    - GetDateCtrl() - DateCtrl4
+    - GetDateCtrl() - DateCtrl
     - GetTimeCtrl() - TimeCtrl or TimeWithSecondsCtrl
 
     Args:
@@ -3588,6 +2678,7 @@ class DateTimeCombo2:
     def __init__(self, parent, value=None, suggestedValue=None,
                  hourChoices=None, minuteChoices=None,
                  showSeconds=False, secondChoices=None):
+        wx.EvtHandler.__init__(self)
         self._parent = parent
         self._showSeconds = showSeconds
         self._suggestedValue = suggestedValue
@@ -3599,7 +2690,7 @@ class DateTimeCombo2:
         self._checkbox.SetValue(checked)
         self._checkbox.Bind(wx.EVT_CHECKBOX, self._onCheckboxChanged)
 
-        self._dateCtrl = DateCtrl4(parent, year=display_value.year,
+        self._dateCtrl = DateCtrl(parent, year=display_value.year,
                                    month=display_value.month, day=display_value.day)
 
         if showSeconds:
@@ -3618,13 +2709,46 @@ class DateTimeCombo2:
         self._readOnly = False
         self._updateEnabled()
 
+        # DTC owns the change event. Listen to sub-control blur and fire
+        # DTC's own EVT_VALUE_CHANGED. Sub-control EVT_VALUE_CHANGED events
+        # are trapped and explicitly dropped — DTC must never rely on them.
+        self._dateCtrl.Bind(wx.EVT_KILL_FOCUS, self._onSubControlBlur)
+        self._timeCtrl.Bind(wx.EVT_KILL_FOCUS, self._onSubControlBlur)
+        self._dateCtrl.Bind(EVT_VALUE_CHANGED, self._onSubControlValueChanged)
+        self._timeCtrl.Bind(EVT_VALUE_CHANGED, self._onSubControlValueChanged)
+
+    def _onSubControlBlur(self, event):
+        """Sub-control lost focus — fire DTC's own EVT_VALUE_CHANGED."""
+        self.NotifyValueChanged()
+        event.Skip()
+
+    def _onSubControlValueChanged(self, event):
+        """Trap and explicitly drop sub-control EVT_VALUE_CHANGED.
+
+        DTC is the composite control and owns the change event. It fires
+        EVT_VALUE_CHANGED on sub-control blur and from ActivateValue()/
+        DeactivateValue(). Sub-control change events are an internal
+        implementation detail and must not propagate to external handlers.
+
+        IMPORTANT: This is a debug log point. If this fires, something is
+        writing directly to the sub-controls instead of going through DTC's
+        public API (ActivateValue, DeactivateValue, SetValue). That is a
+        bug — all value changes must go through DTC.
+        """
+        # Do NOT call event.Skip() — intentionally consumed
+
+    def NotifyValueChanged(self):
+        """Fire EVT_VALUE_CHANGED on self (DTC is a wx.EvtHandler)."""
+        event = ValueChangedEvent(self)
+        wx.PostEvent(self, event)
+
     def _onCheckboxChanged(self, event):
         """Handle checkbox state change — route through abstraction."""
-        if self._checkbox.GetValue():
+        checked = self._checkbox.GetValue()
+        if checked:
             self.ActivateValue()
         else:
             self.DeactivateValue()
-        self._dateCtrl._fireValueChanged()
         event.Skip()
 
     def _updateEnabled(self):
@@ -3691,7 +2815,7 @@ class DateTimeCombo2:
 
         panel.SetSizer(sizer)
 
-        # Re-apply enabled state after reparenting. wx.ComboCtrl (DateCtrl4)
+        # Re-apply enabled state after reparenting. wx.ComboCtrl (DateCtrl)
         # loses its native visual state (button greying, background color)
         # when reparented, because the platform re-creates theme state for
         # the new parent hierarchy. FieldsCtrl-based controls don't have
@@ -3705,7 +2829,7 @@ class DateTimeCombo2:
 
     def HasOpenPopup(self):
         """Return True if any child control has an open popup."""
-        # DateCtrl4 provides public HasOpenPopup()
+        # DateCtrl provides public HasOpenPopup()
         if self._dateCtrl.HasOpenPopup():
             return True
         # TimeCtrl uses FieldsCtrl._popup (same module, acceptable)
@@ -3714,19 +2838,19 @@ class DateTimeCombo2:
         return False
 
     def Bind(self, eventType, handler, source=None, id=wx.ID_ANY, id2=wx.ID_ANY):
-        """Bind event handler to child controls.
+        """Bind event handler.
 
         Routing:
-        - EVT_VALUE_CHANGED: date + time, wrapped so event object is this combo
-        - Other events: all three widgets
+        - EVT_VALUE_CHANGED: bind on self (DTC owns the change event via
+          wx.EvtHandler). DTC fires this on sub-control blur and from
+          ActivateValue()/DeactivateValue().
+        - Other events (e.g. EVT_KILL_FOCUS): forwarded to all sub-controls.
 
         Note: EVT_CHECKBOX is NOT exposed — the checkbox is an internal
-        implementation detail. All value changes (checkbox toggle, date edit,
-        time edit) fire EVT_VALUE_CHANGED.
+        implementation detail.
         """
         if eventType == EVT_VALUE_CHANGED:
-            self._dateCtrl.Bind(eventType, handler)
-            self._timeCtrl.Bind(eventType, handler)
+            super().Bind(eventType, handler, source, id, id2)
         else:
             self._checkbox.Bind(eventType, handler, source, id, id2)
             self._dateCtrl.Bind(eventType, handler, source, id, id2)
@@ -3740,65 +2864,41 @@ class DateTimeCombo2:
             self._checkbox.SetValue(checked)
 
     def ActivateValue(self, value=None):
-        """Set the control to have a value (non-null).
+        """Inactive → Active. Checks checkbox, optionally writes sub-controls.
 
         Args:
             value: datetime.datetime to set, or None to keep the internally
-                   stored value (typically now() from construction, or the
-                   last value before DeactivateValue was called).
+                   stored sub-control values (the stash).
 
-        Used by duration calc logic (steps 2.1, 3.1) to activate a missing
-        date without specifying a value. Also used by SetValue() to set a
-        specific datetime and activate in one call.
-
-        On first activation with no explicit value, uses the suggestedValue
-        from preferences (if provided at construction). After first use the
-        suggestedValue is cleared so subsequent activations keep the last
-        user-set value.
+        Contract: always fires EVT_VALUE_CHANGED.
+        See DATETIME_CONTROLS.md, Sub-Control Stash Model.
         """
         if value is not None:
             self._dateCtrl.SetDate(value.date())
             self._timeCtrl.SetTime(value.time())
+            self._suggestedValue = None
         elif self._suggestedValue is not None:
             self._dateCtrl.SetDate(self._suggestedValue.date())
             self._timeCtrl.SetTime(self._suggestedValue.time())
             self._suggestedValue = None
         self._setCheckboxState(True)
         self._updateEnabled()
+        self.NotifyValueChanged()
 
     def DeactivateValue(self):
-        """Set the control to no value (null/cleared).
+        """Active → Inactive. Unchecks checkbox, sub-controls retain values.
 
-        Values are preserved internally — ActivateValue restores the
-        previous value. Used by duration calc logic (steps 2.5.2, 3.5.2)
-        to deactivate a date.
+        The sub-controls are the stash — they hold the datetime while the
+        checkbox is unchecked. Contract: always fires EVT_VALUE_CHANGED.
+        See DATETIME_CONTROLS.md, Sub-Control Stash Model.
         """
         self._setCheckboxState(False)
         self._updateEnabled()
+        self.NotifyValueChanged()
 
     def IsActive(self):
         """Return True if the control has an active value (non-null)."""
         return self._checkbox.GetValue()
-
-    # Deprecated — log warning and delegate to new methods
-    def IsChecked(self):
-        log_step("DEPRECATED: IsChecked() — use IsActive()", prefix="DateTimeCombo2")
-        return self.IsActive()
-
-    def SetChecked(self, checked):
-        log_step("DEPRECATED: SetChecked() — use ActivateValue()/DeactivateValue()", prefix="DateTimeCombo2")
-        if checked:
-            self.ActivateValue()
-        else:
-            self.DeactivateValue()
-
-    def Activate(self):
-        log_step("DEPRECATED: Activate() — use ActivateValue()", prefix="DateTimeCombo2")
-        self.ActivateValue()
-
-    def Deactivate(self):
-        log_step("DEPRECATED: Deactivate() — use DeactivateValue()", prefix="DateTimeCombo2")
-        self.DeactivateValue()
 
     def GetDateTime(self):
         if not self._checkbox.GetValue():
@@ -3806,14 +2906,6 @@ class DateTimeCombo2:
         d = self._dateCtrl.GetDate()
         t = self._timeCtrl.GetTime()
         return datetime.datetime.combine(d, t)
-
-    def SetDateTime(self, dt):
-        log_step(
-            "DEPRECATED: SetDateTime() should not be called. "
-            "Use ActivateValue(datetime) to set a value, or "
-            "DeactivateValue() to clear it.",
-            prefix="DateTimeCombo2"
-        )
 
     # Domain-compatible GetValue/SetValue for AttributeSync
     def GetValue(self):
@@ -3835,22 +2927,8 @@ class DateTimeCombo2:
     def GetDate(self):
         return self._dateCtrl.GetDate()
 
-    def SetDate(self, d):
-        log_step(
-            "DEPRECATED: SetDate() should not be called. "
-            "Use ActivateValue(datetime) to set a value.",
-            prefix="DateTimeCombo2"
-        )
-
     def GetTime(self):
         return self._timeCtrl.GetTime()
-
-    def SetTime(self, t):
-        log_step(
-            "DEPRECATED: SetTime() should not be called. "
-            "Use ActivateValue(datetime) to set a value.",
-            prefix="DateTimeCombo2"
-        )
 
     def GetChildren(self):
         return [self._checkbox, self._dateCtrl, self._timeCtrl]


### PR DESCRIPTION
Restructure how duration and datetime controls fire events and sync with the domain model. Controls now own their change events and fire only on blur (user edit) or programmatic complete-value write, making every EVT_VALUE_CHANGED a final value suitable for immediate commit. This eliminates the commit_on_focus_loss mechanism entirely.

Event model:
- FieldsCtrl: NumericField.SetValue() no longer fires events; FieldsCtrl fires EVT_VALUE_CHANGED on blur and from SetDuration()/SetTime()/SetDate()
- DateTimeCombo: inherits wx.EvtHandler, owns EVT_VALUE_CHANGED, fires on sub-control blur and state transitions (ActivateValue/DeactivateValue), traps and drops sub-control EVT_VALUE_CHANGED
- All AttributeSync sites use EVT_VALUE_CHANGED with immediate commit

AttributeSync simplification:
- Remove commit_on_focus_loss parameter and all session tracking (editSessionValue, hasChanges, focus event binding, commit() method)
- Remove skip_callback parameter from __executeCommand
- Remove debug trace logging (keep ERROR/WARNING logs)

Editor consolidation:
- Inline 7 task calc helpers into __syncTaskState using widget API (ActivateValue/DeactivateValue/SetDuration) instead of direct commands
- Cached reads at top of __syncTaskState, __syncEffortState, and __updateFieldStates — no step depends on values changed by a prior step
- Replace __stopDateExists() with direct None check on cached read
- Preset handlers route through SetDuration() on control
- Duration mode preset pubsub subscription for external domain changes

Dead code removal:
- Delete old DateTimeCombo v1 (~337 lines), _CalendarPopup (~344 lines), old DateCtrl (~223 lines)
- Delete dead addDateEntry method (used removed entry.DateTimeEntry)
- Delete 7 deprecated DateTimeCombo shims (IsChecked, SetChecked, Activate, Deactivate, SetDateTime, SetDate, SetTime)
- Remove stale _CalendarPopup references and Wayland patch
- Remove debug trace log_step calls from DateTimeCombo and editor

Renames: DateCtrl4 → DateCtrl, DateTimeCombo2 → DateTimeCombo
Version: 2.0.1.59 → 2.0.1.60