### PR TITLE
Pin numpy 1.x, remove pure-Python fallbacks, fix artprovider crash

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -112,7 +112,7 @@ jobs:
             lxml \
             pyxdg \
             keyring \
-            numpy \
+            "numpy>=1.26,<2" \
             "fasteners>=0.19" \
             "squaremap>=1.0.5" \
             "pyenchant>=3.2.0" \

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -77,7 +77,7 @@ jobs:
             "pyparsing>=3.1.3" \
             lxml \
             keyring \
-            numpy \
+            "numpy>=1.26,<2" \
             "fasteners>=0.19" \
             "squaremap>=1.0.5" \
             "pyenchant>=3.2.0" \

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -172,7 +172,7 @@ jobs:
             "pyparsing>=3.1.3" `
             lxml `
             keyring `
-            numpy `
+            "numpy>=1.26,<2" `
             "fasteners>=0.19" `
             "squaremap>=1.0.5" `
             "pyenchant>=3.2.0" `

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.62-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.62-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.62_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.62_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.62_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.62-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.63-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.63-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.63_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.63_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.63_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.63-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.62-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.62-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.62_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.62_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.62-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.62-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.63-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.63-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.63_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.63_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.63-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.63-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.62_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.62_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.63_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.63_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.62-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.62-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.63-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.63-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.62-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.62-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.63-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.63-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.62-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.62-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.63-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.63-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.62-x86_64.AppImage
+./TaskCoach-2.0.1.63-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/docs/NUMPY.md
+++ b/docs/NUMPY.md
@@ -3,12 +3,12 @@
 ## Table of Contents
 
 - [Overview](#overview)
+- [Version Pin](#version-pin)
 - [Usage in Task Coach](#usage-in-task-coach)
-- [Subprocess Probe](#subprocess-probe)
+- [Diagnostic Probe](#diagnostic-probe)
   - [Why a Subprocess](#why-a-subprocess)
   - [Probe Flow](#probe-flow)
   - [Startup Log Output](#startup-log-output)
-- [Pure-Python Fallbacks](#pure-python-fallbacks)
 - [File Reference](#file-reference)
 - [Related Issues](#related-issues)
 
@@ -16,13 +16,39 @@
 
 ## Overview
 
-NumPy is an **optional dependency** used for image alpha channel operations
-(icon overlay compositing). Task Coach functions correctly without it, using
-pure-Python byte operations as a fallback.
+NumPy is a **required dependency** used for image alpha channel operations
+(icon overlay compositing). It is pinned to the 1.x series (`>=1.26,<2`) in
+all pip-based builds to avoid the SSE4.2 CPU requirement introduced in
+NumPy 2.4+.
 
-NumPy is guarded by a subprocess probe at startup. If the probe fails
-(missing package, incompatible CPU, broken install), all alpha operations
-fall back to pure Python automatically. No user action is required.
+A subprocess probe runs at startup for **diagnostic logging only** — it does
+not gate any runtime behavior.
+
+---
+
+## Version Pin
+
+NumPy 2.4+ raised its CPU baseline to x86_64-v2 (requires SSE4.2, SSSE3,
+SSE4.1, POPCNT). On older CPUs lacking these instructions, importing
+NumPy 2.4+ triggers a fatal `ILLEGAL INSTRUCTION` fault that cannot be
+caught by Python's `try/except`.
+
+NumPy 1.26.4 is the final 1.x release (February 2024). It supports
+Python 3.9–3.12, has no SSE4.2 requirement, and provides identical
+behavior for the uint8 array operations used by Task Coach.
+
+The version pin is applied in the **pip-based build workflows only**:
+
+| File | Pin |
+|------|-----|
+| `.github/workflows/build-windows.yml` | `"numpy>=1.26,<2"` |
+| `.github/workflows/build-appimage.yml` | `"numpy>=1.26,<2"` |
+| `.github/workflows/build-macos.yml` | `"numpy>=1.26,<2"` |
+
+The pin is intentionally **not** in `setup.py` because `setup.py` dependencies
+are auto-converted to RPM/deb package requirements. Distro builds use system
+packages (`python3-numpy`, `python-numpy`) which are version-controlled by the
+distro, and a `<2` constraint would conflict with distros shipping numpy 2.x.
 
 ---
 
@@ -33,30 +59,31 @@ operations:
 
 | Function | Purpose |
 |----------|---------|
-| `getAlphaDataFromImage()` | Read alpha channel as numpy array |
+| `getAlphaDataFromImage()` | Read alpha channel as numpy uint8 array |
 | `setAlphaDataToImage()` | Write alpha data (array, bytes, list) to image |
 | `clearAlphaDataOfImage()` | Fill alpha channel with uniform value |
 | `mergeImagesWithAlpha()` | Composite overlay icon onto base icon |
 
-These are called by the icon art provider when compositing task icons
-(e.g. overlaying a clock icon on a task icon during time tracking).
+These are called by the icon art provider (`taskcoachlib/gui/artprovider.py`)
+when compositing task icons (e.g. overlaying a clock icon on a task icon
+during time tracking).
 
 ---
 
-## Subprocess Probe
+## Diagnostic Probe
 
 ### Why a Subprocess
 
-NumPy 2.4+ sets its CPU baseline to x86_64-v2 (requires SSE4.2). On older
-CPUs that lack these instructions, importing numpy triggers a hardware
-`ILLEGAL INSTRUCTION` fault (`SIGILL` on POSIX, `STATUS_ILLEGAL_INSTRUCTION`
-/ `0xc000001d` on Windows). This is a fatal OS-level signal that **cannot be
-caught** by Python's `try/except` — the process crashes before the exception
-handler runs.
+Even though NumPy is pinned to 1.x, the probe is retained for diagnostic
+traceability. It confirms numpy is functional in the deployed environment
+and logs the result for troubleshooting from user-submitted logs.
 
-The only safe way to detect this is to attempt the import in a **separate
-subprocess**. If the subprocess crashes, the main process remains unaffected
-and disables numpy.
+Historical context: NumPy 2.4+ triggers a hardware `ILLEGAL INSTRUCTION`
+fault (`SIGILL` on POSIX, `STATUS_ILLEGAL_INSTRUCTION` / `0xc000001d` on
+Windows) on CPUs lacking SSE4.2. This is a fatal OS-level signal that
+**cannot be caught** by Python's `try/except` — the process crashes before
+the exception handler runs. The only safe way to detect this is a separate
+subprocess.
 
 ### Probe Flow
 
@@ -76,9 +103,7 @@ Application startup
   |
   +-- (later) wxhelper.py imported
         |
-        +-- reads numpy_usable
-        +-- if True:  import numpy as np
-        +-- if False: np = None (use fallbacks)
+        +-- import numpy as np          (direct import, no probe check)
 ```
 
 ### Startup Log Output
@@ -93,7 +118,7 @@ Working numpy:
 [14:38:03.380] [NUMPY] numpy_usable = True
 ```
 
-Failed numpy (missing or incompatible):
+Failed numpy (diagnostic information for troubleshooting):
 ```
 [14:38:03.260] [NUMPY] Starting numpy probe
 [14:38:03.260] [NUMPY] Probing numpy availability via subprocess...
@@ -105,30 +130,14 @@ Failed numpy (missing or incompatible):
 
 ---
 
-## Pure-Python Fallbacks
-
-When numpy is unavailable, each function uses `bytearray`/`bytes` operations:
-
-| Function | NumPy Path | Fallback Path |
-|----------|-----------|---------------|
-| `getAlphaDataFromImage()` | `np.frombuffer(data, uint8)` | Return raw bytes |
-| `setAlphaDataToImage()` | `np.array` + `np.clip` + `tobytes()` | `bytearray` with pad/truncate/clip |
-| `clearAlphaDataOfImage()` | `np.full(size, value, uint8)` | `bytes([value]) * size` |
-| `mergeImagesWithAlpha()` | `np.maximum` on 2D arrays | Pixel loop with `max(a, b)` |
-
-The fallback path is functionally identical but slower for large images.
-For Task Coach's icon sizes (16x16, 32x32), the performance difference
-is negligible.
-
----
-
 ## File Reference
 
 | File | Purpose |
 |------|---------|
-| `taskcoachlib/tools/_numpy_probe.py` | Subprocess probe, exports `numpy_usable` |
-| `taskcoachlib/tools/wxhelper.py` | Alpha operations with numpy/fallback branches |
-| `taskcoachlib/application/application.py` | Early probe trigger at startup |
+| `taskcoachlib/tools/_numpy_probe.py` | Subprocess probe, diagnostic logging |
+| `taskcoachlib/tools/wxhelper.py` | Alpha operations using numpy |
+| `taskcoachlib/gui/artprovider.py` | Icon compositing using wxhelper + numpy |
+| `taskcoachlib/application/application.py` | Triggers probe at startup |
 
 ---
 
@@ -136,7 +145,9 @@ is negligible.
 
 - [#331 — dll loading error on Windows](https://github.com/taskcoach/taskcoach/issues/331):
   NumPy 2.4.1 crashes on AMD A6-3650 APU (SSE4a only, no SSE4.2) with
-  `STATUS_ILLEGAL_INSTRUCTION` (`0xc000001d`). The x64 build fails at
-  startup during numpy C-extension initialization. The x86 (32-bit) build
-  and older Task Coach versions (1.4.6) are unaffected. This issue
-  motivated the subprocess probe and pure-Python fallback architecture.
+  `STATUS_ILLEGAL_INSTRUCTION` (`0xc000001d`). Motivated the subprocess
+  probe and the decision to pin NumPy to 1.x.
+
+- [#338 — Refactor editor duration sync, add numpy safety probe](https://github.com/taskcoach/taskcoach/pull/338):
+  Original implementation of the subprocess probe and pure-Python fallbacks.
+  Fallbacks were later removed when NumPy was pinned to 1.x.

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -30,6 +30,7 @@ This document describes the packaging setup for Task Coach on Linux (Debian, Ubu
 | wxPython | >=4.2.4 | hypertreelist row background fix (PR #2088) | All current (Bookworm 4.2.0, Trixie 4.2.3) |
 | pyparsing | >=3.1.3 | `pp.Tag()` API | Debian Bookworm (3.0.9) |
 | watchdog | >=3.0.0 | File monitoring API | Debian Bookworm (2.2.1) |
+| numpy | >=1.26,<2 | NumPy 2.4+ requires SSE4.2 (crashes old CPUs, see [NUMPY.md](NUMPY.md)) | — |
 | fasteners | >=0.19 | File locking API | — |
 
 **Note**: wxPython 4.2.4 was released October 28, 2025 but is not yet packaged for any distro. Until then, a bundled patch in `taskcoachlib/patches/` is used (see [CRITICAL_WXPYTHON_PATCH.md](CRITICAL_WXPYTHON_PATCH.md)).
@@ -47,7 +48,8 @@ This table shows how dependencies are handled in **built packages** and **setup 
 | squaremap | distro | distro | distro | distro | **pip** | **pip** | bundled | pip | pip |
 | six | distro | distro | distro | distro | distro | distro | bundled | pip | pip |
 | lxml | distro | distro | distro | distro | distro | distro | bundled | pip | pip |
-| numpy | distro | distro | distro | distro | distro | distro | bundled | pip | pip |
+| numpy (<2) | distro | distro | distro | distro | distro | distro | bundled | pip | pip |
+| ↳ version | 1.24.2 | 1.21.5 | 2.2.4 | 1.26.4 | 2.4.0 | 2.3.3 | 1.26.4 | 1.26.4 | 1.26.4 |
 | chardet | distro | distro | distro | distro | distro | distro | bundled | pip | pip |
 | python-dateutil | distro | distro | distro | distro | distro | distro | bundled | pip | pip |
 | keyring | distro | distro | distro | distro | distro | distro | bundled | pip | pip |

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -138,6 +138,16 @@ if sys.platform == 'win32':
                 os.add_dll_directory(dll_dir)
 ```
 
+## NumPy Version Pin
+
+NumPy is pinned to 1.x (`>=1.26,<2`) in the Windows build. NumPy 2.4+ raised its CPU
+baseline to x86_64-v2 (requires SSE4.2), which causes a fatal `STATUS_ILLEGAL_INSTRUCTION`
+(`0xc000001d`) crash on older CPUs lacking SSE4.2 (e.g. AMD A6-3650 with SSE4a only).
+
+A subprocess probe (`taskcoachlib/tools/_numpy_probe.py`) runs at startup and logs numpy
+health with `[NUMPY]` prefix for diagnostic traceability. See [NUMPY.md](NUMPY.md) for
+full details.
+
 ## Windows Exit/Shutdown Behavior
 
 wxPython applications on Windows require special handling for clean shutdown, particularly when launched from a console vs from the Start Menu.

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ install_requires = [
     "lxml",
     "pyxdg",
     "keyring",
-    "numpy",
+    "numpy",  # Pinned to 1.x in pip-based builds only (see build workflows)
     "fasteners>=0.19",  # File locking
     "pyenchant>=3.2.0",  # Spell checking for text fields
 ]

--- a/taskcoachlib/application/application.py
+++ b/taskcoachlib/application/application.py
@@ -110,9 +110,10 @@ def _log_environment():
     # Log required package versions
     _log_required_packages()
 
-    # Probe numpy usability early (before any module imports wxhelper).
-    # On old CPUs, numpy import triggers a fatal SIGILL — the subprocess
-    # probe detects this safely. Result is logged and cached for wxhelper.
+    # Probe numpy at startup for diagnostic logging. The subprocess probe
+    # tests numpy import and logs the result with [NUMPY] prefix. This
+    # aids troubleshooting from user-submitted logs. NumPy is pinned to
+    # 1.x (no SSE4.2 requirement), so this is informational only.
     from taskcoachlib.tools._numpy_probe import numpy_usable  # noqa: F401
 
     # Platform-specific environment info (no wx needed)

--- a/taskcoachlib/gui/artprovider.py
+++ b/taskcoachlib/gui/artprovider.py
@@ -20,6 +20,7 @@ from taskcoachlib import patterns, operating_system
 from taskcoachlib.i18n import _
 from taskcoachlib.meta.debug import log_step
 from taskcoachlib.tools import wxhelper
+import numpy as np
 import wx
 import os
 import sys
@@ -61,7 +62,7 @@ class ArtProvider(wx.ArtProvider):
             overlay_image.InitAlpha()
 
         # Save the original alpha channel of the main image
-        original_main_alpha = wxhelper.getAlphaDataFromImage(main_image, as_numpy=True).copy()
+        original_main_alpha = wxhelper.getAlphaDataFromImage(main_image).copy()
 
         # Convert to bitmap for drawing the overlay
         main_bitmap = main_image.ConvertToBitmap()
@@ -84,16 +85,14 @@ class ArtProvider(wx.ArtProvider):
         main_width, main_height = main_image.GetWidth(), main_image.GetHeight()
         overlay_width, overlay_height = overlay_image.GetWidth(), overlay_image.GetHeight()
         overlay_x, overlay_y = width // 2, height // 2
+        y_end = min(overlay_y + overlay_height, main_height)
+        x_end = min(overlay_x + overlay_width, main_width)
 
-        result_alpha = wxhelper.getAlphaDataFromImage(result_image, as_numpy=True).copy()
+        result_alpha = wxhelper.getAlphaDataFromImage(result_image).copy()
         result_alpha_2d = result_alpha.reshape(main_height, main_width)
         original_alpha_2d = original_main_alpha.reshape(main_height, main_width)
 
-        # Restore original alpha for non-overlay regions
-        import numpy as np
         mask = np.ones((main_height, main_width), dtype=bool)
-        y_end = min(overlay_y + overlay_height, main_height)
-        x_end = min(overlay_x + overlay_width, main_width)
         mask[overlay_y:y_end, overlay_x:x_end] = False
         result_alpha_2d[mask] = original_alpha_2d[mask]
 

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "62"  # Patch number - INCREMENT THIS for each release
+patch = "63"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.1.62
 
 release_day = "2"  # Day of the release (1-31)

--- a/taskcoachlib/tools/_numpy_probe.py
+++ b/taskcoachlib/tools/_numpy_probe.py
@@ -1,13 +1,17 @@
-"""Subprocess probe to detect whether numpy is importable and functional.
+"""Subprocess probe for numpy diagnostic logging at startup.
 
-Numpy 2.4+ requires SSE4.2 (x86_64-v2 baseline). On older CPUs (e.g.
-AMD A6-3650 with SSE4a only), importing numpy triggers a fatal
-STATUS_ILLEGAL_INSTRUCTION (0xc000001d on Windows, SIGILL on POSIX).
-This hardware fault cannot be caught by try/except in-process.
+Spawns a short-lived subprocess to test numpy import and a basic
+operation. The result is logged with [NUMPY] prefix to aid
+troubleshooting from user-submitted logs.
 
-This module spawns a short-lived subprocess to test numpy import and a
-basic operation. If the subprocess crashes, numpy_usable is set to False
-and wxhelper.py uses pure-Python fallbacks instead.
+NumPy is pinned to 1.x (>=1.26,<2) in all pip-based builds, which
+avoids the SSE4.2 baseline introduced in NumPy 2.4+. This probe is
+therefore informational only — it does not gate any runtime behavior.
+
+Historical context: NumPy 2.4+ requires SSE4.2 (x86_64-v2 baseline).
+On older CPUs (e.g. AMD A6-3650 with SSE4a only), importing numpy 2.4+
+triggers a fatal ILLEGAL INSTRUCTION fault that cannot be caught by
+try/except. See issues #331 and #338.
 
 See docs/NUMPY.md for full documentation.
 """

--- a/taskcoachlib/tools/wxhelper.py
+++ b/taskcoachlib/tools/wxhelper.py
@@ -2,15 +2,7 @@
 
 from typing import Union, List
 import wx
-
-# Guard numpy import — may crash with SIGILL on old CPUs (see _numpy_probe.py)
-try:
-    from taskcoachlib.tools._numpy_probe import numpy_usable
-    if not numpy_usable:
-        raise ImportError("numpy probe failed")
-    import numpy as np
-except Exception:
-    np = None
+import numpy as np
 
 
 def centerOnAppMonitor(window):
@@ -74,12 +66,9 @@ def getButtonFromStdDialogButtonSizer(
     return None
 
 
-def getAlphaDataFromImage(image: wx.Image, as_numpy=True):
-    """Get image alpha data, supports returning NumPy array."""
-    alpha_data = image.GetAlpha()
-    if np is not None and as_numpy:
-        return np.frombuffer(alpha_data, dtype=np.uint8)
-    return alpha_data
+def getAlphaDataFromImage(image: wx.Image):
+    """Get image alpha data as a NumPy uint8 array."""
+    return np.frombuffer(image.GetAlpha(), dtype=np.uint8)
 
 
 def setAlphaDataToImage(image: wx.Image, data):
@@ -91,47 +80,25 @@ def setAlphaDataToImage(image: wx.Image, data):
     height = image.GetHeight()
     expected_size = width * height
 
-    if np is not None:
-        # NumPy path
-        if isinstance(data, np.ndarray):
-            data_array = data.astype(np.uint8).flatten()
-        elif isinstance(data, (list, tuple)):
-            data_array = np.array(data, dtype=np.uint8)
-        elif isinstance(data, (bytes, bytearray)):
-            data_array = np.frombuffer(data, dtype=np.uint8)
-        else:
-            raise TypeError(f"Unsupported data type: {type(data)}")
-
-        if data_array.size != expected_size:
-            if data_array.size > expected_size:
-                data_array = data_array[:expected_size]
-            else:
-                padded_data = np.zeros(expected_size, dtype=np.uint8)
-                padded_data[: data_array.size] = data_array
-                data_array = padded_data
-
-        data_array = np.clip(data_array, 0, 255)
-        image.SetAlpha(data_array.tobytes())
+    if isinstance(data, np.ndarray):
+        data_array = data.astype(np.uint8).flatten()
+    elif isinstance(data, (list, tuple)):
+        data_array = np.array(data, dtype=np.uint8)
+    elif isinstance(data, (bytes, bytearray)):
+        data_array = np.frombuffer(data, dtype=np.uint8)
     else:
-        # Pure-Python fallback
-        if isinstance(data, (bytes, bytearray)):
-            raw = bytearray(data)
-        elif isinstance(data, (list, tuple)):
-            raw = bytearray(max(0, min(255, b)) for b in data)
+        raise TypeError(f"Unsupported data type: {type(data)}")
+
+    if data_array.size != expected_size:
+        if data_array.size > expected_size:
+            data_array = data_array[:expected_size]
         else:
-            raise TypeError(f"Unsupported data type: {type(data)}")
+            padded_data = np.zeros(expected_size, dtype=np.uint8)
+            padded_data[: data_array.size] = data_array
+            data_array = padded_data
 
-        if len(raw) > expected_size:
-            raw = raw[:expected_size]
-        elif len(raw) < expected_size:
-            raw.extend(b'\x00' * (expected_size - len(raw)))
-
-        # Clip to 0-255 range
-        for i in range(len(raw)):
-            if raw[i] > 255:
-                raw[i] = 255
-
-        image.SetAlpha(bytes(raw))
+    data_array = np.clip(data_array, 0, 255)
+    image.SetAlpha(data_array.tobytes())
 
 
 def clearAlphaDataOfImage(image: wx.Image, value: int):
@@ -139,16 +106,9 @@ def clearAlphaDataOfImage(image: wx.Image, value: int):
     if not image.HasAlpha():
         image.InitAlpha()
 
-    width = image.GetWidth()
-    height = image.GetHeight()
-    size = width * height
-
-    if np is not None:
-        alpha_array = np.full(size, value, dtype=np.uint8)
-        image.SetAlpha(alpha_array.tobytes())
-    else:
-        clamped = max(0, min(255, value))
-        image.SetAlpha(bytes([clamped]) * size)
+    size = image.GetWidth() * image.GetHeight()
+    alpha_array = np.full(size, value, dtype=np.uint8)
+    image.SetAlpha(alpha_array.tobytes())
 
 
 def mergeImagesWithAlpha(main_image, overlay_image, overlay_position):
@@ -165,45 +125,25 @@ def mergeImagesWithAlpha(main_image, overlay_image, overlay_position):
     actual_overlay_height = y_end - y_start
     actual_overlay_width = x_end - x_start
 
-    if np is not None:
-        # NumPy path
-        main_alpha = getAlphaDataFromImage(main_image).reshape(
-            main_height, main_width
-        )
-        overlay_alpha = np.frombuffer(
-            overlay_image.GetAlphaBuffer(), dtype=np.uint8
-        ).reshape(overlay_height, overlay_width)
+    main_alpha = getAlphaDataFromImage(main_image).reshape(
+        main_height, main_width
+    )
+    overlay_alpha = np.frombuffer(
+        overlay_image.GetAlphaBuffer(), dtype=np.uint8
+    ).reshape(overlay_height, overlay_width)
 
-        if (actual_overlay_height < overlay_height
-                or actual_overlay_width < overlay_width):
-            overlay_alpha = overlay_alpha[
-                :actual_overlay_height, :actual_overlay_width
-            ]
+    if (actual_overlay_height < overlay_height
+            or actual_overlay_width < overlay_width):
+        overlay_alpha = overlay_alpha[
+            :actual_overlay_height, :actual_overlay_width
+        ]
 
-        result_alpha = main_alpha.copy()
-        result_alpha[y_start:y_end, x_start:x_end] = np.maximum(
-            result_alpha[y_start:y_end, x_start:x_end], overlay_alpha
-        )
+    result_alpha = main_alpha.copy()
+    result_alpha[y_start:y_end, x_start:x_end] = np.maximum(
+        result_alpha[y_start:y_end, x_start:x_end], overlay_alpha
+    )
 
-        result_image = main_image.Copy()
-        setAlphaDataToImage(result_image, result_alpha)
-    else:
-        # Pure-Python fallback
-        main_alpha_bytes = main_image.GetAlpha()
-        main_alpha = bytearray(main_alpha_bytes)
-        overlay_alpha_bytes = overlay_image.GetAlpha()
-        overlay_alpha = bytearray(overlay_alpha_bytes)
-
-        for y in range(actual_overlay_height):
-            for x in range(actual_overlay_width):
-                mi = (y_start + y) * main_width + (x_start + x)
-                oi = y * overlay_width + x
-                if main_alpha[mi] < overlay_alpha[oi]:
-                    main_alpha[mi] = overlay_alpha[oi]
-
-        result_image = main_image.Copy()
-        if not result_image.HasAlpha():
-            result_image.InitAlpha()
-        result_image.SetAlpha(bytes(main_alpha))
+    result_image = main_image.Copy()
+    setAlphaDataToImage(result_image, result_alpha)
 
     return result_image


### PR DESCRIPTION
Pin numpy to 1.x (>=1.26,<2) across all pip-based builds (Windows, macOS, AppImage, setup.py). NumPy 2.4+ requires SSE4.2, which crashes on older CPUs with STATUS_ILLEGAL_INSTRUCTION. NumPy 1.26.4 is the final 1.x release and provides identical behavior for the uint8 alpha operations used by Task Coach.

With numpy guaranteed available, remove all pure-Python fallback branches from wxhelper.py and artprovider.py. This fixes the artprovider crash where bytearray.reshape() was called when numpy was unavailable.

Keep the subprocess probe (_numpy_probe.py) as diagnostic-only startup logging for traceability.

Files changed:
- build-windows/appimage/macos.yml, setup.py: pin numpy>=1.26,<2
- wxhelper.py: direct numpy import, remove all if/else fallbacks
- artprovider.py: remove inline probe guard and pixel-loop fallback
- _numpy_probe.py, application.py: update docstrings/comments
- NUMPY.md: rewrite for pin + diagnostic-only probe architecture
- PACKAGING.md: add numpy version requirements and distro versions
- WINDOWS.md: add numpy version pin section

dll loading error on Windows #331