### PR TITLE
Refactor monetary controls: NumericCtrl base, live preferences.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.60-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.60-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.60_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.60_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.60_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.60-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.61-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.61-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.61_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.61_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.61_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.61-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.60-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.60-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.60_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.60_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.60-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.60-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.61-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.61-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.61_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.61_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.61-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.61-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.60_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.60_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.61_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.61_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.60-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.60-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.61-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.61-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.60-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.60-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.61-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.61-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.60-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.60-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.61-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.61-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.60-x86_64.AppImage
+./TaskCoach-2.0.1.61-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/docs/ATTRIBUTE_PATTERN.md
+++ b/docs/ATTRIBUTE_PATTERN.md
@@ -255,3 +255,9 @@ must pass `source_field` so the sync logic knows which field changed
 (DURATION_CALCULATIONS.md section 0.1) and skips steps that would
 overwrite the user's change.
 
+See also: [LOCALE.md](LOCALE.md) for how locale settings interact with
+Layer 2 controls (decimal separator, date/time format detection).
+[NUMERIC_CONTROLS.md](NUMERIC_CONTROLS.md) and
+[MONETARY_CONTROLS.md](MONETARY_CONTROLS.md) for `EVT_VALUE_CHANGED`
+migration of monetary controls (TODO #1).
+

--- a/docs/DATETIME_CONTROLS.md
+++ b/docs/DATETIME_CONTROLS.md
@@ -569,6 +569,9 @@ The settings are stored in `TaskCoach.ini` under `[view]` as `dateformat` and `t
 - `getEffectiveTimeFormat()` - Returns "24" or "12" respecting user settings (defaults to "24" when automatic)
 - `getDateFormatFromSettings()` - Raw setting value
 
+See [LOCALE.md](LOCALE.md) for the common three-layer locale access pattern
+used across all regional settings (date, time, decimal separator, currency).
+
 ## Events
 
 Use standard wx events for sync:

--- a/docs/LOCALE.md
+++ b/docs/LOCALE.md
@@ -1,0 +1,158 @@
+# Locale Handling
+
+Unified reference for all locale and regional settings in the application.
+
+## Index
+
+- [Three-Layer Pattern](#three-layer-pattern)
+- [Settings Keys](#settings-keys)
+- [Detection Mechanisms](#detection-mechanisms)
+- [Data vs Display](#data-vs-display)
+- [Restart Requirement](#restart-requirement)
+- [Locale Initialization](#locale-initialization)
+- [Cross-References](#cross-references)
+
+---
+
+## Three-Layer Pattern
+
+All locale concerns follow the same three-layer access pattern:
+
+1. **Detection function** — pure locale detection, no settings involved.
+   Returns what the system locale provides.
+2. **Settings function** — reads the user preference only. Returns empty
+   string if automatic (no override).
+3. **Effective function** — combines both: setting → detection → default.
+   This is what controls and renderers call.
+
+Example (date format):
+```
+getDetectedLocaleDateFormat()     # Layer 1: strftime("%x") probe
+getDateFormatFromSettings()       # Layer 2: settings.Settings().get("view", "dateformat")
+getEffectiveDateFormat()          # Layer 3: setting → detection → ISO default
+```
+
+Example (decimal separator):
+```
+_get_locale_decimal_char()        # Layer 1: locale.localeconv()["decimal_point"]
+_get_configured_decimal_char()    # Layer 3: setting → locale → "."
+```
+
+---
+
+## Settings Keys
+
+| Setting key | Section | Values | Detection method | Default | File |
+|---|---|---|---|---|---|
+| `language_set_by_user` | `view` | locale code / `""` | env vars + `locale.getlocale` | `"en_US"` | `application.py` |
+| `dateformat` | `view` | `"YMD-"`, `"MDY/"`, `"DMY/"`, `"DMY."`, `"YMD/"`, `""` | `strftime("%x")` probe | ISO `YYYY-MM-DD` | `maskedtimectrl.py` |
+| `timeformat` | `view` | `"24"`, `"12"`, `""` | `strftime("%X")` AM/PM check | `"24"` | `maskedtimectrl.py` |
+| `decimal_separator` | `view` | `"."`, `","`, `""` | `locale.localeconv()["decimal_point"]` | `"."` | `numericctrl.py` |
+| `currency_decimal_places` | `view` | `"0"`, `"2"`, `"3"`, `""` | `locale.localeconv()["frac_digits"]` | `2` | `currencyctrl.py` |
+
+All defaults defined in `taskcoachlib/config/defaults.py`, `view` section.
+
+---
+
+## Detection Mechanisms
+
+### strftime probing (date/time)
+
+Formats a test date/time with locale-aware `strftime` directives and parses
+the output to detect field order, separator, and 12/24h mode.
+
+- **Date:** `datetime.date(3333, 11, 22).strftime("%x")` — searches for
+  positions of year/month/day in output to determine field order and separator.
+- **Time:** `datetime.time(14, 30).strftime("%X")` — checks for AM/PM
+  indicators via `strftime("%p")`.
+- **File:** `taskcoachlib/widgets/maskedtimectrl.py`
+
+### locale.localeconv() dict (numeric/currency)
+
+Returns a dict with numeric formatting conventions. Key fields:
+
+| Field | Meaning | Example (en_US) | Example (de_DE) | Sentinel |
+|---|---|---|---|---|
+| `decimal_point` | Decimal separator | `"."` | `","` | `""` → fallback to `"."` |
+| `frac_digits` | Currency decimal places | `2` | `2` | `127` (CHAR_MAX) → fallback to `2` |
+| `thousands_sep` | Thousands separator | `","` | `"."` | Can be empty or non-ASCII |
+| `grouping` | Grouping pattern | `[3, 3, 0]` | `[3, 3, 0]` | — |
+
+- **Files:** `numericctrl.py`, `currencyctrl.py`, `masked.py`
+
+### Environment variables + locale.getlocale() (language)
+
+Cascading checks for language selection:
+
+1. Command-line options (`--language`, `--pofile`)
+2. User preference (`view/language_set_by_user`)
+3. External setting (`view/language`)
+4. `LANG` environment variable (strip `.UTF-8` suffix)
+5. `LC_ALL` environment variable
+6. `locale.getlocale(locale.LC_MESSAGES)`
+7. Final fallback: `"en_US"`
+
+- **Files:** `application.py`, `i18n/__init__.py`
+
+---
+
+## Data vs Display
+
+**Locale is UI-only.** Domain and persistence always use Python defaults:
+
+- **Numeric:** Python `float` with period decimal. `str(25.5)` → `"25.5"`.
+- **Date/time:** Python `datetime` objects. XML uses ISO-like format.
+- **The control is the locale boundary.** `NumericCtrl.GetValue()` returns
+  Python float (period). `NumericCtrl.SetValue(float)` displays with locale
+  decimal. Same for `DateCtrl`, `TimeCtrl`.
+
+Data flow example (German locale, comma decimal):
+```
+User types "25,50"
+  → CurrencyCtrl displays "25,50" (locale)
+  → CurrencyCtrl.GetValue() → 25.5 (Python float, period)
+    → AttributeSync → domain → task.setHourlyFee(25.5)
+      → XML writer: str(25.5) → "25.5" (period, always)
+```
+
+---
+
+## Restart Requirement
+
+Format changes (date, time, decimal separator, currency decimal places)
+require a restart because:
+
+- `render.py` compiles format strings once at module load time
+- Controls are created with the effective format at construction time
+- Changing the format setting does not retroactively update existing controls
+
+The Regional preferences page shows a restart warning when any format setting
+is changed from its original value.
+
+---
+
+## Locale Initialization
+
+At startup, `Application.__init_language()` calls `i18n.Translator(language)`
+which:
+
+1. Calls `locale.setlocale(locale.LC_ALL, ...)` with the resolved locale
+2. Creates a `wx.Locale` instance for wxWidgets
+3. Loads the gettext translation catalog
+4. Works around broken locales (e.g. Norwegian `nb_NO` vs `no_NO`)
+
+After this, `locale.localeconv()` returns the correct values for the active
+locale, and `strftime` uses the locale's date/time formatting.
+
+---
+
+## Cross-References
+
+- **Date/time controls:** [DATETIME_CONTROLS.md](DATETIME_CONTROLS.md) —
+  `DateCtrl`, `TimeCtrl`, `DateTimeCombo`, locale detection via strftime
+- **Numeric controls:** [NUMERIC_CONTROLS.md](NUMERIC_CONTROLS.md) —
+  `NumericCtrl`, blur validation, decimal separator handling
+- **Monetary controls:** [MONETARY_CONTROLS.md](MONETARY_CONTROLS.md) —
+  `CurrencyCtrl`, currency decimal places from locale
+- **Attribute sync:** [ATTRIBUTE_PATTERN.md](ATTRIBUTE_PATTERN.md) —
+  Layer 2 (UI↔Domain sync), `EVT_VALUE_CHANGED` pattern

--- a/docs/MONETARY_CONTROLS.md
+++ b/docs/MONETARY_CONTROLS.md
@@ -1,95 +1,81 @@
 # Monetary Controls
 
-This document describes the monetary (currency/amount) input controls used in Task Coach, the legacy control's known issues, and the replacement.
+Currency input controls used in Task Coach.
 
-## Table of Contents
+## Index
 
-- [Background](#background)
-- [Current Control — AmountCtrl (masked.NumCtrl)](#current-control--amountctrl-maskednumctrl)
-  - [Architecture](#architecture)
-  - [Known Bugs in wxPython Phoenix](#known-bugs-in-wxpython-phoenix)
-- [Replacement — CurrencyCtrl](#replacement--currencyctrl)
-  - [Design](#design)
-  - [Locale Handling](#locale-handling)
-  - [Future Considerations](#future-considerations)
+- [Overview](#overview)
+- [Legacy Controls](#legacy-controls)
+- [CurrencyCtrl(NumericCtrl)](#currencytrlnumericctrl)
+  - [Currency Decimal Places](#currency-decimal-places)
+  - [EVT_VALUE_CHANGED](#evt_value_changed)
 - [Usage Sites](#usage-sites)
 - [Files](#files)
+- [Cross-References](#cross-references)
 
-## Background
+---
 
-Task Coach uses monetary amount fields in the Budget tab of the task editor for hourly fee, fixed fee, and revenue. These fields require locale-aware decimal input with two decimal places.
+## Overview
 
-wxPython does not provide a built-in currency input control. The C++ `wxFloatingPointValidator` is intentionally excluded from the Python binding. The wxPython community has long noted this gap — a [wxPython forum discussion on money controls](https://discuss.wxpython.org/t/money-control/24654) confirms that developers typically build custom solutions.
+Task Coach uses monetary amount fields in the Budget tab of the task editor
+for hourly fee, fixed fee, and revenue. These fields require locale-aware
+decimal input with configurable decimal places.
 
-## Current Control — AmountCtrl (masked.NumCtrl)
+wxPython does not provide a built-in currency input control. The C++
+`wxFloatingPointValidator` is intentionally excluded from the Python binding.
 
-### Architecture
+---
 
-`AmountCtrl` (`taskcoachlib/widgets/masked.py`) is a thin wrapper around `wx.lib.masked.NumCtrl`, a **standard wxPython widget** — it is not custom to Task Coach. The wrapper configures locale-aware parameters:
+## Legacy Controls
+
+Two previous implementations were abandoned:
+
+1. **`AmountCtrl`** (`masked.py`) — wrapped `wx.lib.masked.NumCtrl`. Crashed
+   during normal typing due to unfixed Phoenix bugs (#2587, #1179). Unusable.
+2. **`CurrencyCtrl` + `CurrencyValidator`** — `wx.TextCtrl` with per-keystroke
+   `wx.Validator` filtering. Period keystrokes were silently blocked or
+   corrupted input on GTK. Paste bypassed validation entirely. Not fit for
+   purpose.
+
+Both are replaced by the current `CurrencyCtrl(NumericCtrl)`.
+
+---
+
+## CurrencyCtrl(NumericCtrl)
+
+`CurrencyCtrl` is a thin subclass of `NumericCtrl` that adds currency-specific
+decimal places from the locale. See [NUMERIC_CONTROLS.md](NUMERIC_CONTROLS.md)
+for the base class design: free typing, blur-time validation, locale decimal
+handling, `EVT_VALUE_CHANGED` pattern, domain-based revert.
 
 ```python
-class AmountCtrl(FixOverwriteSelectionMixin, masked.NumCtrl):
-    def __init__(self, parent, value=0, locale_conventions=None):
-        locale_conventions = locale_conventions or locale.localeconv()
-        # ... extracts decimalChar, groupChar from locale ...
-        super().__init__(
-            parent, value=value,
-            allowNegative=False, fractionWidth=2,
-            selectOnEntry=True,
-            decimalChar=decimalChar, groupChar=groupChar,
-            groupDigits=groupDigits,
-        )
+class CurrencyCtrl(NumericCtrl):
+    def __init__(self, parent, value=0.0, decimal_char=None, **kwargs):
+        decimal_places = _get_configured_currency_decimal_places()
+        super().__init__(parent, value=value, decimal_places=decimal_places,
+                         decimal_char=decimal_char, **kwargs)
 ```
 
-`AmountEntry` (`taskcoachlib/gui/dialog/entry.py`) wraps `AmountCtrl` in a `PanelWithBoxSizer`, adding read-only support (disable + grey background) and `NavigateBook()` for notebook tab traversal.
+### Currency Decimal Places
 
-### Known Bugs in wxPython Phoenix
+Fallback chain: configured pref → `locale.localeconv()["frac_digits"]` → `2`
 
-`wx.lib.masked.NumCtrl` has **open, unfixed bugs** in wxPython Phoenix that cause crashes during normal typing. These are fundamental event-handling bugs in the masked edit framework, not Task Coach configuration problems.
+| Source | Value | Example |
+|---|---|---|
+| Preferences override | User setting | `view/currency_decimal_places` |
+| `locale.localeconv()["frac_digits"]` | Locale default | 2 (USD/EUR), 0 (JPY), 3 (BHD) |
+| `frac_digits == 127` (CHAR_MAX) | Sentinel | Falls back to 2 |
 
-**Issue [#2587](https://github.com/wxWidgets/Phoenix/issues/2587)** (open, reported Dec 2024, wxPython 4.2.1+):
+Configurable in Preferences → Regional → "Currency decimal places".
 
-Three distinct crashes:
-1. **`_adjustFloat` ValueError** — Deleting the initial value then typing triggers `ValueError: not enough values to unpack` when `_adjustFloat` splits on the decimal character. The value string no longer contains the expected decimal point.
-2. **`_insertKey` IndexError** — Deletion and re-entry triggers `IndexError: string index out of range` in the character validation logic.
-3. **Fatal crash on macOS** — Moving cursor then typing a decimal point causes `NSTextRange` assertion failure and `PyGILState_Release: thread state must be current when releasing` — a fatal Python crash.
+### EVT_VALUE_CHANGED
 
-**Issue [#1179](https://github.com/wxWidgets/Phoenix/issues/1179)** (open, wxPython 4.0.4+):
+`AttributeSync` in `BudgetPage` binds `EVT_VALUE_CHANGED` instead of
+`EVT_KILL_FOCUS` for hourly fee and fixed fee. This completes
+ATTRIBUTE_PATTERN.md TODO #1 for monetary controls, matching the pattern
+already used by `DurationCtrl` and `DateTimeCombo`.
 
-- **Select-and-type IndexError** — Selecting multiple characters with mouse and pressing a number key causes `IndexError: string index out of range`.
-- **Root cause**: Phoenix changed event ordering between `EVT_KEY_DOWN` and `EVT_CHAR`. After `_OnKeyDown`, the TextCtrl contents are already changed, but `_OnChar` still expects the original unmodified value. This event ordering worked correctly in Classic wxPython but broke in Phoenix.
-- A tentative workaround (overriding `_OnKeyDown` to call `_OnChar` directly) was suggested but never officially implemented.
-
-**No fix has been merged** for either issue as of January 2026.
-
-## Replacement — CurrencyCtrl
-
-### Design
-
-`CurrencyCtrl` (`taskcoachlib/widgets/currencyctrl.py`) replaces `AmountCtrl` using `wx.TextCtrl` + custom `wx.Validator`. This is the approach recommended by the wxPython community (including the reporter of issue #2587) as the standard pattern for currency input.
-
-Implementation:
-- `wx.TextCtrl` with `wx.TE_RIGHT` (right-aligned, standard for monetary amounts)
-- `CurrencyValidator` (`wx.Validator` subclass): filters keystrokes to digits, single decimal point, and navigation keys
-- On focus-loss: auto-formats to 2 decimal places (e.g., `5` becomes `5.00`)
-- `GetValue()` returns `float`, `SetValue(float)` sets formatted text
-- Read-only support handled by `AmountEntry` wrapper (disable + grey background)
-- Locale-aware decimal point from `locale.localeconv()`
-
-`AmountEntry` (`taskcoachlib/gui/dialog/entry.py`) wraps `CurrencyCtrl` in a `PanelWithBoxSizer`, providing read-only support and `NavigateBook()` for notebook tab traversal. `AttributeSync` uses `wx.EVT_KILL_FOCUS` to trigger persistence, which aligns with the focus-loss formatting.
-
-### Locale Handling
-
-Locale handling (preserved from the legacy control):
-- **Decimal point**: `locale.localeconv()["decimal_point"]` (e.g., `.` in en_US, `,` in de_DE)
-- **Formatting**: `"%.2f" % value` with locale decimal char substitution
-
-### Future Considerations
-
-- **Currency symbols**: Currently not displayed in controls (the label provides context). Could add optional prefix/suffix rendering.
-- **Negative amounts**: Currently `allowNegative=False`. Could be added if budget scenarios require it.
-- **Thousands grouping during input**: Current control groups digits; the TextCtrl replacement could add this on focus-loss formatting.
-- **Alternative: `wx.SpinCtrlDouble`**: A native wxPython widget that enforces numeric input with configurable decimal places. However, the spinner UI (up/down arrows) is inappropriate for dollar amount fields.
+---
 
 ## Usage Sites
 
@@ -99,11 +85,25 @@ Locale handling (preserved from the legacy control):
 | `taskcoachlib/gui/dialog/editor.py` | `AmountEntry` → `CurrencyCtrl` | Fixed fee | Yes |
 | `taskcoachlib/gui/dialog/editor.py` | `AmountEntry` → `CurrencyCtrl` | Revenue | No (read-only) |
 
+---
+
 ## Files
 
 | File | Purpose |
 |------|---------|
-| `taskcoachlib/widgets/currencyctrl.py` | `CurrencyCtrl` + `CurrencyValidator` (replacement) |
-| `taskcoachlib/widgets/masked.py` | Legacy `AmountCtrl` (wraps `wx.lib.masked.NumCtrl`) — no longer used by AmountEntry |
-| `taskcoachlib/gui/dialog/entry.py` | `AmountEntry` (wraps `CurrencyCtrl` in panel) |
+| `taskcoachlib/widgets/numericctrl.py` | `NumericCtrl` base class |
+| `taskcoachlib/widgets/currencyctrl.py` | `CurrencyCtrl(NumericCtrl)` subclass |
+| `taskcoachlib/gui/dialog/entry.py` | `AmountEntry` wrapper (panel + read-only support) |
 | `taskcoachlib/gui/dialog/editor.py` | Budget tab uses `AmountEntry` for fee/revenue fields |
+| `taskcoachlib/widgets/masked.py` | Legacy `AmountCtrl` — no longer used |
+
+---
+
+## Cross-References
+
+- **Numeric controls:** [NUMERIC_CONTROLS.md](NUMERIC_CONTROLS.md) —
+  `NumericCtrl` base class, blur validation, UX rationale
+- **Locale handling:** [LOCALE.md](LOCALE.md) — three-layer pattern, settings
+  keys, detection mechanisms, data vs display
+- **Attribute sync:** [ATTRIBUTE_PATTERN.md](ATTRIBUTE_PATTERN.md) — Layer 2
+  (UI↔Domain), `EVT_VALUE_CHANGED` migration

--- a/docs/NUMERIC_CONTROLS.md
+++ b/docs/NUMERIC_CONTROLS.md
@@ -1,0 +1,185 @@
+# Numeric Controls
+
+`NumericCtrl` — general-purpose numeric input with free typing and blur-time
+validation.
+
+## Index
+
+- [Overview](#overview)
+- [Class Hierarchy](#class-hierarchy)
+- [NumericCtrl API](#numericctrl-api)
+- [Blur-Time Validation](#blur-time-validation)
+- [EVT_VALUE_CHANGED Pattern](#evt_value_changed-pattern)
+- [Locale Decimal Handling](#locale-decimal-handling)
+- [Preferences](#preferences)
+- [UX Rationale](#ux-rationale)
+- [Cross-References](#cross-references)
+
+---
+
+## Overview
+
+`NumericCtrl` is a `wx.TextCtrl` subclass that:
+
+- Allows **free typing** — no keystroke blocking, no validator
+- **Validates on blur** — parses text as float, formats if valid, reverts to
+  domain value if invalid
+- Fires **`EVT_VALUE_CHANGED`** on blur (valid input) and from `SetValue()`
+  (programmatic writes)
+- Handles **locale decimal** — displays with locale separator, returns Python
+  float with period decimal internally
+
+**File:** `taskcoachlib/widgets/numericctrl.py`
+
+---
+
+## Class Hierarchy
+
+```
+numericctrl.py:
+  NumericCtrl(wx.TextCtrl)
+      decimal_places=None  → floating: "12.3" stays "12.3"
+      decimal_places=2     → fixed: "12.3" becomes "12.30"
+
+currencyctrl.py:
+  CurrencyCtrl(NumericCtrl)
+      decimal_places = locale frac_digits (default 2)
+```
+
+See [MONETARY_CONTROLS.md](MONETARY_CONTROLS.md) for `CurrencyCtrl` details.
+
+---
+
+## NumericCtrl API
+
+### Constructor
+
+```python
+NumericCtrl(parent, value=0.0, decimal_places=None, decimal_char=None, **kwargs)
+```
+
+- `value` — initial float value
+- `decimal_places` — `None` = floating (strip trailing zeros), `int` = fixed
+  (always format to N places)
+- `decimal_char` — override for locale decimal. Fallback chain:
+  explicit param → configured pref → `locale.localeconv()["decimal_point"]` → `"."`
+
+### GetValue() → float
+
+Returns the current value as a Python float. Always uses period decimal
+internally, regardless of display locale.
+
+### SetValue(float)
+
+Formats the float for display using locale decimal. Updates `_lastSetValue`
+(the domain reference value) and fires `EVT_VALUE_CHANGED`.
+
+---
+
+## Blur-Time Validation
+
+The control stores `_lastSetValue` — updated only by `SetValue(float)` (called
+by the constructor and by `AttributeSync` when pushing domain values). This
+tracks what the domain last told the control to display.
+
+On focus loss (`_onKillFocus`):
+
+1. Read raw text from control
+2. Replace locale decimal with `.`, try `float()`
+3. **If valid:** update `_lastSetValue`, format display, fire `EVT_VALUE_CHANGED`
+4. **If invalid:** revert display to `_format(_lastSetValue)`, do NOT fire
+   `EVT_VALUE_CHANGED` (nothing changed in the domain)
+
+Empty field is treated as `0.0`.
+
+---
+
+## EVT_VALUE_CHANGED Pattern
+
+Reuses the existing `EVT_VALUE_CHANGED` / `ValueChangedEvent` from
+`maskedtimectrl.py`. Same event type used by `DurationCtrl`, `DateTimeCombo`,
+and now `NumericCtrl`.
+
+Fires from:
+- `_onKillFocus` — after successful blur validation (user finished editing)
+- `SetValue()` — when called programmatically (domain pushed a new value)
+
+`AttributeSync` binds `EVT_VALUE_CHANGED` instead of `EVT_KILL_FOCUS`. This
+completes ATTRIBUTE_PATTERN.md TODO #1 for monetary controls.
+
+---
+
+## Locale Decimal Handling
+
+### Display
+
+`_format(value)` replaces `"."` with the locale decimal character for display.
+
+- `decimal_places=None` → `"%g"` formatting (strip trailing zeros)
+- `decimal_places=2` → `"%.2f"` formatting (fixed 2 places)
+
+### Input parsing
+
+`GetValue()` and `_onKillFocus` replace the locale decimal with `"."` before
+calling `float()`.
+
+### Fallback chain
+
+```
+explicit decimal_char param
+  → settings.Settings().get("view", "decimal_separator")
+    → locale.localeconv()["decimal_point"]
+      → "."
+```
+
+---
+
+## Preferences
+
+Two settings in Preferences → Regional:
+
+**Decimal separator** (`view/decimal_separator`):
+- `""` — Automatic (detect from system)
+- `"."` — Period
+- `","` — Comma
+
+**Currency decimal places** (`view/currency_decimal_places`):
+- `""` — Automatic (from locale `frac_digits`)
+- `"0"` — 0 places (e.g. JPY, KRW)
+- `"2"` — 2 places (e.g. USD, EUR)
+- `"3"` — 3 places (e.g. BHD, KWD)
+
+Changes require restart. See [LOCALE.md](LOCALE.md) for the common pattern.
+
+---
+
+## UX Rationale
+
+Modern best practice for numeric input fields ([Smashing Magazine](https://www.smashingmagazine.com/2022/09/inline-validation-web-forms-ux/),
+[David Luhr](https://luhr.co/blog/2025/07/01/a-deep-dive-on-the-ux-of-number-inputs/)):
+
+- **Do NOT block characters on keypress.** Per-keystroke filtering creates
+  frustrating workarounds and confusing behavior.
+- **Allow free typing**, then validate and correct on blur.
+- **Revert to last valid value** on invalid input (not 0.00). The domain value
+  via `_lastSetValue` provides the revert target.
+- **No error messages** — these fields sync to the domain model on blur via
+  `AttributeSync`. Inline errors with no resolution path would just sit there.
+- **Never trap focus** — universally discouraged UX pattern.
+
+The previous `CurrencyValidator` approach blocked period keystrokes on GTK,
+deleted characters in insert mode, and allowed invalid paste content. The
+free-typing approach eliminates all of these issues.
+
+---
+
+## Cross-References
+
+- **Locale handling:** [LOCALE.md](LOCALE.md) — three-layer pattern, settings
+  keys, detection mechanisms
+- **Monetary controls:** [MONETARY_CONTROLS.md](MONETARY_CONTROLS.md) —
+  `CurrencyCtrl` subclass, currency-specific locale handling
+- **Attribute sync:** [ATTRIBUTE_PATTERN.md](ATTRIBUTE_PATTERN.md) — Layer 2
+  (UI↔Domain), `EVT_VALUE_CHANGED` migration
+- **Date/time controls:** [DATETIME_CONTROLS.md](DATETIME_CONTROLS.md) —
+  same `EVT_VALUE_CHANGED` pattern, same blur-time commit approach

--- a/taskcoachlib/config/defaults.py
+++ b/taskcoachlib/config/defaults.py
@@ -58,6 +58,10 @@ defaults = {
         "dateformat": "",
         # Time format override: "24" = 24-hour (default), "12" = 12-hour with AM/PM, "" = automatic
         "timeformat": "24",
+        # Decimal separator override: "" = automatic (from locale), "." = period, "," = comma
+        "decimal_separator": "",
+        # Currency decimal places override: "" = automatic (from locale frac_digits), or "0"/"2"/"3"
+        "currency_decimal_places": "",
         "categoryfiltermatchall": "False",
         "weekstart": "monday",  # Start of work week, 'monday' or 'sunday'
         # The next three options are used in the effort dialog to populate the

--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -2171,7 +2171,7 @@ class BudgetPage(Page):
             currentHourlyFee,
             self.items,
             command.EditHourlyFeeCommand,
-            wx.EVT_KILL_FOCUS,
+            widgets.EVT_VALUE_CHANGED,
             self.items[0].hourlyFeeChangedEventType(),
         )
         self.addEntry(
@@ -2192,7 +2192,7 @@ class BudgetPage(Page):
             currentFixedFee,
             self.items,
             command.EditFixedFeeCommand,
-            wx.EVT_KILL_FOCUS,
+            widgets.EVT_VALUE_CHANGED,
             self.items[0].fixedFeeChangedEventType(),
         )
         self.addEntry(

--- a/taskcoachlib/gui/dialog/preferences.py
+++ b/taskcoachlib/gui/dialog/preferences.py
@@ -1387,7 +1387,13 @@ class LanguagePage(SettingsPage):
             if setting == "language_set_by_user":
                 choiceCtrls[0].Bind(wx.EVT_CHOICE, self._onLanguageChange)
 
-        # Separator line between language and date/time format sections
+        # Separator line between language and spell check sections
+        self.addLine()
+
+        # === SPELL CHECK SECTION ===
+        self._setupSpellCheckSection()
+
+        # Separator line between spell check and date/time format sections
         self.addLine()
 
         # === DATE FORMAT SECTION ===
@@ -1514,15 +1520,109 @@ class LanguagePage(SettingsPage):
         )
         self.addEntry("", timeFormatNote)
 
-        # Separator line between time format and spell check sections
+        # Separator line between time format and number format sections
         self.addLine()
 
-        # === SPELL CHECK SECTION ===
-        self._setupSpellCheckSection()
+        # === NUMBER FORMAT SECTION ===
+        # Decimal separator dropdown
+        decSepPanel = wx.Panel(self)
+        decSepSizer = wx.BoxSizer(wx.HORIZONTAL)
+
+        self._decimalSepChoice = wx.Choice(decSepPanel)
+        decimalSepFormats = [
+            ("", _("Automatic (detect from system)")),
+            (".", _("Period (.)")),
+            (",", _("Comma (,)")),
+        ]
+        currentDecSep = self.gettext("view", "decimal_separator")
+        selectedDecSepIdx = 0
+        for i, (value, label) in enumerate(decimalSepFormats):
+            self._decimalSepChoice.Append(label, value)
+            if value == currentDecSep:
+                selectedDecSepIdx = i
+        self._decimalSepChoice.SetSelection(selectedDecSepIdx)
+        self._decimalSepChoice.Bind(wx.EVT_CHOICE, self._onDecimalSepChange)
+        decSepSizer.Add(self._decimalSepChoice, 0, wx.ALIGN_CENTER_VERTICAL)
+
+        # Detected decimal separator label
+        import locale as _locale
+        detectedDecSep = _locale.localeconv().get("decimal_point", ".") or "."
+        self._detectedDecSepLabel = wx.StaticText(
+            decSepPanel,
+            label=_("Detected: %s") % ('"%s"' % detectedDecSep)
+        )
+        self._detectedDecSepLabel.SetForegroundColour(
+            wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
+        )
+        decSepSizer.Add(self._detectedDecSepLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 15)
+
+        decSepPanel.SetSizer(decSepSizer)
+        self.addEntry(_("Decimal separator"), decSepPanel)
+
+        # Currency decimal places dropdown
+        currDpPanel = wx.Panel(self)
+        currDpSizer = wx.BoxSizer(wx.HORIZONTAL)
+
+        self._currencyDpChoice = wx.Choice(currDpPanel)
+        currencyDpOptions = [
+            ("", _("Automatic (from locale)")),
+            ("0", _("0 (e.g. JPY, KRW)")),
+            ("2", _("2 (e.g. USD, EUR)")),
+            ("3", _("3 (e.g. BHD, KWD)")),
+        ]
+        currentCurrDp = self.gettext("view", "currency_decimal_places")
+        selectedCurrDpIdx = 0
+        for i, (value, label) in enumerate(currencyDpOptions):
+            self._currencyDpChoice.Append(label, value)
+            if value == currentCurrDp:
+                selectedCurrDpIdx = i
+        self._currencyDpChoice.SetSelection(selectedCurrDpIdx)
+        self._currencyDpChoice.Bind(wx.EVT_CHOICE, self._onCurrencyDpChange)
+        currDpSizer.Add(self._currencyDpChoice, 0, wx.ALIGN_CENTER_VERTICAL)
+
+        # Detected currency decimal places label
+        detectedFrac = _locale.localeconv().get("frac_digits", 2)
+        if detectedFrac == 127:
+            detectedFrac = 2
+        self._detectedCurrDpLabel = wx.StaticText(
+            currDpPanel,
+            label=_("Detected: %d") % detectedFrac
+        )
+        self._detectedCurrDpLabel.SetForegroundColour(
+            wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
+        )
+        currDpSizer.Add(self._detectedCurrDpLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 15)
+
+        currDpPanel.SetSizer(currDpSizer)
+        self.addEntry(_("Currency decimal places"), currDpPanel)
+
+        # Demo CurrencyCtrl showing the selected decimal separator and places (live update)
+        from taskcoachlib.widgets.numericctrl import NumericCtrl
+        currDemoPanel = wx.Panel(self)
+        currDemoSizer = wx.BoxSizer(wx.HORIZONTAL)
+        currDemoLabel = wx.StaticText(currDemoPanel, label=_("Preview:"))
+        currDemoSizer.Add(currDemoLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10)
+        # Resolve effective decimal char and places for initial demo
+        effectiveDecChar = currentDecSep or detectedDecSep
+        if currentCurrDp:
+            effectiveCurrDp = int(currentCurrDp)
+        else:
+            effectiveCurrDp = detectedFrac
+        self._demoCurrencyCtrl = NumericCtrl(
+            currDemoPanel,
+            value=1234.56,
+            decimal_places=effectiveCurrDp,
+            decimal_char=effectiveDecChar,
+        )
+        currDemoSizer.Add(self._demoCurrencyCtrl, 0, wx.ALIGN_CENTER_VERTICAL)
+        currDemoPanel.SetSizer(currDemoSizer)
+        self.addEntry("", currDemoPanel)
 
         # Store original formats to detect changes
         self._originalDateFormat = currentFormat
         self._originalTimeFormat = currentTimeFormat
+        self._originalDecimalSep = currentDecSep
+        self._originalCurrencyDp = currentCurrDp
 
         self.fit()
 
@@ -1695,6 +1795,53 @@ class LanguagePage(SettingsPage):
 
         event.Skip()
 
+    def _onDecimalSepChange(self, event):
+        """Handle decimal separator dropdown change - update demo and restart warning."""
+        self._updateCurrencyDemo()
+        self._updateRestartWarning()
+        event.Skip()
+
+    def _onCurrencyDpChange(self, event):
+        """Handle currency decimal places dropdown change - update demo and restart warning."""
+        self._updateCurrencyDemo()
+        self._updateRestartWarning()
+        event.Skip()
+
+    def _updateCurrencyDemo(self):
+        """Recreate the demo NumericCtrl with current dropdown selections."""
+        import locale as _locale
+        from taskcoachlib.widgets.numericctrl import NumericCtrl
+
+        # Resolve effective decimal char
+        selectedDecSep = self._decimalSepChoice.GetClientData(
+            self._decimalSepChoice.GetSelection()
+        )
+        if not selectedDecSep:
+            selectedDecSep = _locale.localeconv().get("decimal_point", ".")
+
+        # Resolve effective currency decimal places
+        selectedCurrDp = self._currencyDpChoice.GetClientData(
+            self._currencyDpChoice.GetSelection()
+        )
+        if selectedCurrDp:
+            effectiveDp = int(selectedCurrDp)
+        else:
+            effectiveDp = _locale.localeconv().get("frac_digits", 2)
+            if effectiveDp == 127:
+                effectiveDp = 2
+
+        # Destroy old and create new
+        parent = self._demoCurrencyCtrl.GetParent()
+        sizer = parent.GetSizer()
+        self._demoCurrencyCtrl.Destroy()
+        self._demoCurrencyCtrl = NumericCtrl(
+            parent, value=1234.56,
+            decimal_places=effectiveDp, decimal_char=selectedDecSep,
+        )
+        sizer.Add(self._demoCurrencyCtrl, 0, wx.ALIGN_CENTER_VERTICAL)
+        parent.Layout()
+        parent.Fit()
+
     def _onLanguageChange(self, event):
         """Handle language dropdown change."""
         self._updateLocaleWarning()
@@ -1711,12 +1858,21 @@ class LanguagePage(SettingsPage):
             self._timeFormatChoice.GetSelection()
         )
 
+        selected_decimal_sep = self._decimalSepChoice.GetClientData(
+            self._decimalSepChoice.GetSelection()
+        )
+        selected_currency_dp = self._currencyDpChoice.GetClientData(
+            self._currencyDpChoice.GetSelection()
+        )
+
         # Check if any regional setting has changed
         language_changed = selected_lang != self._originalLanguage
         date_format_changed = selected_date_format != self._originalDateFormat
         time_format_changed = selected_time_format != self._originalTimeFormat
+        decimal_sep_changed = selected_decimal_sep != self._originalDecimalSep
+        currency_dp_changed = selected_currency_dp != self._originalCurrencyDp
 
-        if language_changed or date_format_changed or time_format_changed:
+        if language_changed or date_format_changed or time_format_changed or decimal_sep_changed or currency_dp_changed:
             # Change detected - show red warning
             self._restartWarning.SetLabel(
                 self._restartWarningBase + " " + _("Change detected, restart required!")
@@ -1754,6 +1910,16 @@ class LanguagePage(SettingsPage):
             self._timeFormatChoice.GetSelection()
         )
         self.set("view", "timeformat", selectedTimeFormat)
+        # Save decimal separator setting
+        selectedDecSep = self._decimalSepChoice.GetClientData(
+            self._decimalSepChoice.GetSelection()
+        )
+        self.set("view", "decimal_separator", selectedDecSep)
+        # Save currency decimal places setting
+        selectedCurrDp = self._currencyDpChoice.GetClientData(
+            self._currencyDpChoice.GetSelection()
+        )
+        self.set("view", "currency_decimal_places", selectedCurrDp)
         # Save spell check settings
         self.setboolean("spellcheck", "enabled", self._spellCheckEnabledCheck.IsChecked())
         selectedSpellLang = self._spellCheckLangChoice.GetClientData(
@@ -2510,7 +2676,9 @@ class Preferences(widgets.NotebookDialog):
             self.CentreOnParent()
 
     def addPages(self):
-        self._interior.SetMinSize((1250, 550))
+        screenHeight = wx.Display(wx.Display.GetFromWindow(self)).GetClientArea().GetHeight()
+        height = min(650, int(screenHeight * 0.9))
+        self._interior.SetMinSize((1250, height))
         for page_name in self.allPageNames:
             page = self.createPage(page_name)
             self._interior.AddPage(page, page.pageTitle, page.pageIcon)

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,8 +41,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "60"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.1.60
+patch = "61"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.1.61
 
 release_day = "2"  # Day of the release (1-31)
 release_month = "February"  # Month of the release

--- a/taskcoachlib/widgets/__init__.py
+++ b/taskcoachlib/widgets/__init__.py
@@ -55,6 +55,7 @@ from .calendarconfig import CalendarConfigDialog
 from .password import GetPassword
 from .hcalendar import HierarchicalCalendar
 from .hcalendarconfig import HierarchicalCalendarConfigDialog
+from .numericctrl import NumericCtrl
 from .currencyctrl import CurrencyCtrl
 from . import masked
 from wx.lib import sized_controls

--- a/taskcoachlib/widgets/currencyctrl.py
+++ b/taskcoachlib/widgets/currencyctrl.py
@@ -17,118 +17,41 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import locale
-import wx
+from taskcoachlib.widgets.numericctrl import NumericCtrl
 
 
-class CurrencyValidator(wx.Validator):
-    """Validator that restricts input to valid currency characters:
-    digits, a single locale-aware decimal point, and navigation keys."""
+def _get_configured_currency_decimal_places():
+    """Get currency decimal places from preferences, falling back to locale.
 
-    def __init__(self, decimal_char=None):
-        super().__init__()
-        self._decimalChar = decimal_char or locale.localeconv().get("decimal_point", ".")
-        if not self._decimalChar:
-            self._decimalChar = "."
-        self.Bind(wx.EVT_CHAR, self.OnChar)
-
-    def Clone(self):
-        return CurrencyValidator(self._decimalChar)
-
-    def Validate(self, parent):
-        return True
-
-    def TransferToWindow(self):
-        return True
-
-    def TransferFromWindow(self):
-        return True
-
-    def OnChar(self, event):
-        keycode = event.GetKeyCode()
-
-        # Always allow navigation/control keys
-        if keycode < wx.WXK_SPACE or keycode == wx.WXK_DELETE:
-            event.Skip()
-            return
-        if keycode in (wx.WXK_RETURN, wx.WXK_TAB, wx.WXK_BACK,
-                       wx.WXK_LEFT, wx.WXK_RIGHT, wx.WXK_HOME, wx.WXK_END):
-            event.Skip()
-            return
-        # Allow Ctrl+key combos (copy, paste, select all, etc.)
-        if event.ControlDown() or event.CmdDown():
-            event.Skip()
-            return
-
-        char = chr(keycode) if keycode < 256 else None
-
-        if char is None:
-            event.Skip()
-            return
-
-        # Allow digits
-        if char.isdigit():
-            event.Skip()
-            return
-
-        # Allow single decimal point
-        if char == self._decimalChar:
-            ctrl = self.GetWindow()
-            if self._decimalChar not in ctrl.GetValue():
-                event.Skip()
-            return
-
-        # Block everything else (no beep, just silently reject)
+    Fallback chain: configured pref -> locale frac_digits -> 2
+    """
+    try:
+        from taskcoachlib.config import settings
+        val = settings.Settings().get("view", "currency_decimal_places")
+        if val:
+            return int(val)
+    except Exception:
+        pass
+    frac = locale.localeconv().get("frac_digits", 2)
+    if frac == 127:  # CHAR_MAX = not available
+        frac = 2
+    return frac
 
 
-class CurrencyCtrl(wx.TextCtrl):
-    """Currency input control using wx.TextCtrl + CurrencyValidator.
+class CurrencyCtrl(NumericCtrl):
+    """Currency input control: NumericCtrl with decimal_places from locale.
 
-    Replaces the crash-prone wx.lib.masked.NumCtrl (AmountCtrl).
-    Right-aligned, locale-aware decimal point, formats to 2dp on focus loss.
+    Gets decimal_places from locale.localeconv()["frac_digits"] (2 for
+    USD/EUR, 0 for JPY, 3 for BHD). Falls back to 2 if frac_digits is
+    127 (CHAR_MAX = not available) or if configured in preferences.
     """
 
-    def __init__(self, parent, value=0.0, **kwargs):
-        self._decimalChar = locale.localeconv().get("decimal_point", ".") or "."
+    def __init__(self, parent, value=0.0, decimal_char=None, **kwargs):
+        decimal_places = _get_configured_currency_decimal_places()
         super().__init__(
             parent,
-            style=wx.TE_RIGHT | wx.TE_PROCESS_TAB,
-            validator=CurrencyValidator(self._decimalChar),
+            value=value,
+            decimal_places=decimal_places,
+            decimal_char=decimal_char,
             **kwargs,
         )
-        self.SetValue(value)
-        self.Bind(wx.EVT_KILL_FOCUS, self._onKillFocus)
-
-    def GetValue(self):
-        """Return the current value as a float."""
-        text = super().GetValue().strip()
-        if not text:
-            return 0.0
-        # Normalize locale decimal to Python float decimal
-        text = text.replace(self._decimalChar, ".")
-        try:
-            return float(text)
-        except ValueError:
-            return 0.0
-
-    def SetValue(self, value):
-        """Set the control to display a formatted float value."""
-        if isinstance(value, (int, float)):
-            text = self._format(value)
-        else:
-            text = str(value)
-        super().SetValue(text)
-
-    def _format(self, value):
-        """Format a float to 2 decimal places using locale decimal char."""
-        formatted = "%.2f" % value
-        if self._decimalChar != ".":
-            formatted = formatted.replace(".", self._decimalChar)
-        return formatted
-
-    def _onKillFocus(self, event):
-        """Auto-format to 2 decimal places when focus leaves the control."""
-        event.Skip()
-        if not self.IsEnabled():
-            return
-        current = self.GetValue()
-        self.SetValue(current)

--- a/taskcoachlib/widgets/numericctrl.py
+++ b/taskcoachlib/widgets/numericctrl.py
@@ -1,0 +1,138 @@
+"""
+Task Coach - Your friendly task manager
+Copyright (C) 2004-2016 Task Coach developers <developers@taskcoach.org>
+
+Task Coach is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Task Coach is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import locale
+import wx
+from taskcoachlib.widgets.maskedtimectrl import EVT_VALUE_CHANGED, ValueChangedEvent
+
+
+def _get_locale_decimal_char():
+    """Get decimal separator from locale, with safe fallback."""
+    return locale.localeconv().get("decimal_point", ".") or "."
+
+
+def _get_configured_decimal_char():
+    """Get decimal separator from preferences, falling back to locale.
+
+    Fallback chain: configured pref -> locale -> "."
+    """
+    try:
+        from taskcoachlib.config import settings
+        val = settings.Settings().get("view", "decimal_separator")
+        if val:
+            return val
+    except Exception:
+        pass
+    return _get_locale_decimal_char()
+
+
+class NumericCtrl(wx.TextCtrl):
+    """Numeric input control: free typing, blur-time validation, locale-aware.
+
+    Constructor params:
+        value: initial float value (default 0.0)
+        decimal_places: None = floating (preserve user precision, strip
+            trailing zeros), int = fixed (always format to N places)
+        decimal_char: override for locale decimal; fallback chain:
+            explicit param -> configured pref -> locale -> "."
+
+    On blur: parse text as float. If valid, format and fire
+    EVT_VALUE_CHANGED. If invalid, revert display to _lastSetValue
+    (the domain value) without firing EVT_VALUE_CHANGED.
+
+    API:
+        GetValue() -> Python float (always period decimal internally)
+        SetValue(float) -> formats with locale decimal for display,
+            fires EVT_VALUE_CHANGED
+    """
+
+    def __init__(self, parent, value=0.0, decimal_places=None,
+                 decimal_char=None, **kwargs):
+        self._decimalPlaces = decimal_places
+        self._decimalChar = decimal_char or _get_configured_decimal_char()
+        self._lastSetValue = float(value)
+        super().__init__(
+            parent,
+            style=wx.TE_RIGHT | wx.TE_PROCESS_TAB,
+            **kwargs,
+        )
+        # Set initial display text without firing EVT_VALUE_CHANGED
+        super().SetValue(self._format(self._lastSetValue))
+        self.Bind(wx.EVT_KILL_FOCUS, self._onKillFocus)
+
+    def GetValue(self):
+        """Return the current value as a Python float (period decimal)."""
+        text = super().GetValue().strip()
+        if not text:
+            return 0.0
+        text = text.replace(self._decimalChar, ".")
+        try:
+            return float(text)
+        except ValueError:
+            return self._lastSetValue
+
+    def SetValue(self, value):
+        """Set the control to display a formatted float value.
+
+        Updates _lastSetValue and fires EVT_VALUE_CHANGED.
+        """
+        if isinstance(value, (int, float)):
+            self._lastSetValue = float(value)
+        else:
+            try:
+                self._lastSetValue = float(value)
+            except (ValueError, TypeError):
+                self._lastSetValue = 0.0
+        super().SetValue(self._format(self._lastSetValue))
+        self._fireValueChanged()
+
+    def _format(self, value):
+        """Format a float for display using locale decimal char."""
+        if self._decimalPlaces is not None:
+            formatted = "%.*f" % (self._decimalPlaces, value)
+        else:
+            formatted = "%g" % value
+        if self._decimalChar != ".":
+            formatted = formatted.replace(".", self._decimalChar)
+        return formatted
+
+    def _onKillFocus(self, event):
+        """Validate on blur: format if valid, revert if invalid."""
+        event.Skip()
+        if not self.IsEnabled():
+            return
+        text = super().GetValue().strip()
+        if not text:
+            parsed = 0.0
+        else:
+            normalized = text.replace(self._decimalChar, ".")
+            try:
+                parsed = float(normalized)
+            except ValueError:
+                # Invalid input: revert to domain value, no event
+                super().SetValue(self._format(self._lastSetValue))
+                return
+        # Valid input: format and fire
+        self._lastSetValue = parsed
+        super().SetValue(self._format(parsed))
+        self._fireValueChanged()
+
+    def _fireValueChanged(self):
+        """Fire EVT_VALUE_CHANGED to notify AttributeSync."""
+        event = ValueChangedEvent(self)
+        self.GetEventHandler().ProcessEvent(event)

--- a/tests/unittests/guiTests/AmountEntryTest.py
+++ b/tests/unittests/guiTests/AmountEntryTest.py
@@ -18,7 +18,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import test
+import wx
 from taskcoachlib.gui.dialog import entry
+from taskcoachlib.widgets.numericctrl import NumericCtrl
+from taskcoachlib.widgets.currencyctrl import CurrencyCtrl
 
 
 class AmountEntryTest(test.wxTestCase):
@@ -32,3 +35,147 @@ class AmountEntryTest(test.wxTestCase):
     def testSetValue(self):
         self.amountEntry.SetValue(1.0)
         self.assertEqual(1.0, self.amountEntry.GetValue())
+
+
+class NumericCtrlTest(test.wxTestCase):
+    """Tests for NumericCtrl base class."""
+
+    def setUp(self):
+        super().setUp()
+        self.ctrl = NumericCtrl(self.frame, value=0.0, decimal_places=2,
+                                decimal_char=".")
+
+    def testCreateDefault(self):
+        self.assertEqual(0.0, self.ctrl.GetValue())
+
+    def testCreateWithValue(self):
+        ctrl = NumericCtrl(self.frame, value=12.34, decimal_places=2,
+                           decimal_char=".")
+        self.assertEqual(12.34, ctrl.GetValue())
+
+    def testSetValue(self):
+        self.ctrl.SetValue(25.5)
+        self.assertEqual(25.5, self.ctrl.GetValue())
+
+    def testSetValueFormatsDisplay(self):
+        self.ctrl.SetValue(12.3)
+        self.assertEqual("12.30", wx.TextCtrl.GetValue(self.ctrl))
+
+    def testGetValueReturnsPythonFloat(self):
+        self.ctrl.SetValue(99.99)
+        result = self.ctrl.GetValue()
+        self.assertIsInstance(result, float)
+        self.assertEqual(99.99, result)
+
+    def testEmptyFieldReturnsZero(self):
+        wx.TextCtrl.SetValue(self.ctrl, "")
+        self.assertEqual(0.0, self.ctrl.GetValue())
+
+    def testInvalidTextReturnsLastSetValue(self):
+        self.ctrl.SetValue(10.0)
+        # Directly set invalid text bypassing our SetValue
+        wx.TextCtrl.SetValue(self.ctrl, "abc")
+        self.assertEqual(10.0, self.ctrl.GetValue())
+
+    def testBlurFormatsValidInput(self):
+        """Valid input is formatted on blur."""
+        self.ctrl.SetValue(0.0)
+        wx.TextCtrl.SetValue(self.ctrl, "12.34")
+        # Simulate blur
+        event = wx.FocusEvent(wx.wxEVT_KILL_FOCUS)
+        self.ctrl._onKillFocus(event)
+        self.assertEqual("12.34", wx.TextCtrl.GetValue(self.ctrl))
+
+    def testBlurRevertsInvalidInput(self):
+        """Invalid input reverts to last set value on blur."""
+        self.ctrl.SetValue(5.0)
+        wx.TextCtrl.SetValue(self.ctrl, "12.34.56")
+        event = wx.FocusEvent(wx.wxEVT_KILL_FOCUS)
+        self.ctrl._onKillFocus(event)
+        self.assertEqual("5.00", wx.TextCtrl.GetValue(self.ctrl))
+
+    def testBlurRevertsGarbageInput(self):
+        """Garbage text reverts to last set value on blur."""
+        self.ctrl.SetValue(7.5)
+        wx.TextCtrl.SetValue(self.ctrl, "abc1.00xyz")
+        event = wx.FocusEvent(wx.wxEVT_KILL_FOCUS)
+        self.ctrl._onKillFocus(event)
+        self.assertEqual("7.50", wx.TextCtrl.GetValue(self.ctrl))
+
+    def testBlurEmptyFieldBecomesZero(self):
+        """Empty field becomes 0.00 on blur."""
+        self.ctrl.SetValue(10.0)
+        wx.TextCtrl.SetValue(self.ctrl, "")
+        event = wx.FocusEvent(wx.wxEVT_KILL_FOCUS)
+        self.ctrl._onKillFocus(event)
+        self.assertEqual("0.00", wx.TextCtrl.GetValue(self.ctrl))
+
+
+class NumericCtrlFloatingTest(test.wxTestCase):
+    """Tests for NumericCtrl with floating decimal places (decimal_places=None)."""
+
+    def setUp(self):
+        super().setUp()
+        self.ctrl = NumericCtrl(self.frame, value=0.0, decimal_places=None,
+                                decimal_char=".")
+
+    def testFloatingFormatsNoTrailingZeros(self):
+        self.ctrl.SetValue(12.0)
+        self.assertEqual("12", wx.TextCtrl.GetValue(self.ctrl))
+
+    def testFloatingPreservesPrecision(self):
+        self.ctrl.SetValue(12.3)
+        self.assertEqual("12.3", wx.TextCtrl.GetValue(self.ctrl))
+
+    def testFloatingFormatsSmallDecimals(self):
+        self.ctrl.SetValue(0.5)
+        self.assertEqual("0.5", wx.TextCtrl.GetValue(self.ctrl))
+
+
+class NumericCtrlLocaleTest(test.wxTestCase):
+    """Tests for NumericCtrl with non-period decimal char."""
+
+    def setUp(self):
+        super().setUp()
+        self.ctrl = NumericCtrl(self.frame, value=0.0, decimal_places=2,
+                                decimal_char=",")
+
+    def testDisplayUsesLocaleDecimal(self):
+        self.ctrl.SetValue(25.5)
+        self.assertEqual("25,50", wx.TextCtrl.GetValue(self.ctrl))
+
+    def testGetValueReturnsPeriodDecimal(self):
+        self.ctrl.SetValue(25.5)
+        self.assertEqual(25.5, self.ctrl.GetValue())
+
+    def testBlurParsesLocaleDecimal(self):
+        wx.TextCtrl.SetValue(self.ctrl, "12,34")
+        event = wx.FocusEvent(wx.wxEVT_KILL_FOCUS)
+        self.ctrl._onKillFocus(event)
+        self.assertEqual(12.34, self.ctrl.GetValue())
+
+    def testBlurFormatsWithLocaleDecimal(self):
+        wx.TextCtrl.SetValue(self.ctrl, "12,34")
+        event = wx.FocusEvent(wx.wxEVT_KILL_FOCUS)
+        self.ctrl._onKillFocus(event)
+        self.assertEqual("12,34", wx.TextCtrl.GetValue(self.ctrl))
+
+
+class CurrencyCtrlTest(test.wxTestCase):
+    """Tests for CurrencyCtrl subclass."""
+
+    def setUp(self):
+        super().setUp()
+        self.ctrl = CurrencyCtrl(self.frame, value=0.0, decimal_char=".")
+
+    def testCreate(self):
+        self.assertEqual(0.0, self.ctrl.GetValue())
+
+    def testSetValue(self):
+        self.ctrl.SetValue(42.0)
+        self.assertEqual(42.0, self.ctrl.GetValue())
+
+    def testFormatsToTwoDecimalPlaces(self):
+        """Default locale should give 2 decimal places."""
+        self.ctrl.SetValue(5.0)
+        self.assertEqual("5.00", wx.TextCtrl.GetValue(self.ctrl))


### PR DESCRIPTION
Replace CurrencyValidator keystroke-blocking with NumericCtrl(wx.TextCtrl) free-typing base class and blur-time validation. Add decimal separator and currency decimal places to Regional preferences with live preview. Move spell check under language section. Migrate AttributeSync to EVT_VALUE_CHANGED. Add LOCALE.md and NUMERIC_CONTROLS.md docs with cross-references.

Budget tab fields completely broken, needs full refactor #189

I refactored the numeric and currency controls to follow modern UX.  You can type anything, if it doesn't validate, it reverts to the last saved value (or zero).   Locale settings, decimals separator character and number of decimals places, can be overridden under Peferences -> Regional. See screenshots below. 

<img width="954" height="745" alt="Screenshot from 2026-02-02 13-15-20" src="https://github.com/user-attachments/assets/556e089d-6aba-43b1-a081-6978bf4563bb" />

<img width="610" height="232" alt="Screenshot from 2026-02-02 13-15-37" src="https://github.com/user-attachments/assets/b7b55c52-e84b-4e55-a897-743f7374f3c1" />

<img width="682" height="187" alt="Screenshot from 2026-02-02 13-16-20" src="https://github.com/user-attachments/assets/2882d1df-d019-429e-b5c5-0407746e149c" />

<img width="621" height="460" alt="Screenshot from 2026-02-02 13-17-26" src="https://github.com/user-attachments/assets/35e67ba8-8215-472c-8d05-2efd953ff6d7" />
