### PR TITLE
Fix time spent calculations, crash guard logging, editor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.61-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.61-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.61_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.61_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.61_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.61-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.62-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.62-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.62_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.62_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.62_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.62-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.61-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.61-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.61_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.61_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.61-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.61-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.62-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.62-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.62_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.62_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.62-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.62-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.61_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.61_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.62_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.62_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.61-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.61-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.62-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.62-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.61-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.61-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.62-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.62-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.61-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.61-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.62-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.62-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.61-x86_64.AppImage
+./TaskCoach-2.0.1.62-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/docs/APPEARANCE_STYLES.md
+++ b/docs/APPEARANCE_STYLES.md
@@ -1,0 +1,268 @@
+# Appearance Styles
+
+## Table of Contents
+
+- [TODO](#todo)
+- [Overview](#overview)
+- [SSOT Architecture](#ssot-architecture)
+- [Field Types](#field-types)
+- [Derivation Sources by Object Type](#derivation-sources-by-object-type)
+  - [Task](#task)
+  - [Note](#note)
+  - [Category](#category)
+  - [Attachment](#attachment)
+  - [Effort](#effort)
+- [Category Style Priority](#category-style-priority)
+- [Default Icons](#default-icons)
+- [ComputeStyles Polling](#computestyles-polling)
+  - [Processing Order](#processing-order)
+  - [Owned Object Traversal](#owned-object-traversal)
+- [Stored Procedures](#stored-procedures)
+  - [computeDerived](#computederived)
+  - [computeEffective](#computeeffective)
+  - [_getFromCategories](#_getfromcategories)
+  - [_getFromParent](#_getfromparent)
+- [SSOT Accessors (base Object)](#ssot-accessors-base-object)
+- [Appearance Tab (Editor)](#appearance-tab-editor)
+- [File Reference](#file-reference)
+- [See Also](#see-also)
+
+---
+
+## TODO
+
+1. **Attachment styling**: Attachments appear to use the parent task's styling
+   for fg/bg/font, but not for icon (icon is file-type based). However,
+   attachments have no categories and the current `computeDerived` gives them
+   no sources. Consider whether the Attachment Appearance tab and the
+   Attachment branch in the derived/effective logic should be removed entirely,
+   or whether parent-task inheritance should be added properly.
+
+2. **Note styling incomplete**: Notes now correctly derive icon from categories
+   (via `_getFromCategories`), but legacy behavior shows that Notes do not
+   derive fg/bg/font styling from their categories. The refactored
+   `computeDerived` applies `_getFromCategories` for all field types, but the
+   actual results need to be reviewed and tested to confirm that category
+   fg/bg/font values now flow through to Notes as expected.
+
+---
+
+## Overview
+
+All domain objects (Task, Category, Note, Attachment) use a Single Source of
+Truth (SSOT) architecture for appearance properties. Each object stores derived,
+override, and effective values for each style field. A per-second polling system
+(`ComputeStyles`) recomputes derived and effective values for all objects.
+
+Efforts are the exception: they have no appearance/styling system and use a
+hardcoded icon (`clock_icon`).
+
+---
+
+## SSOT Architecture
+
+Each style field has three layers per object:
+
+| Layer | Description | Persisted? |
+|-------|-------------|------------|
+| **Override** | Explicitly set by user via Appearance tab | Yes |
+| **Derived** | Computed from sources (categories, parent, status) | No (volatile) |
+| **Effective** | Override if set, otherwise derived | No (volatile) |
+
+Volatile fields are recomputed by `ComputeStyles` polling within 1 second of
+any change. They are `None` after file load until the first poll runs.
+
+---
+
+## Field Types
+
+Four style fields, defined in `FIELD_TYPES`:
+
+| Field | Default (no value) | No-value source |
+|-------|-------------------|-----------------|
+| `fgColor` | `SYS_COLOUR_WINDOWTEXT` | `"System Theme"` |
+| `bgColor` | `SYS_COLOUR_WINDOW` | `"System Theme"` |
+| `font` | `SYS_DEFAULT_GUI_FONT` | `"System Theme"` |
+| `icon` | `""` (empty) | `"N/A"` |
+
+Icons have type-specific defaults applied in `computeDerived` (see
+[Default Icons](#default-icons)).
+
+---
+
+## Derivation Sources by Object Type
+
+### Task
+
+Sources checked in order (first non-system-theme value wins):
+
+1. **Categories** - sorted by `stylePriority` descending (via `_getFromCategories`)
+2. **Parent task** - `parent.effectiveXxx()` (via `_getFromParent`)
+3. **Status** - `statusIcon()`, `statusFgColor()`, etc. from `computeStoredStatus()`
+
+Source labels: `[Category] name`, `[Task] name`, `[Status] active/completed/...`
+
+### Note
+
+Sources checked in order:
+
+1. **Categories** - sorted by `stylePriority` descending (via `_getFromCategories`)
+2. **Parent note** - `parent.effectiveXxx()` (via `_getFromParent`)
+
+Source labels: `[Category] name`, `[Note] name`
+
+Notes are categorizable (`CategorizableCompositeObject`), same as Tasks.
+
+### Category
+
+Sources checked in order:
+
+1. **Parent category** - `parent.effectiveXxx()` (via `_getFromParent`)
+
+Source label: `[Category] name`
+
+### Attachment
+
+No sources. Derived value is always `None`. Only override or default icon applies.
+
+### Effort
+
+Not processed by the appearance system. Uses hardcoded `clock_icon`.
+
+---
+
+## Category Style Priority
+
+When an object belongs to multiple categories, `stylePriority` determines which
+category's appearance wins. Higher priority = checked first.
+
+- Stored on `Category` as `__stylePriority` (integer, default 0)
+- Sorted descending: `categories.sort(key=stylePriority, reverse=True)`
+- First category with a non-system-theme value for the field wins
+- Editable via `EditStylePriorityCommand`
+
+**File:** `taskcoachlib/domain/category/category.py` (stylePriority accessor)
+**File:** `taskcoachlib/command/categoryCommands.py` (EditStylePriorityCommand)
+
+---
+
+## Default Icons
+
+Types without a status-based icon fallback get a default icon via
+`TYPE_DEFAULT_ICONS` in `appearance.py`, applied at the end of `computeDerived`
+when no other source provides an icon:
+
+| Type | Default Icon | Source Label |
+|------|-------------|-------------|
+| Category | `folder_blue_icon` | `"System Theme"` |
+| Note | `note_icon` | `"System Theme"` |
+| Attachment | `paperclip_icon` | `"System Theme"` |
+
+Tasks get their default icon from status (e.g., `led_blue_icon` for active).
+
+---
+
+## ComputeStyles Polling
+
+`ComputeStyles` subscribes to `timer.second` and recomputes all objects every
+second. This catches all changes without explicit triggers.
+
+**File:** `taskcoachlib/domain/base/appearance.py` (class `ComputeStyles`)
+
+### Processing Order
+
+1. **Categories** (so tasks/notes can read their effective values)
+2. **Tasks** (including child tasks via flat `CompositeSet`)
+3. **Global notes** (standalone notes from `taskFile.notes()`)
+
+### Owned Object Traversal
+
+`_computeForObject` recursively processes owned objects after computing
+the object's own styles:
+
+- `obj.notes(recursive=True)` - all owned notes (flat list + children)
+- `obj.attachments()` - all owned attachments
+
+This covers the full ownership graph: task -> notes -> attachments -> notes -> ...
+No circular ownership exists because users create new objects under owners.
+
+---
+
+## Stored Procedures
+
+### computeDerived
+
+Computes the derived value for one field of one object. Checks sources in
+type-specific order and writes via `obj.setDerivedXxx(value, source)`.
+
+### computeEffective
+
+Computes the effective value: override if set, otherwise derived. Writes via
+`obj.setEffectiveXxx(value, default, source)`.
+
+### _getFromCategories
+
+Shared helper for Task and Note derivation. Gets the object's categories,
+sorts by `stylePriority` descending, returns `(value, source)` from the first
+category with a non-system-theme effective value.
+
+### _getFromParent
+
+Shared helper for Task, Note, and Category derivation. Checks the object's
+parent for a non-system-theme effective value, returns `(value, source)`.
+
+---
+
+## SSOT Accessors (base Object)
+
+All accessors are defined on `taskcoachlib/domain/base/object.py`:
+
+| Method | Returns |
+|--------|---------|
+| `derivedXxx()` | Derived value (or field default) |
+| `derivedXxxSource()` | Source label for derived value |
+| `effectiveXxx()` | Effective value (override or derived) |
+| `effectiveXxxSource()` | Source label for effective value |
+| `setDerivedXxx(value, source)` | Write derived SSOT |
+| `setEffectiveXxx(value, [default,] source)` | Write effective SSOT |
+
+Where `Xxx` is `FgColor`, `BgColor`, `Icon`, or `Font`.
+
+---
+
+## Appearance Tab (Editor)
+
+`TaskAppearancePage` (extends `ScrolledPage`) shows three sections:
+
+1. **Derived values** - read-only display with source labels
+2. **Override values** - user-editable controls
+3. **Effective values** - read-only computed result
+
+Used by Tasks, Categories, Notes, and Attachments (each editor includes
+an `"appearance"` page).
+
+**File:** `taskcoachlib/gui/dialog/editor.py` (class `TaskAppearancePage`)
+
+---
+
+## File Reference
+
+| File | Purpose |
+|------|---------|
+| `taskcoachlib/domain/base/appearance.py` | SSOT stored procedures, ComputeStyles, constants |
+| `taskcoachlib/domain/base/object.py` | SSOT accessor/setter methods on base Object |
+| `taskcoachlib/domain/task/task.py` | Task status icon/color/font, `computeStoredStatus()` |
+| `taskcoachlib/domain/category/category.py` | `stylePriority` attribute |
+| `taskcoachlib/domain/categorizable/categorizable.py` | Legacy category color/font mixers |
+| `taskcoachlib/command/categoryCommands.py` | `EditStylePriorityCommand` |
+| `taskcoachlib/config/defaults.py` | Default status icons/colors/fonts |
+| `taskcoachlib/gui/dialog/editor.py` | `TaskAppearancePage` (Appearance tab) |
+
+---
+
+## See Also
+
+- [TASK_STATUS.md](TASK_STATUS.md) - Task status system and status-based icon defaults
+- [SCHEDULERS.md](SCHEDULERS.md) - GlobalTimer architecture (drives ComputeStyles polling)
+- [ICON_LIBRARY.md](ICON_LIBRARY.md) - Icon sources, structure, and adding new icons
+- [ICON_PLURALIZE.md](ICON_PLURALIZE.md) - Plural/singular icon mapping (may be removed)

--- a/docs/CRASH_GUARD.md
+++ b/docs/CRASH_GUARD.md
@@ -1,0 +1,118 @@
+# Crash Guard System
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [The Problem](#the-problem)
+3. [Guards](#guards)
+4. [Log Output](#log-output)
+5. [Debugging a Segfault](#debugging-a-segfault)
+6. [Key Files](#key-files)
+
+---
+
+## Overview
+
+Task Coach uses wxPython, which wraps C++ widgets. When Python holds a reference to a wx object whose C++ counterpart has been destroyed, calling any method on it causes a segfault. This commonly happens with `wx.CallAfter` — a callback is scheduled, but the target widget is destroyed before the callback fires.
+
+The crash guard system prevents these segfaults and logs diagnostic information when they would have occurred.
+
+The crash guard is part of the runtime workarounds documented in [TODO.md — Monkeypatches and Workarounds](TODO.md#monkeypatches-and-workarounds).
+
+---
+
+## The Problem
+
+wxPython segfaults from deleted C++ objects are:
+- **Intermittent** — depend on timing between event dispatch, widget destruction, and deferred callbacks
+- **Untraceable at C++ level** — Python's `faulthandler` can only show frames up to `wx.MainLoop`, not the actual C++ crash site
+- **Silent** — without guards, the app simply dies with no useful information
+
+Common triggers:
+- `wx.CallAfter(widget.method)` where the widget is destroyed before the callback runs
+- Event handlers firing on widgets that are being or have been closed (AUI panes, dialogs)
+- `pub.subscribe` handlers referencing destroyed widgets
+- HyperTreeList operations (`GetItemPyData`, `GetSelections`) on deleted tree items
+
+---
+
+## Guards
+
+### 1. wx.CallAfter Wrapper (`monkeypatches.py`)
+
+A global monkey-patch replaces `wx.CallAfter` with a guarded version. When the callback is a bound method on a `wx.Object`:
+
+- The scheduling call stack is captured at `CallAfter` time
+- Before executing the callback, `bool(obj)` is checked — returns `False` if the C++ object is deleted
+- If the object is dead, the call is skipped and a `[CRASH_GUARD]` message is logged with the original scheduling traceback
+- `RuntimeError` from deleted C++ objects is also caught as a fallback
+
+Non-wx callbacks pass through with zero overhead.
+
+### 2. OnExceptionInMainLoop (`application.py` — `wxApp`)
+
+Catches any unhandled Python exception that occurs during wx event dispatch. Logs the full traceback with a `[CRASH_GUARD]` prefix and returns `True` to continue running. Without this, some exceptions during event handling are silently swallowed by wx.
+
+### 3. faulthandler (`taskcoach.py`)
+
+Enabled at startup with `all_threads=True`. Produces Python-level stack traces on hard crashes (SIGSEGV, SIGBUS). This is the last line of defense — if a segfault gets past the guards, faulthandler at least shows which Python code was executing.
+
+---
+
+## Log Output
+
+All guard messages use the `CRASH_GUARD` prefix via `log_step()` (see `taskcoachlib/meta/debug.py`).
+
+### Blocked CallAfter to destroyed object:
+```
+[16:30:45.123] [CRASH_GUARD] Blocked CallAfter to destroyed object: TreeListCtrl.DoResize
+[16:30:45.123] [CRASH_GUARD] Originally scheduled from:
+[16:30:45.123] [CRASH_GUARD]   File "taskcoachlib/widgets/autowidth.py", line 64, in onResize
+[16:30:45.123] [CRASH_GUARD]     wx.CallAfter(self.DoResize)
+```
+
+### RuntimeError caught during callback:
+```
+[16:30:45.125] [CRASH_GUARD] RuntimeError calling TreeListCtrl.DoResize: wrapped C/C++ object has been deleted
+[16:30:45.125] [CRASH_GUARD] Originally scheduled from:
+[16:30:45.125] [CRASH_GUARD]   File "taskcoachlib/widgets/autowidth.py", line 64, in onResize
+[16:30:45.125] [CRASH_GUARD]     wx.CallAfter(self.DoResize)
+```
+
+### Unhandled exception in event loop:
+```
+[16:30:45.130] [CRASH_GUARD] Unhandled exception in MainLoop: Traceback (most recent call last):
+  File "...", line ..., in ...
+RuntimeError: wrapped C/C++ object of type TreeListMainWindow has been deleted
+```
+
+---
+
+## Debugging a Segfault
+
+If a segfault still occurs (the guards don't catch everything — direct event handlers on dead widgets bypass `CallAfter`):
+
+### Using GDB for C++ backtraces
+```bash
+gdb -ex run -ex "thread apply all bt" -ex quit --args python3 taskcoach.py
+```
+
+This shows the actual C++ frames that `faulthandler` cannot.
+
+### Filtering guard logs
+```bash
+python3 taskcoach.py 2>&1 | grep CRASH_GUARD
+```
+
+If `CRASH_GUARD` messages appear during normal use, they indicate code paths that would have segfaulted without the guards. These should be investigated and fixed (typically by adding proper cleanup or removing unnecessary `CallAfter` usage).
+
+---
+
+## Key Files
+
+| File | Component |
+|------|-----------|
+| `taskcoachlib/workarounds/monkeypatches.py` | `wx.CallAfter` wrapper |
+| `taskcoachlib/application/application.py` | `wxApp.OnExceptionInMainLoop` |
+| `taskcoach.py` | `faulthandler.enable()` setup |
+| `taskcoachlib/meta/debug.py` | `log_step()` utility for ad-hoc debugging |

--- a/docs/TASK_STATUS.md
+++ b/docs/TASK_STATUS.md
@@ -1018,9 +1018,9 @@ Tasks have `derivedXxx()` / `derivedXxxSource()` and `effectiveXxx()` / `effecti
 ### Notes, Efforts, and Attachments
 
 **Notes:**
-- Inherit appearance from parent notes only (do NOT inherit from attached task)
+- Inherit appearance from categories (sorted by stylePriority) then parent notes
 - SSOT `effectiveXxx()` methods follow same pattern as Tasks/Categories
-- Fewer sources than Tasks: only parent note or own override (no categories, no status)
+- Sources: categories → parent note → default icon (no status)
 - Appearance tab shows Derived/Override/Effective sections
 
 **Efforts:**

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -153,6 +153,8 @@ This section documents workarounds and patches in the codebase that should be re
 |----------|------------|---------|--------------|
 | `taskcoach.py:43-71` | `_set_wayland_app_id()` | Sets GLib program name for Wayland app ID matching | Required for proper Wayland dock integration |
 | `taskcoach.py:73-74` | `import workarounds.monkeypatches` | Runtime patches for hypertreelist, inspect.getargspec, Window.SetSize | Required for wxPython compatibility |
+| `monkeypatches.py` | `wx.CallAfter` crash guard | Prevents segfaults from callbacks to destroyed C++ objects | Required — see [CRASH_GUARD.md](CRASH_GUARD.md) |
+| `application.py` | `OnExceptionInMainLoop` | Catches unhandled exceptions during wx event dispatch | Required — see [CRASH_GUARD.md](CRASH_GUARD.md) |
 
 ### Python 3.10 Support (Ubuntu 22.04)
 

--- a/taskcoach.py
+++ b/taskcoach.py
@@ -26,7 +26,12 @@ import faulthandler
 # This provides detailed Python stack traces on crashes (SIGSEGV, SIGBUS, etc.)
 # which are essential for diagnosing future issues. Without it, crashes only show
 # "Fatal Python error: Segmentation fault" with no actionable information.
-faulthandler.enable()
+# NOTE: On Windows, only enable if stderr is redirected to a file,
+# as faulthandler writing to console during shutdown can cause issues.
+if sys.platform != 'win32' or not sys.stderr.isatty():
+    faulthandler.enable(all_threads=True)
+else:
+    faulthandler.enable()
 
 # Fix DLL loading on Windows with Python embeddable package
 # The embeddable package doesn't process .pth files by default.
@@ -60,16 +65,6 @@ if sys.platform == 'win32':
 #
 # from taskcoachlib.tee import init_tee
 # init_tee()
-
-import faulthandler
-
-# Enable faulthandler to get Python tracebacks on segfaults
-# This helps debug crashes in wxPython/GTK C++ code by showing which
-# Python code was executing when the crash occurred
-# NOTE: On Windows, only enable if stderr is redirected to a file,
-# as faulthandler writing to console during shutdown can cause issues
-if sys.platform != 'win32' or not sys.stderr.isatty():
-    faulthandler.enable(all_threads=True)
 
 
 def _set_wayland_app_id():

--- a/taskcoachlib/application/application.py
+++ b/taskcoachlib/application/application.py
@@ -428,6 +428,20 @@ class wxApp(wx.App):
         if event is not None:
             event.Skip()
 
+    def OnExceptionInMainLoop(self):
+        """Called by wx when an unhandled exception occurs during event dispatch.
+
+        Logs the full traceback to stderr so crashes during event handling
+        are visible instead of being silently swallowed. Returns True to
+        continue running (the event that caused the error is skipped).
+        See docs/CRASH_GUARD.md for details.
+        """
+        import traceback
+        from taskcoachlib.meta.debug import log_step
+        log_step("Unhandled exception in MainLoop:",
+                 traceback.format_exc(), prefix="CRASH_GUARD")
+        return True
+
 
 class Application(object, metaclass=patterns.Singleton):
     """

--- a/taskcoachlib/command/effortCommands.py
+++ b/taskcoachlib/command/effortCommands.py
@@ -228,7 +228,7 @@ class EditEffortDurationCommand(base.BaseCommand):
     def __init__(self, *args, **kwargs):
         self.__newDuration = kwargs.pop("newValue")
         super().__init__(*args, **kwargs)
-        self.__oldDurations = [item.duration() for item in self.items]
+        self.__oldDurations = [item.timeSpent() for item in self.items]
 
     def do_command(self):
         super().do_command()

--- a/taskcoachlib/domain/base/appearance.py
+++ b/taskcoachlib/domain/base/appearance.py
@@ -162,6 +162,14 @@ DERIVED_SETTERS = {
 }
 
 
+# Default icons for types without status-based icons (Task gets icons from status)
+TYPE_DEFAULT_ICONS = {
+    'Category': 'folder_blue_icon',
+    'Note': 'note_icon',
+    'Attachment': 'paperclip_icon',
+}
+
+
 def _getObjectType(obj):
     class_name = obj.__class__.__name__
     if class_name == 'Task':
@@ -181,14 +189,52 @@ def _isSystemThemeValue(value):
     return False
 
 
+def _getFromCategories(object_ref, effective_getter):
+    """Get a style value from the object's categories, sorted by stylePriority.
+
+    Returns (value, source) from the highest-priority category that has
+    a non-system-theme value, or (None, None) if no category provides one.
+    """
+    if not hasattr(object_ref, 'categories'):
+        return None, None
+    categories = list(object_ref.categories())
+    categories.sort(
+        key=lambda c: getattr(c, 'stylePriority', lambda: 0)(),
+        reverse=True,
+    )
+    for cat in categories:
+        getter = getattr(cat, effective_getter, None)
+        if getter:
+            cat_value = getter()
+            if cat_value and not _isSystemThemeValue(cat_value):
+                return cat_value, f"[Category] {cat.subject()}"
+    return None, None
+
+
+def _getFromParent(object_ref, obj_type, effective_getter):
+    """Get a style value from the object's parent.
+
+    Returns (value, source) or (None, None).
+    """
+    if not object_ref.parent():
+        return None, None
+    parent = object_ref.parent()
+    getter = getattr(parent, effective_getter, None)
+    if getter:
+        parent_value = getter()
+        if parent_value and not _isSystemThemeValue(parent_value):
+            return parent_value, f"[{obj_type}] {parent.subject()}"
+    return None, None
+
+
 def computeDerived(object_ref, field_type):
     """Compute derived value from sources and write to SSOT.
 
     Sources by object type:
-    - Category: parent.effectiveXxx()
     - Task: categories (sorted by stylePriority) → parent → status
-    - Note: parent.effectiveXxx()
-    - Attachment: (none - always empty)
+    - Note: categories (sorted by stylePriority) → parent
+    - Category: parent only
+    - Attachment: (none - always uses default icon)
 
     OUTPUTS: Calls object_ref.setDerivedXxx(value, source)
     """
@@ -200,29 +246,14 @@ def computeDerived(object_ref, field_type):
 
     if obj_type == 'Task':
         # Task sources: categories → parent → status
-        # Check categories first (sorted by stylePriority, higher = first)
-        if hasattr(object_ref, 'categories'):
-            categories = list(object_ref.categories())
-            # Sort by stylePriority descending (higher priority first)
-            categories.sort(key=lambda c: getattr(c, 'stylePriority', lambda: 0)(), reverse=True)
-            for cat in categories:
-                getter = getattr(cat, effective_getter, None)
-                if getter:
-                    cat_value = getter()
-                    if cat_value and not _isSystemThemeValue(cat_value):
-                        value = cat_value
-                        source = f"[Category] {cat.subject()}"
-                        break
+        value, src = _getFromCategories(object_ref, effective_getter)
+        if src:
+            source = src
 
-        # Check parent task if no category value
-        if value is None and object_ref.parent():
-            parent = object_ref.parent()
-            getter = getattr(parent, effective_getter, None)
-            if getter:
-                parent_value = getter()
-                if parent_value and not _isSystemThemeValue(parent_value):
-                    value = parent_value
-                    source = f"[Task] {parent.subject()}"
+        if value is None:
+            value, src = _getFromParent(object_ref, obj_type, effective_getter)
+            if src:
+                source = src
 
         # Fall back to status
         if value is None:
@@ -235,18 +266,31 @@ def computeDerived(object_ref, field_type):
                 else:
                     source = "[Status]"
 
-    elif obj_type in ('Category', 'Note'):
-        # Category/Note sources: parent only
-        if object_ref.parent():
-            parent = object_ref.parent()
-            getter = getattr(parent, effective_getter, None)
-            if getter:
-                parent_value = getter()
-                if parent_value and not _isSystemThemeValue(parent_value):
-                    value = parent_value
-                    source = f"[{obj_type}] {parent.subject()}"
+    elif obj_type == 'Note':
+        # Note sources: categories → parent
+        value, src = _getFromCategories(object_ref, effective_getter)
+        if src:
+            source = src
+
+        if value is None:
+            value, src = _getFromParent(object_ref, obj_type, effective_getter)
+            if src:
+                source = src
+
+    elif obj_type == 'Category':
+        # Category sources: parent only
+        value, src = _getFromParent(object_ref, obj_type, effective_getter)
+        if src:
+            source = src
 
     # Attachment: no sources, value stays None
+
+    # Default icon fallback for types without status (Category, Note, Attachment)
+    if field_type == 'icon' and value is None:
+        default_icon = TYPE_DEFAULT_ICONS.get(obj_type)
+        if default_icon:
+            value = default_icon
+            source = SYSTEM_THEME_SOURCE
 
     # Write via object setter
     setter_name = DERIVED_SETTERS[field_type]
@@ -338,8 +382,9 @@ class ComputeStyles:
         if not self._taskFile:
             return
 
-        # Process in order: categories, tasks, notes, attachments
-        # Categories first so tasks can read their effective values
+        # Process in order: categories, tasks, global notes
+        # Categories first so tasks can read their effective values.
+        # _computeForObject handles owned notes and attachments recursively.
         for category in self._taskFile.categories():
             self._computeForObject(category)
 
@@ -349,23 +394,23 @@ class ComputeStyles:
         for note in self._taskFile.notes():
             self._computeForObject(note)
 
-        # Attachments from tasks and notes
-        for task in self._taskFile.tasks():
-            if hasattr(task, 'attachments'):
-                for attachment in task.attachments():
-                    self._computeForObject(attachment)
-        for note in self._taskFile.notes():
-            if hasattr(note, 'attachments'):
-                for attachment in note.attachments():
-                    self._computeForObject(attachment)
-
     def _computeForObject(self, obj):
-        """Per-object processing: status (tasks only) → derived → effective."""
+        """Per-object processing: status (tasks only) → derived → effective.
+
+        Also processes owned notes and attachments, which in turn process
+        their own owned objects (attachments own notes, notes own attachments).
+        """
         if hasattr(obj, 'computeStoredStatus'):
             obj.computeStoredStatus()
         for field_type in FIELD_TYPES:
             computeDerived(obj, field_type)
             computeEffective(obj, field_type)
+        if hasattr(obj, 'notes'):
+            for n in obj.notes(recursive=True):
+                self._computeForObject(n)
+        if hasattr(obj, 'attachments'):
+            for a in obj.attachments():
+                self._computeForObject(a)
 
     def shutdown(self):
         """Cleanup subscriptions."""

--- a/taskcoachlib/domain/effort/base.py
+++ b/taskcoachlib/domain/effort/base.py
@@ -87,7 +87,7 @@ class BaseEffort(object):
     def sendDurationChangedMessage(self):
         pub.sendMessage(
             self.durationChangedEventType(),
-            newValue=self.duration(),
+            newValue=self.timeSpent(),
             sender=self,
         )
 

--- a/taskcoachlib/domain/effort/composite.py
+++ b/taskcoachlib/domain/effort/composite.py
@@ -57,13 +57,13 @@ class BaseCompositeEffort(base.BaseEffort):  # pylint: disable=W0223
             return duration.round(seconds=rounding, alwaysUp=roundUp)
         return duration
 
-    def duration(
+    def totalTimeSpent(
         self, recursive=False, rounding=0, roundUp=False, consolidate=False
     ):
         if consolidate:
             totalEffort = sum(
                 (
-                    self.__doRound(effort.duration(), 0, False)
+                    self.__doRound(effort.timeSpent(), 0, False)
                     for effort in self._getEfforts(recursive)
                 ),
                 date.TimeDelta(),
@@ -71,7 +71,7 @@ class BaseCompositeEffort(base.BaseEffort):  # pylint: disable=W0223
             return totalEffort.round(seconds=rounding, alwaysUp=roundUp)
         return sum(
             (
-                self.__doRound(effort.duration(), rounding, roundUp)
+                self.__doRound(effort.timeSpent(), rounding, roundUp)
                 for effort in self._getEfforts(recursive)
             ),
             date.TimeDelta(),
@@ -80,16 +80,16 @@ class BaseCompositeEffort(base.BaseEffort):  # pylint: disable=W0223
     def isBeingTracked(self, recursive=False):  # pylint: disable=W0613
         return any(effort.isBeingTracked() for effort in self._getEfforts())
 
-    def durationDay(
+    def totalTimeSpentForDay(
         self, dayOffset, rounding=0, roundUp=False, consolidate=False
     ):
-        """Return the duration of this composite effort on a specific day."""
+        """Return the total time spent of grouped efforts on a specific day."""
         startOfDay = self.getStart() + date.TimeDelta(days=dayOffset)
         endOfDay = self.getStart() + date.TimeDelta(days=dayOffset + 1)
         if consolidate:
             totalEffort = sum(
                 (
-                    self.__doRound(effort.duration(), 0, false)
+                    self.__doRound(effort.timeSpent(), 0, false)
                     for effort in self._getEfforts(recursive=False)
                     if startOfDay <= effort.getStart() <= endOfDay
                 ),
@@ -98,7 +98,7 @@ class BaseCompositeEffort(base.BaseEffort):  # pylint: disable=W0223
             return self.__doRound(totalEffort, rounding, roundUp)
         return sum(
             (
-                self.__doRound(effort.duration(), rounding, roundUp)
+                self.__doRound(effort.timeSpent(), rounding, roundUp)
                 for effort in self._getEfforts(recursive=False)
                 if startOfDay <= effort.getStart() <= endOfDay
             ),

--- a/taskcoachlib/domain/effort/effort.py
+++ b/taskcoachlib/domain/effort/effort.py
@@ -176,9 +176,18 @@ class Effort(baseeffort.BaseEffort, base.Object):
             sender=self,
         )
 
+    def timeSpent(self, now=date.DateTime.now):
+        """Always compute elapsed time from start/stop."""
+        stop = self._stop.get()
+        if stop is not None:
+            return stop - self._start.get()
+        return now() - self._start.get()
+
     def duration(self, now=date.DateTime.now):
-        cached = self.__duration.get()
-        return (now() - self._start.get()) if cached is None else cached
+        """DEPRECATED: use timeSpent() instead."""
+        from taskcoachlib.meta.debug import log_step
+        log_step("DEPRECATED effort.duration() called, use timeSpent()", prefix="DEPRECATION")
+        return
 
     def setDuration(self, newDuration, event=None):
         """Setter — normalizes and delegates to Attribute."""
@@ -241,7 +250,7 @@ class Effort(baseeffort.BaseEffort, base.Object):
     def revenue(self):
         task = self._task() if self._task else None
         hourlyFee = task.hourlyFee() if task else 0
-        return self.duration().hours() * hourlyFee
+        return self.timeSpent().hours() * hourlyFee
 
     @staticmethod
     def periodSortFunction(**kwargs):

--- a/taskcoachlib/domain/task/task.py
+++ b/taskcoachlib/domain/task/task.py
@@ -919,7 +919,7 @@ class Task(
 
     def timeSpent(self, recursive=False):
         return sum(
-            (effort.duration() for effort in self.efforts(recursive)),
+            (effort.timeSpent() for effort in self.efforts(recursive)),
             date.TimeDelta(),
         )
 

--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -229,7 +229,7 @@ class SubjectPage(Page):
         self.addEntry(
             _("Subject"),
             self._subjectEntry,
-            flags=[wx.ALIGN_RIGHT, wx.EXPAND],
+            flags=[None, wx.ALL | wx.EXPAND],
         )
 
     def addDescriptionEntry(self):
@@ -260,7 +260,7 @@ class SubjectPage(Page):
             _("Description"),
             self._descriptionEntry,
             growable=True,
-            flags=[wx.ALIGN_TOP | wx.ALIGN_RIGHT, wx.EXPAND],
+            flags=[None, wx.ALL | wx.EXPAND],
         )
 
     def addCreationDateTimeEntry(self):
@@ -274,21 +274,13 @@ class SubjectPage(Page):
             creation_text += " - %s" % render.dateTime(
                 max_creation_datetime, humanReadable=True
             )
-        self.addEntry(
-            _("Creation date"),
-            creation_text,
-            flags=[wx.ALIGN_RIGHT, wx.EXPAND],
-        )
+        self.addEntry(_("Creation date"), creation_text)
 
     def addModificationDateTimeEntry(self):
         self._modificationTextEntry = wx.StaticText(
             self, label=self.__modification_text()
         )
-        self.addEntry(
-            _("Modification date"),
-            self._modificationTextEntry,
-            flags=[wx.ALIGN_RIGHT, wx.EXPAND],
-        )
+        self.addEntry(_("Modification date"), self._modificationTextEntry)
         for eventType in self.items[0].modificationEventTypes():
             if eventType.startswith("pubsub"):
                 pub.subscribe(self.onAttributeChanged, eventType)
@@ -369,11 +361,7 @@ class TaskSubjectPage(SubjectPage):
             wx.EVT_SPINCTRL,
             self.items[0].priorityChangedEventType(),
         )
-        self.addEntry(
-            _("Priority"),
-            self._priorityEntry,
-            flags=[wx.ALIGN_RIGHT, wx.EXPAND],
-        )
+        self.addEntry(_("Priority"), self._priorityEntry)
 
     def entries(self):
         entries = super().entries()
@@ -399,10 +387,16 @@ class CategorySubjectPage(SubjectPage):
             if len(self.items) == 1
             else False
         )
-        self._exclusiveSubcategoriesCheckBox = wx.CheckBox(
-            self, label=_("Mutually exclusive")
-        )
+        panel = wx.Panel(self)
+        panelSizer = wx.BoxSizer(wx.HORIZONTAL)
+        self._exclusiveSubcategoriesCheckBox = wx.CheckBox(panel)
         self._exclusiveSubcategoriesCheckBox.SetValue(currentExclusivity)
+        panelSizer.Add(self._exclusiveSubcategoriesCheckBox, 0, wx.ALIGN_CENTER_VERTICAL)
+        hintText = wx.StaticText(panel, label=_("Subcategories are mutually exclusive"))
+        hintText.SetForegroundColour(
+            wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
+        panelSizer.Add(hintText, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
+        panel.SetSizer(panelSizer)
         self._exclusiveSubcategoriesSync = attributesync.AttributeSync(
             "hasExclusiveSubcategories",
             self._exclusiveSubcategoriesCheckBox,
@@ -412,11 +406,7 @@ class CategorySubjectPage(SubjectPage):
             wx.EVT_CHECKBOX,
             self.items[0].exclusiveSubcategoriesChangedEventType(),
         )
-        self.addEntry(
-            _("Subcategories"),
-            self._exclusiveSubcategoriesCheckBox,
-            flags=[None, wx.ALL],
-        )
+        self.addEntry(_("Mutually exclusive"), panel)
 
     def addStylePriorityEntry(self):
         # pylint: disable=W0201
@@ -435,11 +425,7 @@ class CategorySubjectPage(SubjectPage):
             wx.EVT_SPINCTRL,
             self.items[0].stylePriorityChangedEventType(),
         )
-        self.addEntry(
-            _("Style priority"),
-            self._stylePriorityEntry,
-            flags=[wx.ALIGN_RIGHT, wx.EXPAND],
-        )
+        self.addEntry(_("Style priority"), self._stylePriorityEntry)
 
 
 class AttachmentSubjectPage(SubjectPage):
@@ -515,7 +501,7 @@ class AttachmentSubjectPage(SubjectPage):
         type_label = wx.StaticText(panel, label=type_name)
         sizer.Add(type_label, 0, wx.ALIGN_CENTER_VERTICAL)
         panel.SetSizer(sizer)
-        self.addEntry(_("Type"), panel, flags=[wx.ALIGN_RIGHT, wx.ALIGN_CENTER_VERTICAL])
+        self.addEntry(_("Type"), panel, flags=[None, wx.ALIGN_CENTER_VERTICAL])
 
     def addLocationEntry(self):
         panel = wx.Panel(self)
@@ -544,7 +530,7 @@ class AttachmentSubjectPage(SubjectPage):
             sizer.Add(button, 0, wx.LEFT, 5)
             button.Bind(wx.EVT_BUTTON, self.onSelectLocation)
         panel.SetSizer(sizer)
-        self.addEntry(_("Location"), panel, flags=[wx.ALIGN_RIGHT, wx.EXPAND])
+        self.addEntry(_("Location"), panel, flags=[None, wx.EXPAND])
 
     def onSelectLocation(self, event):  # pylint: disable=W0613
         base_path = self._settings.get("file", "lastattachmentpath")
@@ -1104,7 +1090,7 @@ class TaskAppearancePage(ScrolledPage):
         super().close()
 
 
-class DatesPage(Page):
+class DatesPage(ScrolledPage):
     pageName = "dates"
     pageTitle = _("Dates")
     pageIcon = "calendar_icon"
@@ -2017,7 +2003,7 @@ class ProgressPage(Page):
         self.addEntry(
             _("Percentage complete"),
             self._percentageCompleteEntry,
-            flags=[wx.ALIGN_RIGHT, wx.EXPAND],
+            flags=[None, wx.EXPAND],
         )
 
     @staticmethod
@@ -2056,7 +2042,7 @@ class ProgressPage(Page):
         self.addEntry(
             _("Mark task completed when all children are completed?"),
             self._shouldMarkCompletedEntry,
-            flags=[wx.ALIGN_RIGHT, wx.EXPAND],
+            flags=[None, wx.EXPAND],
         )
 
     def entries(self):
@@ -2066,7 +2052,7 @@ class ProgressPage(Page):
         )
 
 
-class BudgetPage(Page):
+class BudgetPage(ScrolledPage):
     pageName = "budget"
     pageTitle = _("Budget")
     pageIcon = "calculator_icon"
@@ -2177,7 +2163,7 @@ class BudgetPage(Page):
         self.addEntry(
             _("Hourly fee"),
             self._hourlyFeeEntry,
-            flags=[wx.ALIGN_RIGHT, wx.ALL],
+            flags=[None, wx.ALL],
         )
 
     def addFixedFeeEntry(self):
@@ -2196,7 +2182,7 @@ class BudgetPage(Page):
             self.items[0].fixedFeeChangedEventType(),
         )
         self.addEntry(
-            _("Fixed fee"), self._fixedFeeEntry, flags=[wx.ALIGN_RIGHT, wx.ALL]
+            _("Fixed fee"), self._fixedFeeEntry, flags=[None, wx.ALL]
         )
 
     def addRevenueEntry(self):
@@ -2206,7 +2192,7 @@ class BudgetPage(Page):
             self, revenue, readonly=True
         )  # pylint: disable=W0201
         self.addEntry(
-            _("Revenue"), self._revenueEntry, flags=[wx.ALIGN_RIGHT, wx.ALL]
+            _("Revenue"), self._revenueEntry, flags=[None, wx.ALL]
         )
         pub.subscribe(
             self.onRevenueChanged, self.items[0].revenueChangedEventType()
@@ -2676,7 +2662,7 @@ class PrerequisitesPage(PageWithViewer):
         return dict()
 
 
-class PathPage(Page):
+class PathPage(ScrolledPage):
     """Page that displays the hierarchical path (nesting) of the current object.
 
     The path is built only when the tab is selected (lazy loading).
@@ -2764,7 +2750,7 @@ class PathPage(Page):
                 pass  # Window destroyed
 
     def _rebuildPathDisplay(self):
-        """Rebuild the path display."""
+        """Rebuild the path display with all sections."""
         if not self._pathPanel or not self._pathSizer:
             return
         try:
@@ -2778,7 +2764,7 @@ class PathPage(Page):
         # Clear existing content
         self._pathSizer.Clear(True)
 
-        # Only show path for single item
+        # Only show sections for single item
         if len(self.items) != 1:
             label = wx.StaticText(self._pathPanel,
                                   label=_("Path is only shown for single items"))
@@ -2787,16 +2773,40 @@ class PathPage(Page):
             return
 
         item = self.items[0]
+
+        # Section: Path
+        self._buildPathSection(item)
+
+        # Section: Categories (Tasks and Notes only)
+        from taskcoachlib.domain import task as task_module, note
+        if isinstance(item, (task_module.Task, note.Note)):
+            self._buildCategoriesSection(item)
+
+        # Section: Prerequisites (Tasks only)
+        if isinstance(item, task_module.Task):
+            self._buildPrerequisitesSection(item)
+
+        # Section: Dependants (Tasks only)
+        if isinstance(item, task_module.Task):
+            self._buildDependantsSection(item)
+
+        self._pathPanel.Layout()
+        self.Layout()
+        self.SetupScrolling(scroll_x=True, scroll_y=True)
+
+    # -- Section builders --------------------------------------------------
+
+    def _buildPathSection(self, item):
+        """Build the Path section: header + hierarchical path display."""
+        self._addSectionHeader(_("Path"))
         path_objects = self._buildPathObjects(item)
 
         if not path_objects:
             label = wx.StaticText(self._pathPanel,
                                   label=_("This item has no parent objects"))
-            self._pathSizer.Add(label, 0, wx.EXPAND)
-            self._pathPanel.Layout()
+            self._pathSizer.Add(label, 0, wx.EXPAND | wx.LEFT, 5)
             return
 
-        # Display path from root to current item
         for index, obj in enumerate(path_objects):
             obj_type, icon_name = self._getTypeInfo(obj)
             subject = obj.subject()
@@ -2808,7 +2818,6 @@ class PathPage(Page):
             if index > 0:
                 indent = wx.Panel(item_panel, size=(index * 20, 1))
                 item_sizer.Add(indent, 0)
-                # Add arrow icon to show hierarchy
                 arrow_bitmap = wx.ArtProvider.GetBitmap(
                     "arrow_down_right", wx.ART_MENU, (16, 16)
                 )
@@ -2822,10 +2831,8 @@ class PathPage(Page):
                 if bitmap.IsOk():
                     icon = wx.StaticBitmap(item_panel, bitmap=bitmap)
                     item_sizer.Add(icon, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
-                    # Subscribe this icon to the object's effective icon changes
                     self._subscribeIconToObject(obj, icon)
 
-            # Add type and subject label using [Type] Subject format
             label_text = "[%s] %s" % (obj_type, subject)
             label = wx.StaticText(item_panel, label=label_text)
 
@@ -2839,8 +2846,86 @@ class PathPage(Page):
             item_panel.SetSizer(item_sizer)
             self._pathSizer.Add(item_panel, 0, wx.EXPAND | wx.ALL, 2)
 
-        self._pathPanel.Layout()
-        self.Layout()
+    def _buildCategoriesSection(self, item):
+        """Build the Categories section: separator, header, category list."""
+        self._addSectionSeparator()
+        self._addSectionHeader(_("Categories"))
+        categories = sorted(item.categories(), key=lambda c: c.subject())
+        if not categories:
+            self._addNoneLabel()
+            return
+        for cat in categories:
+            # Build breadcrumb path: "Parent > Child > Grandchild"
+            ancestors = cat.ancestors()
+            if ancestors:
+                display = " > ".join(a.subject() for a in ancestors)
+                display += " > " + cat.subject()
+            else:
+                display = cat.subject()
+            self._addItemRow(cat, display_text=display)
+
+    def _buildPrerequisitesSection(self, item):
+        """Build the Prerequisites section: separator, header, task list."""
+        self._addSectionSeparator()
+        self._addSectionHeader(_("Prerequisites"))
+        prerequisites = sorted(item.prerequisites(), key=lambda t: t.subject())
+        if not prerequisites:
+            self._addNoneLabel()
+            return
+        for prereq in prerequisites:
+            self._addItemRow(prereq)
+
+    def _buildDependantsSection(self, item):
+        """Build the Dependants section: separator, header, task list."""
+        self._addSectionSeparator()
+        self._addSectionHeader(_("Dependants"))
+        dependants = sorted(item.dependencies(), key=lambda t: t.subject())
+        if not dependants:
+            self._addNoneLabel()
+            return
+        for dep in dependants:
+            self._addItemRow(dep)
+
+    # -- Shared helpers ----------------------------------------------------
+
+    def _addSectionSeparator(self):
+        """Add a horizontal line separator to the path panel."""
+        line = wx.StaticLine(self._pathPanel)
+        self._pathSizer.Add(line, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 8)
+
+    def _addSectionHeader(self, title):
+        """Add a bold section header to the path panel."""
+        header = wx.StaticText(self._pathPanel, label=title)
+        font = header.GetFont()
+        font.SetWeight(wx.FONTWEIGHT_BOLD)
+        header.SetFont(font)
+        self._pathSizer.Add(header, 0, wx.EXPAND | wx.BOTTOM, 4)
+
+    def _addNoneLabel(self):
+        """Add a '(none)' label for empty sections."""
+        label = wx.StaticText(self._pathPanel, label=_("(none)"))
+        self._pathSizer.Add(label, 0, wx.LEFT, 20)
+
+    def _addItemRow(self, obj, display_text=None):
+        """Add an item row with icon and label to the path panel."""
+        obj_type, icon_name = self._getTypeInfo(obj)
+        item_panel = wx.Panel(self._pathPanel)
+        item_sizer = wx.BoxSizer(wx.HORIZONTAL)
+
+        # Add type icon if available
+        if icon_name:
+            bitmap = wx.ArtProvider.GetBitmap(icon_name, wx.ART_MENU, (16, 16))
+            if bitmap.IsOk():
+                icon = wx.StaticBitmap(item_panel, bitmap=bitmap)
+                item_sizer.Add(icon, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+                self._subscribeIconToObject(obj, icon)
+
+        label_text = display_text or ("[%s] %s" % (obj_type, obj.subject()))
+        label = wx.StaticText(item_panel, label=label_text)
+        item_sizer.Add(label, 1, wx.ALIGN_CENTER_VERTICAL)
+
+        item_panel.SetSizer(item_sizer)
+        self._pathSizer.Add(item_panel, 0, wx.EXPAND | wx.ALL, 2)
 
     def _subscribeIconToObject(self, obj, bitmap):
         """Register a StaticBitmap for updates when object's effective icon changes."""
@@ -2925,20 +3010,18 @@ class PathPage(Page):
         super().close()
 
     def _getTypeInfo(self, obj):
-        """Get the type name and icon for an object."""
+        """Get the type name and effective icon for an object."""
         from taskcoachlib.domain import task as task_module
         from taskcoachlib.domain import category, note, attachment, effort
 
         if isinstance(obj, task_module.Task):
-            return (_("Task"), obj.effectiveIcon() or "led_blue_icon")
+            return (_("Task"), obj.effectiveIcon())
         elif isinstance(obj, category.Category):
-            return (_("Category"), obj.effectiveIcon() or "folder_blue_icon")
+            return (_("Category"), obj.effectiveIcon())
         elif isinstance(obj, note.Note):
-            # Notes use icon(recursive=True) - no effectiveIcon() SSOT
-            return (_("Note"), obj.icon(recursive=True) or "note_icon")
+            return (_("Note"), obj.effectiveIcon())
         elif isinstance(obj, attachment.Attachment):
-            # Attachments have no inheritance
-            return (_("Attachment"), obj.icon() or "paperclip_icon")
+            return (_("Attachment"), obj.effectiveIcon())
         elif isinstance(obj, effort.Effort):
             return (_("Effort"), "clock_icon")
         else:

--- a/taskcoachlib/gui/menu.py
+++ b/taskcoachlib/gui/menu.py
@@ -1219,14 +1219,7 @@ class ColumnPopupMenu(ColumnPopupMenuMixin, Menu):
 
     def __init__(self, window):
         super().__init__(window)
-        wx.CallAfter(self.appendUICommands, *self.getUICommands())
-
-    def appendUICommands(self, *args, **kwargs):
-        # Prepare for PyDeadObjectError since we're called from wx.CallAfter
-        try:
-            super().appendUICommands(*args, **kwargs)
-        except RuntimeError:
-            pass
+        self.appendUICommands(*self.getUICommands())
 
 
 class EffortViewerColumnPopupMenu(

--- a/taskcoachlib/gui/uicommand/uicommand.py
+++ b/taskcoachlib/gui/uicommand/uicommand.py
@@ -1331,9 +1331,6 @@ class ViewExpandAll(mixin_uicommand.NeedsTreeViewerMixin, ViewerCommand):
             **kwargs
         )
 
-    def enabled(self, event):
-        return super().enabled(event) and self.viewer.isAnyItemExpandable()
-
     def doCommand(self, event):
         self.viewer.expandAll()
 
@@ -1347,9 +1344,6 @@ class ViewCollapseAll(mixin_uicommand.NeedsTreeViewerMixin, ViewerCommand):
             *args,
             **kwargs
         )
-
-    def enabled(self, event):
-        return super().enabled(event) and self.viewer.isAnyItemCollapsable()
 
     def doCommand(self, event):
         self.viewer.collapseAll()

--- a/taskcoachlib/gui/viewer/base.py
+++ b/taskcoachlib/gui/viewer/base.py
@@ -837,11 +837,6 @@ class TreeViewer(Viewer):  # pylint: disable=W0223
             item.expand(False, context=self.settingsSection(), notify=False)
         self.refresh()
 
-    def isAnyItemExpandable(self):
-        return self.widget.isAnyItemExpandable()
-
-    def isAnyItemCollapsable(self):
-        return self.widget.isAnyItemCollapsable()
 
     def createModeToolBarUICommands(self):
         return super().createModeToolBarUICommands() + (

--- a/taskcoachlib/gui/viewer/effort.py
+++ b/taskcoachlib/gui/viewer/effort.py
@@ -668,7 +668,7 @@ class EffortViewer(
     def __sumTimeSpent(self, efforts):
         td = date.TimeDelta()
         for effort in efforts:
-            td = td + effort.duration()
+            td = td + effort.timeSpent()
 
         sumTimeSpent = render.timeSpent(
             td,
@@ -771,54 +771,53 @@ class EffortViewer(
         return anEffort.getStop() == previousEffort.getStop()
 
     def __renderTimeSpent(self, anEffort):
-        """Return a rendered version of the effort duration."""
-        kwargs = dict()
+        """Return a rendered version of the effort time spent."""
         if isinstance(anEffort, effort.BaseCompositeEffort):
-            kwargs["rounding"] = self.__round_precision()
-            kwargs["roundUp"] = self.__always_round_up()
-        duration = anEffort.duration(**kwargs)
+            timeSpent = anEffort.totalTimeSpent(
+                rounding=self.__round_precision(),
+                roundUp=self.__always_round_up(),
+            )
+        else:
+            timeSpent = anEffort.timeSpent()
         # Check for aggregation because we never round in details mode
         if self.isShowingAggregatedEffort():
-            duration = self.__round_duration(duration)
+            timeSpent = self.__roundTimeSpent(timeSpent)
             showSeconds = self.__show_seconds()
         else:
             showSeconds = True
         return render.timeSpent(
-            duration,
+            timeSpent,
             showSeconds=showSeconds,
         )
 
     def __renderTotalTimeSpent(self, anEffort):
-        """Return a rendered version of the effort total duration (of
-        composite efforts)."""
-        # No need to check for aggregation because this method is only used
-        # in aggregated mode
-        total_duration = anEffort.duration(
+        """Return a rendered version of the total time spent (aggregated mode only)."""
+        totalTimeSpent = anEffort.totalTimeSpent(
             recursive=True,
             rounding=self.__round_precision(),
             roundUp=self.__always_round_up(),
             consolidate=self.__consolidate_efforts_per_task(),
         )
         return render.timeSpent(
-            total_duration,
+            totalTimeSpent,
             showSeconds=self.__show_seconds(),
         )
 
     def __renderTimeSpentOnDay(self, anEffort, dayOffset):
-        """Return a rendered version of the duration of the effort on a
-        specific day."""
-        kwargs = dict()
-        if isinstance(anEffort, effort.BaseCompositeEffort):
-            kwargs["rounding"] = self.__round_precision()
-            kwargs["roundUp"] = self.__always_round_up()
-            kwargs["consolidate"] = self.__consolidate_efforts_per_task()
-        duration = (
-            anEffort.durationDay(dayOffset, **kwargs)
-            if self.aggregation == "week"
-            else date.TimeDelta()
-        )
+        """Return a rendered version of the time spent on a specific day."""
+        if self.aggregation != "week":
+            timeSpent = date.TimeDelta()
+        elif isinstance(anEffort, effort.BaseCompositeEffort):
+            timeSpent = anEffort.totalTimeSpentForDay(
+                dayOffset,
+                rounding=self.__round_precision(),
+                roundUp=self.__always_round_up(),
+                consolidate=self.__consolidate_efforts_per_task(),
+            )
+        else:
+            timeSpent = anEffort.timeSpent()
         return render.timeSpent(
-            self.__round_duration(duration),
+            self.__roundTimeSpent(timeSpent),
             showSeconds=self.__show_seconds(),
         )
 
@@ -851,10 +850,9 @@ class EffortViewer(
         """Return the total revenue of the effort as a monetary value."""
         return render.monetaryAmount(anEffort.revenue(recursive=True))
 
-    def __round_duration(self, duration):
-        """Round a duration with the current precision and direction (i.e.
-        always up or not)."""
-        return duration.round(
+    def __roundTimeSpent(self, timeSpent):
+        """Round time spent with the current precision and direction."""
+        return timeSpent.round(
             seconds=self.__round_precision(), alwaysUp=self.__always_round_up()
         )
 

--- a/taskcoachlib/gui/viewer/task.py
+++ b/taskcoachlib/gui/viewer/task.py
@@ -970,12 +970,6 @@ class HierarchicalCalendarViewer(
         )
         return create(event=None, show=show)
 
-    def isAnyItemExpandable(self):
-        return False
-
-    def isAnyItemCollapsable(self):
-        return False
-
     def GetPrintout(self, settings):
         return self.widget.GetPrintout(settings)
 
@@ -1154,15 +1148,6 @@ class CalendarViewer(
         else:
             toSave = dt.Format()
         self.settings.set(self.settingsSection(), "viewdate", toSave)
-
-    # We need to override these because BaseTaskTreeViewer is a tree viewer, but
-    # CalendarViewer is not. There is probably a better solution...
-
-    def isAnyItemExpandable(self):
-        return False
-
-    def isAnyItemCollapsable(self):
-        return False
 
     def reconfig(self):
         self.widget.Freeze()

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,8 +41,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "61"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.1.61
+patch = "62"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.1.62
 
 release_day = "2"  # Day of the release (1-31)
 release_month = "February"  # Month of the release

--- a/taskcoachlib/widgets/calendarwidget.py
+++ b/taskcoachlib/widgets/calendarwidget.py
@@ -422,9 +422,6 @@ class Calendar(wx.Panel):
     def curselection(self):
         return self._content.curselection()
 
-    def isAnyItemCollapsable(self):
-        return False
-
     def select(self, tasks):
         if len(tasks) == 1:
             self._content.SelectTask(tasks[0])

--- a/taskcoachlib/widgets/draganddrop.py
+++ b/taskcoachlib/widgets/draganddrop.py
@@ -446,9 +446,10 @@ class TreeCtrlDragAndDropMixin(TreeHelperMixin):
                 part = -1
             elif flags & wx.TREE_HITTEST_ONITEMLOWERPART:
                 part = 1
-            # Use _dragColumn (where drag started) for ordering detection,
-            # not dropColumn from HitTest which returns -1 for narrow columns
-            self.OnDrop(dropTarget, self._dragItems, part, self._dragColumn)
+            # Use _ColumnHitTest on the drop point to reliably detect the
+            # target column (HitTest can return -1 for narrow columns)
+            actualDropColumn = self._ColumnHitTest(event.GetPoint())
+            self.OnDrop(dropTarget, self._dragItems, part, actualDropColumn)
         else:
             # Work around an issue with HyperTreeList. HyperTreeList will
             # restore the selection to the last item highlighted by the drag,

--- a/taskcoachlib/widgets/tcsquaremap.py
+++ b/taskcoachlib/widgets/tcsquaremap.py
@@ -108,11 +108,6 @@ class TcSquareMap(tooltip.ToolTipMixin, squaremap.SquareMap):
     def GetItemCount(self):
         return 0
 
-    def isAnyItemExpandable(self):
-        return False
-
-    isAnyItemCollapsable = isAnyItemExpandable
-
     def GetMainWindow(self):
         return self
 

--- a/taskcoachlib/widgets/timeline.py
+++ b/taskcoachlib/widgets/timeline.py
@@ -103,11 +103,6 @@ class Timeline(tooltip.ToolTipMixin, timeline.TimeLine):
     def GetItemCount(self):
         return 0
 
-    def isAnyItemExpandable(self):
-        return False
-
-    isAnyItemCollapsable = isAnyItemExpandable
-
     def GetMainWindow(self):
         return self
 

--- a/taskcoachlib/widgets/treectrl.py
+++ b/taskcoachlib/widgets/treectrl.py
@@ -161,23 +161,6 @@ class HyperTreeList(draganddrop.TreeCtrlDragAndDropMixin, BaseHyperTreeList):
             self.SelectAll()
         self.selectCommand()
 
-    def isAnyItemCollapsable(self):
-        for item in self.GetItemChildren():
-            if self.__is_item_collapsable(item):
-                return True
-        return False
-
-    def isAnyItemExpandable(self):
-        for item in self.GetItemChildren():
-            if self.__is_item_expandable(item):
-                return True
-        return False
-
-    def __is_item_expandable(self, item):
-        return self.ItemHasChildren(item) and not self.IsExpanded(item)
-
-    def __is_item_collapsable(self, item):
-        return self.ItemHasChildren(item) and self.IsExpanded(item)
 
     def IsLabelBeingEdited(self):
         return bool(self.GetLabelTextCtrl())

--- a/taskcoachlib/workarounds/monkeypatches.py
+++ b/taskcoachlib/workarounds/monkeypatches.py
@@ -162,3 +162,74 @@ def Window_SetSizeNew(self, *args, **kw):
 
 
 Window.SetSize = Window_SetSizeNew
+
+
+# =============================================================================
+# wx.CallAfter Crash Guard
+# =============================================================================
+# wx.CallAfter schedules a callback to run in the main event loop. If the
+# callback is a bound method on a wx widget that has been destroyed (C++ object
+# deleted), calling it causes a segfault. This wrapper detects that situation,
+# logs it, and skips the call.
+#
+# For details, see: docs/CRASH_GUARD.md
+# =============================================================================
+
+import traceback
+from taskcoachlib.meta.debug import log_step
+
+_wx_CallAfter_original = wx.CallAfter
+
+
+def _guarded_CallAfter(callableObj, *args, **kw):
+    """Wrapper around wx.CallAfter that guards against calls to dead objects.
+
+    When a wx.CallAfter is scheduled but the target wx object is destroyed
+    before the callback fires, the original wx.CallAfter would segfault.
+    This wrapper captures the scheduling traceback and wraps the callback
+    so it checks object validity before calling.
+    """
+    # Capture where the CallAfter was scheduled from (for logging)
+    schedule_tb = traceback.format_stack(limit=6)[:-1]
+
+    # Check if this is a bound method on a wx object
+    obj = getattr(callableObj, '__self__', None)
+    is_wx_obj = isinstance(obj, wx.Object)
+
+    if is_wx_obj:
+        # Wrap the call with a validity check
+        def _safe_call(*a, **k):
+            try:
+                # bool(wxObject) returns False if C++ object is deleted
+                if not obj:
+                    caller = "%s.%s" % (type(obj).__name__,
+                                        getattr(callableObj, '__name__', '?'))
+                    log_step("Blocked CallAfter to destroyed object:", caller,
+                             prefix="CRASH_GUARD")
+                    log_step("Originally scheduled from:",
+                             prefix="CRASH_GUARD")
+                    for line in schedule_tb:
+                        for part in line.rstrip().split('\n'):
+                            log_step("  " + part, prefix="CRASH_GUARD")
+                    return
+                callableObj(*a, **k)
+            except RuntimeError as e:
+                if "C/C++ object" in str(e) or "deleted" in str(e):
+                    caller = "%s.%s" % (type(obj).__name__,
+                                        getattr(callableObj, '__name__', '?'))
+                    log_step("RuntimeError calling %s:" % caller, e,
+                             prefix="CRASH_GUARD")
+                    log_step("Originally scheduled from:",
+                             prefix="CRASH_GUARD")
+                    for line in schedule_tb:
+                        for part in line.rstrip().split('\n'):
+                            log_step("  " + part, prefix="CRASH_GUARD")
+                else:
+                    raise
+
+        _wx_CallAfter_original(_safe_call, *args, **kw)
+    else:
+        _wx_CallAfter_original(callableObj, *args, **kw)
+
+
+wx.CallAfter = _guarded_CallAfter

--- a/tests/unittests/widgetTests/TreeCtrlTest.py
+++ b/tests/unittests/widgetTests/TreeCtrlTest.py
@@ -240,52 +240,6 @@ class CommonTestsMixin(object):
         item = self.getFirstTreeItem()
         self.assertEqual("item 0", self.treeCtrl.GetItemText(item))
 
-    def testIsAnyItemCollapsable_NoItems(self):
-        self.assertFalse(self.treeCtrl.isAnyItemCollapsable())
-
-    def testIsAnyItemExpandable_NoItems(self):
-        self.assertFalse(self.treeCtrl.isAnyItemExpandable())
-
-    def testIsAnyItemCollapsable_OneItem(self):
-        self.children[None] = [self.item0]
-        self.treeCtrl.RefreshAllItems(1)
-        self.assertFalse(self.treeCtrl.isAnyItemCollapsable())
-
-    def testIsAnyItemExpandable_OneItem(self):
-        self.children[None] = [self.item0]
-        self.treeCtrl.RefreshAllItems(1)
-        self.assertFalse(self.treeCtrl.isAnyItemExpandable())
-
-    def testIsAnyItemCollapsable_OneCollapsedParent(self):
-        self.children[None] = [self.item0]
-        self.children[self.item0] = [self.item0_0]
-        self.collapsedItems.append(self.item0)
-        self.treeCtrl.RefreshAllItems(2)
-        self.assertFalse(self.treeCtrl.isAnyItemCollapsable())
-
-    def testIsAnyItemExpandable_OneCollapsedParent(self):
-        self.children[None] = [self.item0]
-        self.children[self.item0] = [self.item0_0]
-        self.collapsedItems.append(self.item0)
-        self.treeCtrl.RefreshAllItems(2)
-        self.assertTrue(self.treeCtrl.isAnyItemExpandable())
-
-    def testIsAnyItemCollapsable_OneExpandedParent(self):
-        self.children[None] = [self.item0]
-        self.children[self.item0] = [self.item0_0]
-        self.treeCtrl.RefreshAllItems(2)
-        parent = self.getFirstTreeItem()
-        self.treeCtrl.Expand(parent)
-        self.assertTrue(self.treeCtrl.isAnyItemCollapsable())
-
-    def testIsAnyItemExpandable_OneExpandedParent(self):
-        self.children[None] = [self.item0]
-        self.children[self.item0] = [self.item0_0]
-        self.treeCtrl.RefreshAllItems(2)
-        parent = self.getFirstTreeItem()
-        self.treeCtrl.Expand(parent)
-        self.assertFalse(self.treeCtrl.isAnyItemExpandable())
-
 
 class TreeListCtrlTest(TreeCtrlTestCase, CommonTestsMixin):
     def setUp(self):


### PR DESCRIPTION
Separate time spent from duration in the effort domain model. Duration is a UI concept for the editor control; time spent is always computed from start/stop times. Add effort.timeSpent() that always returns stop - start (or now - start when tracking). Rename composite methods to totalTimeSpent() and totalTimeSpentForDay(). Deprecate the old duration() getter. Update all viewers and commands to use the new API.

Fix prerequisites/dependants drag-and-drop: use _ColumnHitTest on the drop point to reliably detect the target column instead of the drag origin column. Remove unused expand/collapse helper methods.

Add crash guard system: wx.CallAfter wrapper that detects destroyed C++ objects before calling methods on them, OnExceptionInMainLoop handler, both using log_step for timestamped output. Fix ColumnPopupMenu to call appendUICommands directly instead of via CallAfter.

Improve editor layout: fix mutually exclusive checkbox alignment in category editor, convert Dates/Budget/Path pages to ScrolledPage, clean up label alignment flags across editor pages. Expand PathPage with Categories, Prerequisites, and Dependants sections.

Add appearance style system, cross-reference CRASH_GUARD.md with TODO.md monkeypatches section, bump version to 2.0.1.62.

Time Spent Calculation show far higher than is correct #345