### PR TITLE
Add Windows native date picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.64-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.64-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.64_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.64_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.64_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.64-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.65-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.65-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.65_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.65_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.65_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.65-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.64-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.64-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.64_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.64_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.64-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.64-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.65-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.65-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.65_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.65_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.65-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.65-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.64_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.64_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.65_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.65_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.64-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.64-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.65-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.65-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.64-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.64-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.65-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.65-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.64-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.64-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.65-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.65-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.64-x86_64.AppImage
+./TaskCoach-2.0.1.65-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/Welcome.tsk
+++ b/Welcome.tsk
@@ -16,7 +16,7 @@ Visual diagram showing task prerequisite relationships
 </description>
 </attachment>
 </task>
-<task id="41745a54-5466-11e2-a067-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:54:53.607728" modificationDateTime="2025-12-22 22:24:28.162914" subject="Task Coach has many features!" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" actualstartdate="2013-01-01 18:04:03.077518">
+<task id="41745a54-5466-11e2-a067-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:54:53.607728" modificationDateTime="2025-12-22 22:24:28.162914" subject="Task Coach has many features!" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2013-01-01 17:00:00" actualstartdate="2013-01-01 18:04:03.077518">
 <description>
 • EFFORT TRACKING
 • Notes and attachments
@@ -35,14 +35,14 @@ Spreadsheet comparing Task Coach features with alternatives
 </description>
 </attachment>
 </task>
-<task id="5cc79b72-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:00:00" subject="Sample Project: Website Redesign" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" actualstartdate="2026-01-17 10:00:00" priority="3">
+<task id="5cc79b72-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:00:00" subject="Sample Project: Website Redesign" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-15 09:00:00" actualstartdate="2026-01-17 10:00:00" priority="3">
 <description>
 This example shows how to organize a project with multiple phases.
 Each phase can have its own subtasks, deadlines, and budget.
 Use categories to tag tasks by context (work, client, etc.)
 </description>
 <task id="5cc79b73-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:01:00" modificationDateTime="2026-01-17 21:15:04.360949" subject="Phase 1: Research and Planning" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-17 21:14:00" duedate="2026-01-18 18:00:00" actualstartdate="2026-01-17 21:14:00" priority="3" reminder="2026-01-18 08:00:00">
-<task id="5cc79b74-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:02:00" subject="Gather requirements from stakeholders" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" completiondate="2026-01-15 12:00:00" percentageComplete="100" priority="2">
+<task id="5cc79b74-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:02:00" subject="Gather requirements from stakeholders" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-10 09:00:00" completiondate="2026-01-15 12:00:00" percentageComplete="100" priority="2">
 <note id="a1b2c307-f412-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:02:00" subject="Stakeholder List">
 <description>
 Key stakeholders:
@@ -58,7 +58,7 @@ Compiled requirements document from stakeholder meetings
 </description>
 </attachment>
 </task>
-<task id="5cc79b75-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:03:00" subject="Analyze competitor websites" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" priority="2" prerequisites="5cc79b74-f40f-11f0-b2c5-24418c661769">
+<task id="5cc79b75-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:03:00" subject="Analyze competitor websites" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-19 09:00:00" priority="2" prerequisites="5cc79b74-f40f-11f0-b2c5-24418c661769">
 <note id="a1b2c301-f412-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:03:00" subject="Competitor Analysis">
 <description>
 Key competitors to review:
@@ -82,7 +82,7 @@ Project Gantt chart with milestones and dependencies
 </attachment>
 </task>
 </task>
-<task id="5cc79b77-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:05:00" subject="Phase 2: Design" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" priority="2">
+<task id="5cc79b77-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:05:00" subject="Phase 2: Design" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-23 09:00:00" priority="2">
 <task id="5cc79b78-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:06:00" subject="Create wireframes" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-23 09:00:00" duedate="2026-01-27 17:00:00" priority="2">
 <note id="4eedb9c6-f411-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:06:00" subject="Design Requirements">
 <description>
@@ -113,7 +113,7 @@ Figma design file with latest homepage mockup revisions
 </description>
 </attachment>
 </task>
-<task id="5cc79b7a-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:08:00" subject="Get client approval" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" priority="3" prerequisites="5cc79b79-f40f-11f0-b2c5-24418c661769">
+<task id="5cc79b7a-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:08:00" subject="Get client approval" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-02-04 09:00:00" priority="3" prerequisites="5cc79b79-f40f-11f0-b2c5-24418c661769">
 <note id="a1b2c303-f412-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:08:00" subject="Approval Process">
 <description>
 Send designs to: john@acme.example.com
@@ -129,7 +129,7 @@ Formal design approval document requiring client signature
 </attachment>
 </task>
 </task>
-<task id="5cc79b7b-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:09:00" subject="Phase 3: Development" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" priority="1">
+<task id="5cc79b7b-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:09:00" subject="Phase 3: Development" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-02-10 09:00:00" priority="1">
 <task id="5cc7a248-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:10:00" subject="Set up development environment" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-02-10 09:00:00" duedate="2026-02-11 17:00:00" priority="1" prerequisites="5cc79b7a-f40f-11f0-b2c5-24418c661769">
 <note id="4eedb9c7-f411-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 10:10:00" subject="Tech Stack">
 <description>
@@ -208,12 +208,12 @@ Discussed initial requirements:
 </description>
 </note>
 </task>
-<task id="5cc7a24c-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 11:00:00" subject="Personal Goals Example" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" actualstartdate="2026-01-01 00:00:00" priority="2">
+<task id="5cc7a24c-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 11:00:00" subject="Personal Goals Example" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2025-12-28 09:00:00" actualstartdate="2026-01-01 09:00:00" priority="2">
 <description>
 Track personal goals and habits with subtasks.
 Use effort tracking to monitor time spent on each goal.
 </description>
-<task id="5cc7a24d-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 11:01:00" subject="Learn a new language" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" actualstartdate="2026-01-01 00:00:00" priority="2">
+<task id="5cc7a24d-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 11:01:00" subject="Learn a new language" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2025-12-30 09:00:00" duedate="2026-03-01 17:00:00" actualstartdate="2026-01-02 08:00:00" priority="2">
 <description>
 Practice 30 minutes daily
 Use spaced repetition for vocabulary
@@ -233,7 +233,7 @@ Anki deck with 500 most common words
 </description>
 </attachment>
 </task>
-<task id="5cc7a24e-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 11:02:00" subject="Exercise routine" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" actualstartdate="2026-01-01 00:00:00" priority="3">
+<task id="5cc7a24e-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 11:02:00" subject="Exercise routine" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2025-12-29 07:00:00" actualstartdate="2026-01-01 07:30:00" priority="3">
 <task id="5cc7a24f-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 11:03:00" subject="Monday: Cardio" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-20 07:00:00" priority="2" />
 <task id="5cc7a250-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 11:04:00" subject="Wednesday: Strength training" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-22 07:00:00" priority="2" prerequisites="5cc7a24f-f40f-11f0-b2c5-24418c661769" />
 <task id="5cc7a251-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 11:05:00" subject="Friday: Yoga or stretching" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-24 07:00:00" priority="1" prerequisites="5cc7a250-f40f-11f0-b2c5-24418c661769" />
@@ -250,7 +250,7 @@ CSV export of workout data from fitness tracker
 </description>
 </attachment>
 </task>
-<task id="5cc7a252-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 11:06:00" subject="Read 12 books this year" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" actualstartdate="2026-01-01 00:00:00" percentageComplete="8" priority="1">
+<task id="5cc7a252-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 11:06:00" subject="Read 12 books this year" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2025-12-31 09:00:00" duedate="2026-12-31 23:59:00" actualstartdate="2026-01-01 10:00:00" percentageComplete="8" priority="1">
 <description>
 Track progress: 1 book per month
 Currently reading: "Deep Work" by Cal Newport
@@ -307,15 +307,15 @@ Signed service agreement with payment terms
 </description>
 </attachment>
 </task>
-<task id="5cc7a256-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 13:00:00" subject="Shopping and Errands" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')">
+<task id="5cc7a256-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 13:00:00" subject="Shopping and Errands" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-18 09:00:00">
 <description>
 Use tasks for shopping lists and errands.
 Check off items as you complete them!
 </description>
 <task id="5cc7a257-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 13:01:00" subject="Grocery shopping" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-18 10:00:00" priority="1">
-<task id="5cc7a258-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 13:02:00" subject="Milk and eggs" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" completiondate="2026-01-16 10:00:00" percentageComplete="100" />
-<task id="5cc7a259-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 13:03:00" subject="Fresh vegetables" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" />
-<task id="5cc7a25a-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 13:04:00" subject="Bread" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" />
+<task id="5cc7a258-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 13:02:00" subject="Milk and eggs" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-16 08:00:00" completiondate="2026-01-16 10:00:00" percentageComplete="100" />
+<task id="5cc7a259-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 13:03:00" subject="Fresh vegetables" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-30 10:00:00" duedate="2026-02-03 17:00:00" actualstartdate="2026-02-01 10:00:00" />
+<task id="5cc7a25a-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 13:04:00" subject="Bread" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-02-03 08:00:00" duedate="2026-02-05 12:00:00" actualstartdate="2026-02-04 08:00:00" />
 <note id="4eedb9ca-f411-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 13:01:00" subject="Shopping Tips">
 <description>
 Preferred store: Local farmers market (Saturdays)
@@ -324,7 +324,7 @@ Remember reusable bags!
 </description>
 </note>
 </task>
-<task id="5cc7a25b-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 13:05:00" subject="Return library books" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" duedate="2026-01-20 17:00:00" priority="2">
+<task id="5cc7a25b-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 13:05:00" subject="Return library books" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-19 10:00:00" duedate="2026-01-20 17:00:00" priority="2">
 <note id="a1b2c306-f412-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 13:05:00" subject="Books to Return">
 <description>
 1. "Clean Code" by Robert Martin - due Jan 20
@@ -339,7 +339,7 @@ Link to online library catalog for renewals
 </description>
 </attachment>
 </task>
-<task id="f0109812-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 13:06:00" subject="Schedule dentist appointment" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" duedate="2026-01-25 17:00:00" priority="1">
+<task id="f0109812-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 13:06:00" subject="Schedule dentist appointment" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-20 09:00:00" duedate="2026-01-25 17:00:00" priority="1">
 <note id="4eedb9cb-f411-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 13:06:00" subject="Dentist Info">
 <description>
 Dr. Smith's Office: (555) 123-4567
@@ -355,7 +355,7 @@ Scanned copy of dental insurance card for reference
 </attachment>
 </task>
 </task>
-<task id="6bb4ceb5-5468-11e2-ab5f-0016cbad0bd0" status="1" creationDateTime="2013-01-01 18:10:23.487902" subject="Appearance is adjustable" fgColor="(47, 47, 111, 255)" bgColor="(203, 243, 179, 255)" font="DejaVu Sans 8" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')">
+<task id="6bb4ceb5-5468-11e2-ab5f-0016cbad0bd0" status="1" creationDateTime="2013-01-01 18:10:23.487902" subject="Appearance is adjustable" fgColor="(47, 47, 111, 255)" bgColor="(203, 243, 179, 255)" font="DejaVu Sans 8" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-20 10:00:00">
 <description>
 Choose your own fonts and colors,
 either per task, per category tag,
@@ -367,34 +367,34 @@ Example CSS theme file for Task Coach customization
 </description>
 </attachment>
 </task>
-<task id="e557eb35-5463-11e2-9c94-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:38:00.077533" modificationDateTime="2026-01-17 22:18:32.406463" subject="Task Coach uses hierarchies" expandedContexts="('prerequisiteviewerintaskeditor',)" duedate="2026-01-17 08:00:00" actualstartdate="2026-01-17 22:17:00" priority="2">
-<task id="1c6acfee-5464-11e2-bd7c-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:39:32.476048" modificationDateTime="2025-12-22 22:25:50.976600" subject="Tasks can be subtasks of larger projects" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="2" />
-<task id="5a5a8573-5464-11e2-83f7-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:41:16.388014" modificationDateTime="2025-12-22 22:29:27.138169" subject="There is no limit to the hierarchy" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="2">
-<task id="7c1e4dbd-5464-11e2-a871-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:42:13.035916" modificationDateTime="2025-12-22 22:29:12.225269" subject="Any task can have its own subtasks" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="2">
-<task id="1a253523-5466-11e2-9c94-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:53:47.657904" modificationDateTime="2025-12-20 13:17:50.466476" subject="Grey color means &quot;inactive&quot;" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="2">
+<task id="e557eb35-5463-11e2-9c94-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:38:00.077533" modificationDateTime="2026-01-17 22:18:32.406463" subject="Task Coach uses hierarchies" expandedContexts="('prerequisiteviewerintaskeditor',)" plannedstartdate="2026-01-15 09:00:00" duedate="2026-01-17 08:00:00" actualstartdate="2026-01-17 22:17:00" priority="2">
+<task id="1c6acfee-5464-11e2-bd7c-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:39:32.476048" modificationDateTime="2025-12-22 22:25:50.976600" subject="Tasks can be subtasks of larger projects" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-10 09:00:00" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="2" />
+<task id="5a5a8573-5464-11e2-83f7-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:41:16.388014" modificationDateTime="2025-12-22 22:29:27.138169" subject="There is no limit to the hierarchy" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-11 09:00:00" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="2">
+<task id="7c1e4dbd-5464-11e2-a871-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:42:13.035916" modificationDateTime="2025-12-22 22:29:12.225269" subject="Any task can have its own subtasks" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-12 09:00:00" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="2">
+<task id="1a253523-5466-11e2-9c94-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:53:47.657904" modificationDateTime="2025-12-20 13:17:50.466476" subject="Grey color means &quot;inactive&quot;" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-13 10:00:00" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="2">
 <description>
 Not started.
 No planned start date, or planned start is in the future.
 </description>
 </task>
-<task id="3b68b747-5465-11e2-9118-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:47:33.968405" modificationDateTime="2025-12-22 22:29:05.761860" subject="Orange means &quot;due soon&quot;" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" duedate="2025-12-21 10:00:00" completiondate="2026-01-17 22:12:00" percentageComplete="100" />
+<task id="3b68b747-5465-11e2-9118-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:47:33.968405" modificationDateTime="2025-12-22 22:29:05.761860" subject="Orange means &quot;due soon&quot;" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2025-12-18 09:00:00" duedate="2025-12-21 10:00:00" completiondate="2026-01-17 22:12:00" percentageComplete="100" />
 <task id="49b38e17-5465-11e2-998c-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:47:57.946961" modificationDateTime="2025-12-20 13:15:12.616042" subject="Purple means &quot;late&quot;" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2013-01-01 17:48:00" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="2">
 <description>
 Planned start time has passed,
 but no actual start date.
 </description>
 </task>
-<task id="8f46a6e8-5467-11e2-98a8-0016cbad0bd0" status="1" creationDateTime="2013-01-01 18:04:13.667241" modificationDateTime="2025-12-20 13:14:52.291717" subject="Blue icon, black text is &quot;active&quot;" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" actualstartdate="2013-01-01 18:04:49.717792" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="1">
+<task id="8f46a6e8-5467-11e2-98a8-0016cbad0bd0" status="1" creationDateTime="2013-01-01 18:04:13.667241" modificationDateTime="2025-12-20 13:14:52.291717" subject="Blue icon, black text is &quot;active&quot;" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2013-01-01 14:00:00" actualstartdate="2013-01-01 18:04:49.717792" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="1">
 <description>
 Task has an actual start date.
 </description>
 </task>
-<task id="aea5a88f-5467-11e2-97b4-0016cbad0bd0" status="1" creationDateTime="2013-01-01 18:05:06.299246" modificationDateTime="2025-12-22 22:23:16.462721" subject="Red means &quot;overdue&quot;" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" duedate="2025-12-04 00:00:00" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="-3">
+<task id="aea5a88f-5467-11e2-97b4-0016cbad0bd0" status="1" creationDateTime="2013-01-01 18:05:06.299246" modificationDateTime="2025-12-22 22:23:16.462721" subject="Red means &quot;overdue&quot;" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2025-11-28 09:00:00" duedate="2025-12-04 17:00:00" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="-3">
 <description>
 Just because it is overdue doesn't mean high priority.
 Priority is separate.
 </description>
-<task id="7be82e5c-5465-11e2-b8cf-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:49:22.177948" subject="Priorities are relative!" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" actualstartdate="2013-01-01 17:53:36.214854" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="-1">
+<task id="7be82e5c-5465-11e2-b8cf-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:49:22.177948" subject="Priorities are relative!" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2013-01-01 15:00:00" actualstartdate="2013-01-01 17:53:36.214854" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="-1">
 <description>
 You don't need to force priorities into a few strict levels.
 Neutral is zero.
@@ -402,7 +402,7 @@ Priorities are relative - positive and negative.
 Whatever range accommodates sorting your tasks.
 </description>
 </task>
-<task id="e8ee4bf8-5465-11e2-be5f-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:52:25.089681" modificationDateTime="2026-01-17 21:19:45.183003" subject="Or use categories if you prefer" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" actualstartdate="2013-01-01 17:53:33.103233" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="-2">
+<task id="e8ee4bf8-5465-11e2-be5f-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:52:25.089681" modificationDateTime="2026-01-17 21:19:45.183003" subject="Or use categories if you prefer" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2013-01-01 16:00:00" actualstartdate="2013-01-01 17:53:33.103233" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="-2">
 <description>
 With category tags you can organize your way.
 </description>
@@ -417,20 +417,20 @@ With category tags you can organize your way.
 </note>
 </task>
 </task>
-<task id="ddcdd028-5464-11e2-a3f1-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:44:56.925130" subject="Green indicates completed tasks" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" completiondate="2013-01-01 17:44:00" percentageComplete="100" priority="1" />
-<task id="fc357e4f-5464-11e2-ae09-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:45:47.936254" subject="It is easy to hide or show any task state" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="-5" />
+<task id="ddcdd028-5464-11e2-a3f1-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:44:56.925130" subject="Green indicates completed tasks" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2013-01-01 10:00:00" completiondate="2013-01-01 17:44:00" percentageComplete="100" priority="1" />
+<task id="fc357e4f-5464-11e2-ae09-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:45:47.936254" subject="It is easy to hide or show any task state" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-14 11:00:00" completiondate="2026-01-17 22:12:00" percentageComplete="100" priority="-5" />
 </task>
 </task>
 <effort id="23dfd100-5469-11e2-b0d7-0016cbad0bd0" status="1" start="2013-01-01 18:15:32" stop="2013-01-01 21:00:45" />
 </task>
-<task id="e9f1cf82-5462-11e2-b0b5-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:30:58.300237" modificationDateTime="2013-02-06 23:41:34.713284" subject="Welcome to Task Coach" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" actualstartdate="2013-01-01 17:30:00" priority="4">
+<task id="e9f1cf82-5462-11e2-b0b5-0016cbad0bd0" status="1" creationDateTime="2013-01-01 17:30:58.300237" modificationDateTime="2013-02-06 23:41:34.713284" subject="Welcome to Task Coach" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2013-01-01 09:00:00" actualstartdate="2013-01-01 17:30:00" priority="4">
 <attachment id="e1f8905d-aa74-46e2-baef-c3447b102eb6" status="1" creationDateTime="2026-01-23 10:00:00" modificationDateTime="2026-01-23 10:00:00" subject="getting_started_guide.pdf" type="file" location="getting_started_guide.pdf" />
 </task>
-<task id="f0109813-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 14:00:00" subject="Tips and Tricks" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" actualstartdate="2026-01-17 14:00:00" priority="1">
+<task id="f0109813-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 14:00:00" subject="Tips and Tricks" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-17 09:00:00" actualstartdate="2026-01-17 14:00:00" priority="1">
 <description>
 Helpful tips for using Task Coach effectively
 </description>
-<task id="f0109814-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 14:01:00" subject="Use keyboard shortcuts for speed" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" priority="1">
+<task id="f0109814-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 14:01:00" subject="Use keyboard shortcuts for speed" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-02-10 09:00:00" priority="1">
 <description>
 • Ctrl+N: New task
 • Ctrl+E: Edit selected item
@@ -445,13 +445,13 @@ Drag tasks to reorder or nest them under other tasks.
 Hover over a collapsed parent to auto-expand it.
 </description>
 </task>
-<task id="f0109816-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 14:03:00" subject="Use filters to focus" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" priority="1">
+<task id="f0109816-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 14:03:00" subject="Use filters to focus" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-15 09:00:00" priority="1">
 <description>
 Filter by status, category, or search text.
 Hide completed tasks to see only what's left to do.
 </description>
 </task>
-<task id="f0109817-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 14:04:00" subject="Try different views" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" priority="1">
+<task id="f0109817-f40f-11f0-b2c5-24418c661769" status="1" creationDateTime="2026-01-17 14:04:00" subject="Try different views" expandedContexts="('prerequisiteviewerintaskeditor', 'taskviewer')" plannedstartdate="2026-01-30 09:00:00" duedate="2026-02-04 17:00:00" actualstartdate="2026-02-01 09:00:00" priority="1">
 <description>
 • Tree view for hierarchies
 • List view for flat display

--- a/docs/ATTRIBUTE_PATTERN.md
+++ b/docs/ATTRIBUTE_PATTERN.md
@@ -20,39 +20,19 @@ The domain model's change-detection and event-notification pattern.
 
 1. **Migrate remaining `EVT_KILL_FOCUS` AttributeSync sites to
    `EVT_VALUE_CHANGED`.** The legacy pattern binds AttributeSync to
-   `EVT_KILL_FOCUS` (blur). This works for user edits (commit on focus
-   loss), but is invisible to programmatic writes — widget methods like
-   `SetDuration()` fire `EVT_VALUE_CHANGED`, not `EVT_KILL_FOCUS`, so
-   the AttributeSync never sees them and the domain is never updated.
-   **Done:** DurationCtrl (task and effort) and all DateTimeCombo fields
-   now use plain `EVT_VALUE_CHANGED` with immediate commit — no
-   `commit_on_focus_loss` needed because `FieldsCtrl` fires only on
-   blur (user) or `SetDuration()` (programmatic). See TODO #2.
-   **Remaining:** monetary controls (budget, hourly fee, fixed fee) are
-   FieldsCtrl-based and should follow the same pattern. Subject,
-   description, and attachment location use `wx.TextCtrl` (fires
-   per-keystroke `EVT_TEXT`) — different migration path. See
+   `EVT_KILL_FOCUS` (blur). This works for user edits but is invisible
+   to programmatic writes — widget methods like `SetDuration()` fire
+   `EVT_VALUE_CHANGED`, not `EVT_KILL_FOCUS`, so the AttributeSync
+   never sees them and the domain is never updated.
+   **Done:** All `MaskedFieldsCtrl`-based controls — DurationCtrl (task
+   and effort), budget (`MaskedDurationCtrl`), all DateTimeComboCtrl fields,
+   hourly fee, and fixed fee now use `EVT_VALUE_CHANGED` with immediate
+   commit. `MaskedFieldsCtrl` fires only on blur (user) or
+   `SetDuration()`/`SetTime()`/`SetDate()` (programmatic).
+   **Remaining:** subject, description, and attachment location use
+   `wx.TextCtrl` (fires per-keystroke `EVT_TEXT`) — different migration
+   path. See
    [Three-Layer Relationship](#three-layer-relationship), Layer 2.
-
-2. **Remove `commit_on_focus_loss` from AttributeSync.** The
-   `commit_on_focus_loss` mechanism was added to batch per-keystroke
-   `EVT_VALUE_CHANGED` events into a single command on blur. This is
-   the wrong separation of concerns — whether events fire per-keystroke
-   or on blur is the **control's** responsibility, not the sync layer's.
-   `FieldsCtrl` now handles this correctly: `NumericField.SetValue()`
-   no longer fires `NotifyValueChanged()`; instead, `FieldsCtrl` fires
-   `EVT_VALUE_CHANGED` only on `_onKillFocus` (user finished typing)
-   and from `SetDuration()`/`SetTime()`/`SetDate()` (programmatic
-   complete-value writes). Every `EVT_VALUE_CHANGED` that reaches
-   `AttributeSync` represents a final value — immediate commit is
-   always correct. The `commit_on_focus_loss` parameter, the
-   `__editSessionValue`/`__hasChanges` tracking, the `__onSetFocus`/
-   `__onKillFocus` handlers, and the `commit()` method can all be
-   removed. All `AttributeSync` sites should use plain
-   `EVT_VALUE_CHANGED` with immediate commit (the default).
-   **Status:** `commit_on_focus_loss` has zero callers (the only caller,
-   `addDateEntry`, was dead code and has been deleted). The mechanism in
-   `attributesync.py` can be removed now.
 
 ---
 
@@ -225,7 +205,7 @@ updated. Domain changes → `control.SetValue()` → UI updated. Expects
 controls to implement `GetValue()`/`SetValue()`. Standard pattern:
 `EVT_VALUE_CHANGED` with immediate commit — the control decides when to fire
 (on blur for user edits, immediately for programmatic writes). Composite
-controls like `DateTimeCombo` inherit `wx.EvtHandler` and own the event,
+controls like `DateTimeComboCtrl` inherit `wx.EvtHandler` and own the event,
 firing on sub-control blur and state transitions. Legacy sites still use
 `EVT_KILL_FOCUS` (see [TODO #1](#todo)).
 **File:** `taskcoachlib/gui/dialog/attributesync.py`

--- a/docs/DATETIME_CONTROLS.md
+++ b/docs/DATETIME_CONTROLS.md
@@ -44,7 +44,7 @@ Simple time and duration input controls with explicit subfields and translatable
   - [Popup Toggle Logic](#popup-toggle-logic)
   - [Dropdown Width and Position](#dropdown-width-and-position)
   - [Events from Popup](#events-from-popup)
-  - [Sync Pattern: EVT_VALUE_CHANGED (DateTimeCombo)](#sync-pattern-evt_value_changed-datetimecombo2)
+  - [Sync Pattern: EVT_VALUE_CHANGED (DateTimeComboCtrl)](#sync-pattern-evt_value_changed-datetimecomboctrl)
   - [Sub-Control Stash Model](#sub-control-stash-model)
 - [Wayland](#wayland)
   - [Problem](#problem)
@@ -54,8 +54,13 @@ Simple time and duration input controls with explicit subfields and translatable
   - [Motivation](#motivation)
   - [Approach](#approach)
   - [Key Classes](#key-classes)
-  - [Focus Management in DateCtrl3](#focus-management-in-datectrl3)
+  - [Focus Management in DateComboCustomCtrl](#focus-management-in-datecombocustomctrl)
   - [Demo](#demo-1)
+- [Platform-Specific DateComboRouterCtrl: Native Windows, Custom Elsewhere](#platform-specific-datecomborouterctrl-native-windows-custom-elsewhere)
+  - [Windows — Native DatePickerCtrl with DTM_SETFORMAT](#windows--native-datepickerctrl-with-dtm_setformat)
+  - [macOS — Custom Control (No Native Format Override)](#macos--custom-control-no-native-format-override)
+  - [Architecture — Factory Function](#architecture--factory-function)
+  - [Preferences Demo Live Update](#preferences-demo-live-update)
 
 **Demo:** `docs/scripts/datetime_controls_demo.py`
 
@@ -64,10 +69,10 @@ Self-contained module with custom-painted single field and navigable subfields.
 
 ## TODO
 
-1. ~~Add `Activate()` method to DateTimeCombo~~ — **Done.** `ActivateValue()` on
-   DateTimeCombo. Editor uses it in `__activateStartDate()` / `__activateDueDate()`.
-2. ~~Add `Deactivate()` method to DateTimeCombo~~ — **Done.** `DeactivateValue()` on
-   DateTimeCombo. Editor deactivation goes through `DeactivateValue()` →
+1. ~~Add `Activate()` method to DateTimeComboCtrl~~ — **Done.** `ActivateValue()` on
+   DateTimeComboCtrl. Editor uses it in `__activateStartDate()` / `__activateDueDate()`.
+2. ~~Add `Deactivate()` method to DateTimeComboCtrl~~ — **Done.** `DeactivateValue()` on
+   DateTimeComboCtrl. Editor deactivation goes through `DeactivateValue()` →
    widget fires event → AttributeSync → command → domain. ~~Previously went
    through commands directly (domain write → pubsub → SetValue(sentinel) →
    unchecks), violating widget-as-UI-SSOT principle.~~ Fixed: all editor
@@ -75,16 +80,16 @@ Self-contained module with custom-painted single field and navigable subfields.
 3. ~~Checkbox toggle EVT_KILL_FOCUS gap~~ — **Resolved.** ~~Editor binds
    `EVT_CHECKBOX` via `combo.Bind(wx.EVT_CHECKBOX, handler)` and calls
    `sync.commit()` explicitly.~~
-   **Update:** EVT_CHECKBOX is no longer exposed by DateTimeCombo. The
+   **Update:** EVT_CHECKBOX is no longer exposed by DateTimeComboCtrl. The
    checkbox is an internal implementation detail. All AttributeSync instances
    now use `EVT_VALUE_CHANGED` as `editedEventType`, which fires on checkbox
    toggle AND date/time edits — no external EVT_CHECKBOX handlers needed.
    See [DURATION_CALCULATIONS.md](DURATION_CALCULATIONS.md) TODO item 9.
-   **Superseded:** DateTimeCombo now inherits `wx.EvtHandler` and posts
+   **Superseded:** DateTimeComboCtrl now inherits `wx.EvtHandler` and posts
    `EVT_VALUE_CHANGED` on itself. See
-   [DateTimeCombo Event Ownership](#datetimecombo-event-ownership).
+   [DateTimeComboCtrl Event Ownership](#datetimecomboctrl-event-ownership).
 4. **Sub-control stash model and event contract** — The sub-controls are the
-   stash for DateTimeCombo. `ActivateValue()` and `DeactivateValue()` must
+   stash for DateTimeComboCtrl. `ActivateValue()` and `DeactivateValue()` must
    each fire `EVT_VALUE_CHANGED` when they change the control's
    externally-visible state. Sub-control events alone are not sufficient —
    they don't fire when only the checkbox changes. See
@@ -95,15 +100,37 @@ Self-contained module with custom-painted single field and navigable subfields.
    inlined into `__syncTaskState` using `ActivateValue()`/`DeactivateValue()`
    /`SetDuration()` on the widget. The effort calc was already inline.
 7. **Migrate remaining `EVT_KILL_FOCUS` AttributeSync sites to
-   `EVT_VALUE_CHANGED`.** DurationCtrl (both task and effort) and all
-   DateTimeCombo fields are done — they use plain `EVT_VALUE_CHANGED` with
-   immediate commit (no `commit_on_focus_loss`). The control fires only on
+   `EVT_VALUE_CHANGED`.** All `MaskedFieldsCtrl`-based controls are done —
+   DurationCtrl (task and effort), budget (`MaskedDurationCtrl`), all
+   DateTimeComboCtrl fields, hourly fee, and fixed fee now use plain
+   `EVT_VALUE_CHANGED` with immediate commit. The control fires only on
    blur or programmatic complete-value write, so every event is a final
-   value. Remaining `EVT_KILL_FOCUS` sites: budget, hourly fee, fixed fee
-   (FieldsCtrl-based monetary controls). Subject, description, and
-   attachment location use `wx.TextCtrl` (per-keystroke `EVT_TEXT`) — a
-   different migration. See
-   [ATTRIBUTE_PATTERN.md TODO #1](ATTRIBUTE_PATTERN.md#todo).
+   value. **Remaining:** subject, description, and attachment location
+   use `wx.TextCtrl` (per-keystroke `EVT_TEXT`) — different migration
+   path. See [ATTRIBUTE_PATTERN.md TODO #1](ATTRIBUTE_PATTERN.md#todo).
+8. **Planned: Extract popup from MaskedFieldsCtrl.** MaskedFieldsCtrl currently
+   contains popup infrastructure (_ChoicesPopup, _openPopupForFocusedField,
+   DismissPopup) that doesn't belong in the base masked field control. The base
+   should only handle fields + navigation + digit entry. Each higher-level
+   control decides what popup to attach:
+   - DateComboCustomCtrl already follows this pattern (uses
+     _CalendarComboPopup via wx.ComboCtrl, DateCtrl has no popup).
+   - TimeCtrl will get its own wrapper with a single popup for the time block.
+   - DurationCtrl will get its own wrapper with a single popup for the
+     duration block.
+   The popup may still live in MaskedFieldsCtrl as infrastructure that
+   higher-level controls opt into, but it will be the higher-level control
+   that decides — not the base class automatically.
+
+9. **Consolidate "N/A" disabled state into DateTimeComboCtrl.** The "N/A"
+   overlay when a date field is unchecked is currently implemented separately
+   in each date picker: `DateComboCustomCtrl` paints it in `DateCtrl._onPaint`,
+   and `_NativeDateCtrl` paints it in `_onPaintNA` (hiding the native picker).
+   This should be consolidated so that `DateTimeComboCtrl` owns a single "N/A"
+   paint layer that covers whichever date picker is behind it. The date picker
+   itself would then only need Enabled/ReadOnly states — it would never need
+   to know about "N/A". This removes duplicate logic and ensures consistent
+   appearance across platforms.
 
 ## Location
 
@@ -277,9 +304,9 @@ Controls provide `GetValue()` / `SetValue()` that work with domain types
 
 See ATTRIBUTE_PATTERN.md for the full three-layer relationship.
 
-### DateTimeCombo Event Ownership
+### DateTimeComboCtrl Event Ownership
 
-`DateTimeCombo` is the composite control and **owns** the change event. It
+`DateTimeComboCtrl` is the composite control and **owns** the change event. It
 inherits from `wx.EvtHandler` so it can host event handlers directly —
 external code binds `EVT_VALUE_CHANGED` on the DTC itself, not on sub-controls.
 
@@ -588,10 +615,10 @@ def onFocusLost(self, event):
 
 ## Creating Custom Controls
 
-Subclass `FieldsCtrl`:
+Subclass `MaskedFieldsCtrl`:
 
 ```python
-class MyDurationCtrl(FieldsCtrl):
+class MyDurationCtrl(MaskedFieldsCtrl):
     def __init__(self, parent, days=0, hours=0, minutes=0,
                  dayChoices=None, hourChoices=None, minuteChoices=None):
         elements = [
@@ -654,7 +681,7 @@ The module is fully self-contained with these components:
 - **Event classes**: `PopupDismissEvent`, `ChoiceSelectedEvent`, `ChoicePreviewEvent`
 - **Popup classes**: `_PopupWindow` (base), `_ChoicesPopup` (dropdown), `_CalendarPopup` (date selection)
 - **Field class**: `NumericField` (individual editable subfield)
-- **Control classes**: `FieldsCtrl` (base), `DurationCtrl`, `DurationCtrlVerbose`, `TimeCtrl`, `TimeWithSecondsCtrl`, `DateCtrl`
+- **Control classes**: `MaskedFieldsCtrl` (base), `DurationCtrl`, `DurationCtrlVerbose`, `TimeCtrl`, `TimeWithSecondsCtrl`, `DateCtrl`, `DateComboCustomCtrl`, `DateComboRouterCtrl` (router), `DateTimeComboCtrl`
 
 ### Font Customization
 
@@ -673,7 +700,7 @@ The control uses `wx.EVT_PAINT` with `wx.PaintDC` for custom rendering. Each sub
 
 Most colours are queried from `wx.SystemSettings` at paint time for live theme switching. Calendar-specific colours are configurable via **Edit > Preferences > Theme** with separate settings for light and dark modes.
 
-**FieldsCtrl (date/time entry fields):**
+**MaskedFieldsCtrl (date/time entry fields):**
 
 | Element | Colour Source | Notes |
 |---------|--------------|-------|
@@ -796,7 +823,7 @@ wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)     # Disabled text
 
 ### Read-Only Mode
 
-All `FieldsCtrl`-based controls support read-only mode:
+All `MaskedFieldsCtrl`-based controls support read-only mode:
 
 ```python
 ctrl.SetReadOnly(True)   # Values visible but greyed, not editable
@@ -837,9 +864,9 @@ The popup fires three events:
 - `EVT_CHOICE_SELECTED`: Enter key or click selection (confirms value)
 - `EVT_POPUP_DISMISS`: Popup closed for any reason (Escape, click outside, selection)
 
-### Sync Pattern: EVT_VALUE_CHANGED (DateTimeCombo)
+### Sync Pattern: EVT_VALUE_CHANGED (DateTimeComboCtrl)
 
-DateTimeCombo uses `EVT_VALUE_CHANGED` for AttributeSync synchronization.
+DateTimeComboCtrl uses `EVT_VALUE_CHANGED` for AttributeSync synchronization.
 This single event fires on all value changes: checkbox toggle, date edit,
 and time edit. The checkbox is an internal implementation detail — external
 code never binds to `EVT_CHECKBOX`.
@@ -863,7 +890,7 @@ self._plannedStartDateTimeSync = attributesync.AttributeSync(
 
 **Setters:**
 - `SetTime(t)` - TimeCtrl, TimeWithSecondsCtrl
-- `SetDate(d)` - DateCtrl
+- `SetDate(d)` - DateCtrl, DateComboCustomCtrl
 - `SetDuration(d)` - DurationCtrl, DurationCtrlVerbose
 
 **ValidateChange for Field Validation:**
@@ -895,7 +922,7 @@ self.__observer.Update()   # Force immediate repaint
 
 ### Sub-Control Stash Model
 
-The sub-controls (DateCtrl, TimeCtrl) are the stash for DateTimeCombo. They
+The sub-controls (DateComboRouterCtrl, TimeCtrl) are the stash for DateTimeComboCtrl. They
 always hold a datetime value — they cannot be empty. When the checkbox is
 unchecked, the sub-controls are hidden behind the "N/A" overlay but retain
 their values. When the checkbox is checked, those same values become visible
@@ -986,22 +1013,22 @@ Platform-conditional base class:
 
 ### Motivation
 
-The original `DateCtrl` uses `_PopupWindow` (wx.Dialog) for its calendar popup, which cannot be positioned on Wayland (xdg_toplevel ignores Move()/SetPosition()). Custom dropdown buttons using `RendererNative.DrawComboBoxDropButton()` are also invisible on Wayland.
+The original date control used `_PopupWindow` (wx.Dialog) for its calendar popup, which cannot be positioned on Wayland (xdg_toplevel ignores Move()/SetPosition()). Custom dropdown buttons using `RendererNative.DrawComboBoxDropButton()` are also invisible on Wayland.
 
 ### Approach
 
-Use `wx.ComboCtrl` which provides a **native dropdown button** and manages popup positioning natively (including Wayland-safe xdg_popup). The inner date field is a clean `FieldsCtrl` subclass with all popup/frame logic removed.
+Use `wx.ComboCtrl` which provides a **native dropdown button** and manages popup positioning natively (including Wayland-safe xdg_popup). The inner date field is a clean `MaskedFieldsCtrl` subclass with all popup/frame logic removed.
 
 ### Key Classes
 
-**`_EmbeddedDateCtrl(FieldsCtrl)`** — Clean date control for embedding inside a ComboCtrl:
+**`DateCtrl(MaskedFieldsCtrl)`** — Clean date control for embedding inside a ComboCtrl:
 - No calendar popup, no frame drawing (`_drawFrame=False`), no field dropdown popups
 - F4/Enter delegates to parent ComboCtrl.Popup()
 - Click only changes subfield focus (no popup toggle)
 - Custom `_onPaint` using `IsThisEnabled()` (own state) so parent ComboCtrl's disabled state for read-only mode shows greyed values, not "N/A"
-- Same date validation, GetDate/SetDate, locale-aware format as DateCtrl
+- Same date validation, GetDate/SetDate, locale-aware format as DateComboCustomCtrl
 
-**`DateCtrl(wx.ComboCtrl)`** — ComboCtrl wrapper around `_EmbeddedDateCtrl`:
+**`DateComboCustomCtrl(wx.ComboCtrl)`** — ComboCtrl wrapper around `DateCtrl`:
 - Native dropdown button and popup management
 - `_CalendarComboPopup` for the calendar dropdown
 - `SetReadOnly(True)` disables the ComboCtrl (greys button) + sets inner control read-only
@@ -1010,15 +1037,19 @@ Use `wx.ComboCtrl` which provides a **native dropdown button** and manages popup
 - `Bind()` override forwards UI events (EVT_KEY_DOWN, EVT_KILL_FOCUS, EVT_SET_FOCUS) to inner control
 - Focus redirection from ComboCtrl's text control to inner DateCtrl
 
-**`DateTimeCombo(wx.EvtHandler)`** — Composite date/time control:
+**`DateComboRouterCtrl`** — Router function returning the platform-appropriate date combo:
+- Windows: `_NativeDateCtrl` (native `wx.adv.DatePickerCtrl` wrapper)
+- Elsewhere (Linux, macOS): `DateComboCustomCtrl`
+
+**`DateTimeComboCtrl(wx.EvtHandler)`** — Composite date/time control:
 - Inherits from `wx.EvtHandler` so it can host event handlers directly
-- Composes checkbox + `DateCtrl` + `TimeCtrl`
+- Composes checkbox + `DateComboRouterCtrl` + `TimeCtrl`
 - Owns the change event: fires `EVT_VALUE_CHANGED` on sub-control blur
   and from `ActivateValue()`/`DeactivateValue()`
 - Traps and drops sub-control `EVT_VALUE_CHANGED` (debug log point)
-- See [DateTimeCombo Event Ownership](#datetimecombo-event-ownership)
+- See [DateTimeComboCtrl Event Ownership](#datetimecomboctrl-event-ownership)
 
-**DateTimeCombo States:**
+**DateTimeComboCtrl States:**
 
 | State | Visual | Entered Via |
 |-------|--------|------------|
@@ -1026,7 +1057,7 @@ Use `wx.ComboCtrl` which provides a **native dropdown button** and manages popup
 | **Inactive** | Checkbox unchecked/enabled, fields show "N/A" | `DeactivateValue()`, construct with `value=None` |
 | **Active + Read-only** | Checkbox checked/disabled, fields greyed | `SetReadOnly()` |
 
-**DateTimeCombo State Transition Methods:**
+**DateTimeComboCtrl State Transition Methods:**
 
 | Method | Effect | Duration Calc Ref |
 |--------|--------|-------------------|
@@ -1036,7 +1067,7 @@ Use `wx.ComboCtrl` which provides a **native dropdown button** and manages popup
 | `SetReadOnly()` | Make combo read-only (no args) | UI Field States |
 | `HideCheckBox()` | Hide checkbox for always-active controls | Effort start |
 
-**DateTimeCombo State Query Methods:**
+**DateTimeComboCtrl State Query Methods:**
 
 | Method | Returns |
 |--------|---------|
@@ -1044,7 +1075,7 @@ Use `wx.ComboCtrl` which provides a **native dropdown button** and manages popup
 | `IsEditable()` | True if editable (not read-only) |
 | `IsReadOnly()` | True if read-only |
 
-**DateTimeCombo Value Access:**
+**DateTimeComboCtrl Value Access:**
 
 | Method | Type |
 |--------|------|
@@ -1053,12 +1084,12 @@ Use `wx.ComboCtrl` which provides a **native dropdown button** and manages popup
 | `GetDate()` | `datetime.date` (read-only) |
 | `GetTime()` | `datetime.time` (read-only) |
 
-**DateTimeCombo Layout Accessors** (for sizer arrangement, not state logic):
+**DateTimeComboCtrl Layout Accessors** (for sizer arrangement, not state logic):
 
 | Method | Returns |
 |--------|---------|
 | `GetCheckBox()` | `wx.CheckBox` |
-| `GetDateCtrl()` | `DateCtrl` |
+| `GetDateCtrl()` | `DateComboCustomCtrl` |
 | `GetTimeCtrl()` | `TimeCtrl` / `TimeWithSecondsCtrl` |
 | `GetWidgets()` | Tuple of all three |
 | `CreateRowPanel(parent)` | `wx.Panel` with all three arranged horizontally |
@@ -1079,12 +1110,12 @@ Use `wx.ComboCtrl` which provides a **native dropdown button** and manages popup
 - `Create()` — creates interior panel, binds paint/mouse/key events
 - `GetAdjustedSize()` — returns calendar dimensions
 - `GetStringValue()` — returns selected date as ISO string
-- `OnPopup()` — syncs selection from parent DateCtrl
-- Duck-typed `_getDateCtrl2()` finds parent via `hasattr` checks
+- `OnPopup()` — syncs selection from parent DateComboCustomCtrl
+- Duck-typed `_getDateComboCustomCtrl()` finds parent via `hasattr` checks
 
-### Focus Management in DateCtrl
+### Focus Management in DateComboCustomCtrl
 
-The ComboCtrl's internal text control is hidden behind the overlaid `_EmbeddedDateCtrl`. DateCtrl handles this by:
+The ComboCtrl's internal text control is hidden behind the overlaid `DateCtrl`. DateComboCustomCtrl handles this by:
 
 1. **Focus redirection**: `EVT_SET_FOCUS` on the ComboCtrl's text control redirects focus to the inner DateCtrl, with a `_redirectingFocus` guard to prevent recursion.
 2. **Text interception**: `EVT_TEXT` handler clears any text the ComboCtrl auto-inserts.
@@ -1092,12 +1123,11 @@ The ComboCtrl's internal text control is hidden behind the overlaid `_EmbeddedDa
 
 ### Wiring
 
-`__init__.py` exports aliases:
-- `DateCtrl as MaskedDateCtrl`
-- `DateTimeCombo as DateTimeCombo`
-
-Old `DateCtrl` (FieldsCtrl-based), `_CalendarPopup`, and `DateTimeCombo` v1
-have been removed. `DateCtrl` and `DateTimeCombo` are the only implementations.
+`__init__.py` exports:
+- `DateCtrl`
+- `DateComboCustomCtrl`
+- `DateComboRouterCtrl` (router)
+- `DateTimeComboCtrl`
 
 ### Demo
 
@@ -1107,3 +1137,129 @@ with various configurations. Run from the project root:
 ```
 python3 docs/scripts/datetime_controls_demo.py
 ```
+
+## Platform-Specific DateComboRouterCtrl: Native Windows, Custom Elsewhere
+
+TaskCoach requires two capabilities from a date picker control:
+
+1. **Masked input** — day, month, and year are independently navigable and
+   editable subfields (arrow keys move between fields, typing replaces the
+   focused field). This prevents invalid freeform text entry and provides a
+   consistent editing experience.
+2. **Format override** — the display order and separator must match the user's
+   chosen format (e.g. `YMD-`, `DMY/`, `MDY.`) from Preferences → Regional,
+   not just the OS locale default.
+
+`DateComboRouterCtrl` selects the implementation per platform based on whether
+the native control satisfies both requirements:
+
+| Platform | Native Control         | Masked Input | Format Override        | Router Returns          |
+|----------|------------------------|--------------|------------------------|-------------------------|
+| Windows  | Win32 Date-Time Picker | Yes          | Yes (`DTM_SETFORMATW`) | `_NativeDateCtrl`       |
+| Linux    | GTK date entry         | No           | No                     | `DateComboCustomCtrl`   |
+| macOS    | NSDatePicker           | Yes          | No (wxWidgets #9888)   | `DateComboCustomCtrl`   |
+
+On **Linux**, `wx.adv.DatePickerCtrl` wraps a GTK widget that is a plain text
+entry with a dropdown calendar — not a masked control. There is no GTK API to
+set a custom date display format. Neither requirement is met, so Linux uses the
+custom ComboCtrl + `DateCtrl` architecture.
+
+On **Windows**, the native Win32 Date-Time Picker is already masked (each
+subfield is independently selectable and editable) and supports
+`DTM_SETFORMATW` for arbitrary format strings. Both requirements are met, and
+the native control also fixes the rendering and focus problems that
+`DateComboCustomCtrl` has on Windows (see below).
+
+On **macOS**, `NSDatePicker` is masked but wxPython does not expose its format
+API, and wxWidgets hardcodes MM/DD/YYYY regardless of locale. Only one
+requirement is met, so macOS uses the custom control.
+
+### Windows — Native DatePickerCtrl with DTM_SETFORMAT
+
+**Problem:** On Windows, `DateCtrl` (a custom-painted `wx.Panel`)
+inside the `wx.ComboCtrl` renders as a white box with no visible date text.
+The panel's background painting conflicts with the ComboCtrl's native text
+area. Tab navigation also breaks due to the focus redirection between the
+ComboCtrl's internal text control and the inner panel (see
+[Focus Management in DateComboCustomCtrl](#focus-management-in-datecombocustomctrl)).
+
+**Solution:** On Windows, `DateComboRouterCtrl` returns a native `wx.adv.DatePickerCtrl` (the
+Win32 Date-Time Picker control) instead of the ComboCtrl + `DateCtrl`
+approach. This provides correct rendering, native keyboard navigation, and
+accessibility out of the box.
+
+**Format override:** The native Win32 Date-Time Picker supports the
+`DTM_SETFORMATW` message (`0x1032`) to set an arbitrary display format at any
+time. This is sent via `ctypes.windll.user32.SendMessageW`. The app's format
+codes (see [Locale and Date Format Settings](#locale-and-date-format-settings))
+are converted to Win32 date format tokens:
+
+| App Format Code | Win32 Format String | Display |
+|-----------------|--------------------:|---------|
+| `"YMD-"` | `yyyy-MM-dd` | 2026-01-18 |
+| `"YMD/"` | `yyyy/MM/dd` | 2026/01/18 |
+| `"MDY/"` | `MM/dd/yyyy` | 01/18/2026 |
+| `"DMY/"` | `dd/MM/yyyy` | 18/01/2026 |
+| `"DMY."` | `dd.MM.yyyy` | 18.01.2026 |
+| `""` (auto) | Detected from locale | varies |
+
+**Live update:** `SetDateFormat(dateFormat)` re-sends `DTM_SETFORMATW` — the
+native control updates instantly without needing to destroy/recreate.
+
+### macOS — Custom Control (No Native Format Override)
+
+`wx.adv.DatePickerCtrl` on macOS wraps `NSDatePicker`, which is a
+segmented/masked control (each date component is independently editable with
+stepper arrows). However:
+
+- wxPython does not expose `NSDatePicker.dateFormatter` — there is no way to
+  set a custom format without adding a PyObjC dependency.
+- [wxWidgets #9888](https://github.com/wxWidgets/wxWidgets/issues/9888) (open
+  since 2008) — the macOS `DatePickerCtrl` ignores the system locale and
+  hardcodes MM/DD/YYYY.
+
+Therefore macOS continues using `DateComboCustomCtrl` (the ComboCtrl +
+`DateCtrl` architecture documented in [Key Classes](#key-classes)),
+which correctly respects the app's format settings.
+
+### Architecture — Factory Function
+
+`DateComboRouterCtrl` is a router function that returns the appropriate implementation
+for the current platform:
+
+- **Windows** (`wx.Platform == '__WXMSW__'`): `_NativeDateCtrl` — wraps
+  `wx.adv.DatePickerCtrl` with `DTM_SETFORMATW` for format control.
+- **Elsewhere** (Linux, macOS): `DateComboCustomCtrl` — the ComboCtrl +
+  `DateCtrl` architecture.
+
+Both implementations expose the same public API:
+
+| Method | Description |
+|--------|-------------|
+| `GetDate()` | Returns `datetime.date` |
+| `SetDate(d)` | Sets date (`datetime.date` or `None` → today) |
+| `SetDateFormat(fmt)` | Change display format (live on Windows, rebuild on others) |
+| `SetReadOnly(bool)` | Grey values, block editing |
+| `IsReadOnly()` | Query read-only state |
+| `HasOpenPopup()` | Whether calendar popup is open |
+| `DismissPopup()` | Close any open popup |
+| `Enable(bool)` | Enable/disable (shows "N/A" when disabled) |
+| `SetFocus()` | Move focus to the control |
+| `Bind(evt, handler)` | Event binding with forwarding |
+
+**Event bridging:** The Windows native wrapper translates
+`wx.adv.EVT_DATE_CHANGED` from the native picker into the app's
+`EVT_VALUE_CHANGED` (see [Events](#events)), so `DateTimeComboCtrl` and
+`AttributeSync` work without changes.
+
+### Preferences Demo Live Update
+
+The Preferences → Regional date format preview (in `preferences.py`
+`_rebuildDemoDateCtrl()`) destroys and recreates the `DateComboRouterCtrl`.
+On Windows, `_NativeDateCtrl.SetDateFormat()` could update the native control
+in place via `DTM_SETFORMATW`, but the current rebuild approach works on all
+platforms.
+
+- **Windows:** `DTM_SETFORMATW` updates the native control in place (via `SetDateFormat()`).
+- **Other platforms:** Destroys and recreates the `DateComboRouterCtrl`
+  with the new field order and separator, preserving the current date value.

--- a/docs/DATETIME_PRESETS.md
+++ b/docs/DATETIME_PRESETS.md
@@ -14,7 +14,7 @@ Default date/time values for new tasks, configured in Preferences.
   - [Reminder Preset](#reminder-preset)
 - [Propose Mode](#propose-mode)
   - [Old Behavior (DateTimeEntry)](#old-behavior-datetimeentry)
-  - [Initial Bug (DateTimeCombo)](#initial-bug-datetimecombo2)
+  - [Initial Bug (DateTimeComboCtrl)](#initial-bug-datetimecomboctrl2)
   - [Fix](#fix)
 - [Duration Mode Interaction](#duration-mode-interaction)
 - [Suggested DateTime Computation](#suggested-datetime-computation)
@@ -26,7 +26,7 @@ Default date/time values for new tasks, configured in Preferences.
 ## TODO
 
 1. **Unify preset and propose paths through the Attribute model or
-   DateTimeCombo public API.** Currently, preset mode writes directly to
+   DateTimeComboCtrl public API.** Currently, preset mode writes directly to
    the Task constructor kwargs (`uicommand.py:1693-1708`), bypassing both
    the Attribute setter/callback chain and the editor widget API. Propose
    mode relies on the editor widget to pre-fill a display value. These two
@@ -34,7 +34,7 @@ Default date/time values for new tasks, configured in Preferences.
    public interface — either:
    - The Attribute model (setter + callback), so all domain invariants
      (recurrence, reminder clearing, child completion) fire correctly; or
-   - A new `DateTimeCombo` method such as
+   - A new `DateTimeComboCtrl` method such as
      `ActivateValue(value, proposed=True)` + `DeactivateValue()`, where
      `proposed=True` means: set the internal display value and mark the
      checkbox checked, but flag the value as "proposed" so the editor
@@ -50,8 +50,8 @@ Default date/time values for new tasks, configured in Preferences.
    completion cascade does not happen. The task is born in an inconsistent
    state. See [Constructor Bypass Problem](#constructor-bypass-problem).
 
-3. ~~**Fix propose mode for DateTimeCombo**~~ — **Done.** `suggestedValue`
-   parameter added to `DateTimeCombo.__init__()`. Editor passes preference-
+3. ~~**Fix propose mode for DateTimeComboCtrl**~~ — **Done.** `suggestedValue`
+   parameter added to `DateTimeComboCtrl.__init__()`. Editor passes preference-
    computed datetime at construction. See [Fix](#fix) section.
 
 4. **Duration mode interaction with presets needs resolution.** New tasks
@@ -138,7 +138,7 @@ When the preference starts with `"preset"`:
    in the Attribute via `Attribute.__init__()`, NOT via `.set()`.
 
 3. **Editor opens**: Reads from domain object. Value is non-None, so
-   `DateTimeCombo` is constructed with `value=datetime`, checkbox starts
+   `DateTimeComboCtrl` is constructed with `value=datetime`, checkbox starts
    checked, fields show the preset datetime.
 
 ### Constructor Bypass Problem
@@ -192,7 +192,7 @@ its "already shown" set when a reminder is snoozed.
 
 ### Old Behavior (DateTimeEntry)
 
-The old `DateTimeEntry` control (removed in the DateTimeCombo refactor)
+The old `DateTimeEntry` control (removed in the DateTimeComboCtrl refactor)
 accepted a `suggestedDateTime` parameter:
 
 ```python
@@ -221,15 +221,15 @@ Result: The display fields showed the suggested datetime (hidden behind
 The value was **never persisted** until the user checked the box and the
 editor committed it through a command.
 
-### Initial Bug (DateTimeCombo)
+### Initial Bug (DateTimeComboCtrl)
 
-`DateTimeCombo` was originally created without suggested datetime support.
+`DateTimeComboCtrl` was originally created without suggested datetime support.
 When `value=None` (propose mode), the constructor defaulted to
 `datetime.now()`, ignoring the user's preference setting entirely.
 
 ### Fix
 
-**Done.** `suggestedValue` parameter added to `DateTimeCombo.__init__()`.
+**Done.** `suggestedValue` parameter added to `DateTimeComboCtrl.__init__()`.
 The editor passes the preference-computed datetime at construction time:
 
 ```python
@@ -242,7 +242,7 @@ The sub-controls are initialized with the suggested datetime and hold it
 while the checkbox is unchecked. In preset mode, `value` is already
 non-None, so `suggestedValue` is ignored.
 
-For how the sub-controls serve as the stash for DateTimeCombo (retaining
+For how the sub-controls serve as the stash for DateTimeComboCtrl (retaining
 the proposed value through activate/deactivate cycles), see
 [DATETIME_CONTROLS.md — Sub-Control Stash Model](DATETIME_CONTROLS.md#sub-control-stash-model).
 
@@ -341,7 +341,7 @@ new snooze time.
 
 ## Related Documentation
 
-- [DATETIME_CONTROLS.md](DATETIME_CONTROLS.md) — DateTimeCombo widget API,
+- [DATETIME_CONTROLS.md](DATETIME_CONTROLS.md) — DateTimeComboCtrl widget API,
   ActivateValue/DeactivateValue, suggested datetime old behavior reference
 - [ATTRIBUTE_PATTERN.md](ATTRIBUTE_PATTERN.md) — Attribute model, setter/callback
   pattern, constructor vs `.set()` behavior, three-layer relationship

--- a/docs/DURATION_CALCULATIONS.md
+++ b/docs/DURATION_CALCULATIONS.md
@@ -40,10 +40,10 @@ Duration calculations for Edit Task Dates and Edit Effort windows.
    OPEN QUESTION: How to differentiate between loading in process
    (mode not yet set, should wait) and invalid value requiring reset
    to automatic?
-9. ~~DateTimeCombo Checkbox toggle EVT_KILL_FOCUS gap~~ — **Resolved.**
+9. ~~DateTimeComboCtrl Checkbox toggle EVT_KILL_FOCUS gap~~ — **Resolved.**
    ~~Editor binds `EVT_CHECKBOX` via `combo.Bind(wx.EVT_CHECKBOX, handler)`
    and calls `sync.commit()` explicitly.~~
-   **Update:** EVT_CHECKBOX is no longer exposed by DateTimeCombo. All
+   **Update:** EVT_CHECKBOX is no longer exposed by DateTimeComboCtrl. All
    AttributeSync instances use `EVT_VALUE_CHANGED` as `editedEventType`,
    which fires on checkbox toggle AND date/time edits. External
    EVT_CHECKBOX handlers and `sync.commit()` hacks removed.
@@ -530,4 +530,4 @@ All values are stored in hardcoded formats — no locale involvement. Locale for
 ### Internal Types
 - Durations use `date.TimeDelta` (extends `datetime.timedelta`, adds `hoursMinutesSeconds()`)
 - DateTimes use `date.DateTime` (extends `datetime.datetime`)
-- UI controls (`DurationCtrl`, `DateTimeCombo`) return these domain types directly for `AttributeSync` compatibility
+- UI controls (`DurationCtrl`, `DateTimeComboCtrl`) return these domain types directly for `AttributeSync` compatibility

--- a/docs/ICON_PICKER_REFACTORING.md
+++ b/docs/ICON_PICKER_REFACTORING.md
@@ -85,6 +85,12 @@ This document describes the custom `IconPicker` widget used in Task Coach for se
 | 33 | Add icon hints to artprovider.py | Done | `chooseableItems` dict with translatable hints arrays |
 | 34 | Test on Windows/macOS | Not Started | Cross-platform verification |
 
+### Transparent Empty Bitmap
+
+| # | Task | Status | Notes |
+|---|------|--------|-------|
+| 35 | Review if `TRANSPARENT_EMPTY_ICON` is still needed | Not Started | `ArtProvider.TRANSPARENT_EMPTY_ICON` was added to centralize transparent bitmap creation (returns a real bitmap with alpha=0). The icon picker "No icon" option needs a real bitmap because `GenBitmapButton.SetBitmapLabel()` crashes on `wx.NullBitmap`. Verify whether this is still the case — if `wx.NullBitmap` works, the constant can be removed. See `artprovider.py`. |
+
 ### Status Legend
 
 - **Done**: Completed and integrated

--- a/docs/LOCALE.md
+++ b/docs/LOCALE.md
@@ -104,7 +104,7 @@ Cascading checks for language selection:
 - **Date/time:** Python `datetime` objects. XML uses ISO-like format.
 - **The control is the locale boundary.** `NumericCtrl.GetValue()` returns
   Python float (period). `NumericCtrl.SetValue(float)` displays with locale
-  decimal. Same for `DateCtrl`, `TimeCtrl`.
+  decimal. Same for `DateComboRouterCtrl`, `TimeCtrl`.
 
 Data flow example (German locale, comma decimal):
 ```
@@ -149,7 +149,7 @@ locale, and `strftime` uses the locale's date/time formatting.
 ## Cross-References
 
 - **Date/time controls:** [DATETIME_CONTROLS.md](DATETIME_CONTROLS.md) —
-  `DateCtrl`, `TimeCtrl`, `DateTimeCombo`, locale detection via strftime
+  `DateComboRouterCtrl`, `TimeCtrl`, `DateTimeComboCtrl`, locale detection via strftime
 - **Numeric controls:** [NUMERIC_CONTROLS.md](NUMERIC_CONTROLS.md) —
   `NumericCtrl`, blur validation, decimal separator handling
 - **Monetary controls:** [MONETARY_CONTROLS.md](MONETARY_CONTROLS.md) —

--- a/docs/MONETARY_CONTROLS.md
+++ b/docs/MONETARY_CONTROLS.md
@@ -73,7 +73,7 @@ Configurable in Preferences → Regional → "Currency decimal places".
 `AttributeSync` in `BudgetPage` binds `EVT_VALUE_CHANGED` instead of
 `EVT_KILL_FOCUS` for hourly fee and fixed fee. This completes
 ATTRIBUTE_PATTERN.md TODO #1 for monetary controls, matching the pattern
-already used by `DurationCtrl` and `DateTimeCombo`.
+already used by `DurationCtrl` and `DateTimeComboCtrl`.
 
 ---
 

--- a/docs/NUMERIC_CONTROLS.md
+++ b/docs/NUMERIC_CONTROLS.md
@@ -97,7 +97,7 @@ Empty field is treated as `0.0`.
 ## EVT_VALUE_CHANGED Pattern
 
 Reuses the existing `EVT_VALUE_CHANGED` / `ValueChangedEvent` from
-`maskedtimectrl.py`. Same event type used by `DurationCtrl`, `DateTimeCombo`,
+`maskedtimectrl.py`. Same event type used by `DurationCtrl`, `DateTimeComboCtrl`,
 and now `NumericCtrl`.
 
 Fires from:

--- a/docs/TASK_STATUS_SORT.md
+++ b/docs/TASK_STATUS_SORT.md
@@ -1,0 +1,96 @@
+# Status-First Task Sorting
+
+## Overview
+
+When "Sort by status first" is enabled (default: on), tasks are grouped by
+their completion status before the selected column sort is applied.  This
+ensures active tasks always appear above inactive tasks, which appear above
+completed tasks — regardless of the primary sort column.
+
+## How It Works
+
+The sorter builds a **composite sort key** for each task:
+
+```
+sort_key = [completed(), inactive()] + [column_sort_key]
+```
+
+Python sorts tuples element-by-element, so the status booleans are evaluated
+first.  `False < True`, which produces three buckets:
+
+| completed() | inactive() | Status bucket                           | Sort position |
+|-------------|------------|-----------------------------------------|---------------|
+| False       | False      | Active, overdue, late, duetoday, due... | 1st (top)     |
+| False       | True       | Inactive                                | 2nd           |
+| True        | False      | Completed                               | 3rd (bottom)  |
+
+Within each bucket, tasks are sorted by the selected column (subject, due
+date, priority, etc.).
+
+### Example: Planned Start column, ascending (today = 2026-02-04)
+
+| # | completed() | inactive() | Planned Start  | Status   | Sort Key                          |
+|---|-------------|------------|----------------|----------|-----------------------------------|
+| 1 | False       | False      | 2026-01-15     | late     | (False, False, 2026-01-15)        |
+| 2 | False       | False      | 2026-01-20     | overdue  | (False, False, 2026-01-20)        |
+| 3 | False       | False      | 2026-02-01     | active   | (False, False, 2026-02-01)        |
+| 4 | False       | False      | 2026-02-04     | duetoday | (False, False, 2026-02-04)        |
+| 5 | False       | True       | 2026-02-10     | inactive | (False, True, 2026-02-10)         |
+| 6 | False       | True       | 2026-03-01     | inactive | (False, True, 2026-03-01)         |
+| 7 | True        | False      | 2026-01-10     | completed| (True, False, 2026-01-10)         |
+| 8 | True        | False      | 2026-01-17     | completed| (True, False, 2026-01-17)         |
+
+Note: active, overdue, late, duetoday, and duetomorrow are **all mixed
+together** in the first bucket.  The sort does not distinguish between them —
+those finer statuses only affect the task's color, not its sort position.
+Within each bucket, the planned start date determines the order.
+
+### Descending sort
+
+The bucket order is **always** Active → Inactive → Completed, regardless of
+sort direction.  Only the column sort within each bucket reverses.
+
+Internally, the descending key negates the booleans to counteract Python's
+`reverse=True`, keeping the bucket order stable.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `taskcoachlib/domain/task/sorter.py` | Composite sort key logic |
+| `taskcoachlib/domain/task/task.py:620-634` | `completed()` and `inactive()` boolean projections |
+| `taskcoachlib/domain/task/status.py` | `TaskStatus` enum (active, inactive, overdue, etc.) |
+| `taskcoachlib/gui/viewer/mixin.py:525-551` | Viewer setting integration |
+| `taskcoachlib/gui/uicommand/uicommand.py:1397` | Menu command "Sort by status first" |
+| `taskcoachlib/config/defaults.py` | Default: `True` for all task viewers |
+
+## History
+
+The status-first sort algorithm was created in 2005 by Frank Niessink:
+[`e6d0de5e` — taskcoach/taskcoachlib/task/sorter.py](https://github.com/taskcoach/taskcoach/blob/e6d0de5ee5bad37b3336bbb9dc0462772f285367/taskcoach/taskcoachlib/task/sorter.py)
+
+It was refactored in 2014 by Jérôme Laheurte for stable sort support, but
+the algorithm itself remained the same:
+[`82a114b4` — taskcoach/taskcoachlib/domain/task/sorter.py](https://github.com/taskcoach/taskcoach/blob/82a114b4bdb3f5054af6628a484a1943516a5167/taskcoach/taskcoachlib/domain/task/sorter.py)
+
+The core logic has not changed since:
+
+```python
+def __createStatusSortKey(self):
+    if self.__sortByTaskStatusFirst:
+        if self.isAscending():
+            return lambda task: [task.completed(), task.inactive()]
+        else:
+            return lambda task: [not task.completed(), not task.inactive()]
+    else:
+        return lambda task: []
+```
+
+## Design Note
+
+`completed()` and `inactive()` are both derived from `computedStatus()` —
+a task has exactly one status at a time.  The two-boolean key is a compact
+encoding that collapses all non-completed, non-inactive statuses (active,
+overdue, late, duetoday, duetomorrow) into a single bucket.  This is
+intentional: finer status distinctions are visual (color) only and do not
+affect sort order.

--- a/docs/scripts/datetime_controls_demo.py
+++ b/docs/scripts/datetime_controls_demo.py
@@ -2,7 +2,7 @@
 """
 Demo app for maskedtimectrl controls.
 Shows different dropdown list scenarios: with choices, without choices, and calendar popup.
-Also demonstrates DateTimeCombo for flexible table layouts.
+Also demonstrates DateTimeComboCtrl for flexible table layouts.
 """
 
 import sys
@@ -17,115 +17,10 @@ import wx
 import wx.adv
 app = wx.App()
 
-from taskcoachlib.widgets import maskedtimectrl
 from taskcoachlib.widgets.maskedtimectrl import (
     DurationCtrl, DurationCtrlVerbose, TimeCtrl, TimeWithSecondsCtrl,
-    DateCtrl, DateTimeCombo, _PopupWindow,
-    PopupDismissEvent, _CalendarComboPopup
+    DateComboRouterCtrl, DateTimeComboCtrl, DateCtrl
 )
-
-# =============================================================================
-# Wayland test patch: Replace _PopupWindow base class with wx.PopupWindow
-# on Wayland so dropdowns use xdg_popup (compositor-positioned) instead of
-# wx.Dialog (xdg_toplevel, which ignores Move()/SetPosition()).
-# =============================================================================
-def _is_wayland():
-    return os.environ.get("XDG_SESSION_TYPE", "").lower() == "wayland"
-
-if _is_wayland():
-    print("[Wayland] Patching _PopupWindow to use wx.PopupWindow (xdg_popup)")
-
-    # wx.PopupWindow is a real C++ type — we can't just swap __bases__ on
-    # _PopupWindow(wx.Dialog) because the C++ object type is fixed at
-    # construction. Instead, create a proper wx.PopupWindow subclass with
-    # the same interface and swap it as the base of the popup subclasses.
-
-    class _WaylandPopupWindow(wx.PopupWindow):
-        """wx.PopupWindow-based replacement for _PopupWindow on Wayland."""
-
-        def __init__(self, *args, **kwargs):
-            # Accept and ignore style/title kwargs from wx.Dialog interface
-            kwargs.pop('style', None)
-            kwargs.pop('title', None)
-            parent = args[0] if args else kwargs.pop('parent', None)
-            wx.PopupWindow.__init__(self, parent, style=wx.BORDER_NONE)
-
-            style = wx.BORDER_NONE
-            if "__WXMSW__" in wx.PlatformInfo:
-                style |= wx.WANTS_CHARS
-            self.__interior = wx.Panel(self, style=style)
-            self._dismissed = False
-
-            self.__interior.Bind(wx.EVT_CHAR, self._onChar)
-
-            self.Fill(self.__interior)
-
-            sizer = wx.BoxSizer()
-            sizer.Add(self.__interior, 1, wx.EXPAND)
-            self.SetSizer(sizer)
-
-        def interior(self):
-            return self.__interior
-
-        def Fill(self, interior):
-            pass
-
-        def Popup(self, position):
-            self.Position(position, (0, 0))
-            self.Show()
-
-        def Dismiss(self):
-            if self._dismissed:
-                return
-            self._dismissed = True
-            self.Hide()
-            try:
-                interior = self.interior()
-                if interior:
-                    interior.Unbind(wx.EVT_CHAR)
-                    interior.Unbind(wx.EVT_PAINT)
-                    interior.Unbind(wx.EVT_LEFT_UP)
-            except RuntimeError:
-                pass
-            self.ProcessEvent(PopupDismissEvent(self))
-            wx.CallLater(100, self._safeDestroy)
-
-        def _safeDestroy(self):
-            try:
-                if self:
-                    self.Destroy()
-            except RuntimeError:
-                pass
-
-        def _onChar(self, event):
-            if not self.HandleKey(event):
-                self.GetParent().OnChar(event)
-
-        def HandleKey(self, event):
-            return False
-
-    # wxPython bakes C++ type info into class objects at creation time, so
-    # __bases__ swap doesn't work. We must create entirely new classes using
-    # type() that inherit from _WaylandPopupWindow and copy all methods from
-    # the original subclasses.
-
-    _OrigChoicesPopup = maskedtimectrl._ChoicesPopup
-
-    # Collect all methods/attrs defined directly on each original class
-    def _get_class_attrs(cls):
-        attrs = {}
-        for name in cls.__dict__:
-            if name != '__dict__' and name != '__weakref__':
-                attrs[name] = cls.__dict__[name]
-        return attrs
-
-    maskedtimectrl._ChoicesPopup = type(
-        '_ChoicesPopup',
-        (_WaylandPopupWindow,),
-        _get_class_attrs(_OrigChoicesPopup)
-    )
-
-    print("[Wayland] Patch applied. Test dropdown positioning below.")
 
 
 class DemoFrame(wx.Frame):
@@ -222,6 +117,23 @@ class DemoFrame(wx.Frame):
         grid.Add(self.ctrl7, 0, wx.ALIGN_CENTER_VERTICAL)
         grid.Add(wx.StaticText(panel, label="WITH choices: [0-30], [0-23], [0,15,30,45]"), 0, wx.ALIGN_CENTER_VERTICAL)
 
+        # 1.8 Raw DateCtrl (no popup, no ComboCtrl wrapper)
+        grid.Add(wx.StaticText(panel, label="1.8 DateCtrl:"), 0, wx.ALIGN_CENTER_VERTICAL)
+        self.ctrl8 = DateCtrl(panel, comboCtrl=None,
+            year=2026, month=2, day=4)
+        grid.Add(self.ctrl8, 0, wx.ALIGN_CENTER_VERTICAL)
+        lbl_8 = wx.StaticText(panel, label="(editable, raw — no popup, no themed frame)")
+        lbl_8.SetForegroundColour(wx.Colour(128, 128, 128))
+        grid.Add(lbl_8, 0, wx.ALIGN_CENTER_VERTICAL)
+
+        # 1.9 Native wx.adv.DatePickerCtrl (GTK on Linux, Win32 DTP on Windows)
+        grid.Add(wx.StaticText(panel, label="1.9 DatePickerCtrl:"), 0, wx.ALIGN_CENTER_VERTICAL)
+        self.ctrl9 = wx.adv.DatePickerCtrl(panel, style=wx.adv.DP_DROPDOWN)
+        grid.Add(self.ctrl9, 0, wx.ALIGN_CENTER_VERTICAL)
+        lbl_9 = wx.StaticText(panel, label="(native wx.adv.DatePickerCtrl — for testing Windows)")
+        lbl_9.SetForegroundColour(wx.Colour(0, 0, 180))
+        grid.Add(lbl_9, 0, wx.ALIGN_CENTER_VERTICAL)
+
         mainSizer.Add(grid, 0, wx.ALL | wx.EXPAND, 20)
 
         # Separator
@@ -248,30 +160,50 @@ class DemoFrame(wx.Frame):
         lbl_baseline.SetForegroundColour(wx.Colour(128, 128, 128))
         dc2Grid.Add(lbl_baseline, 0, wx.ALIGN_CENTER_VERTICAL)
 
-        # 2.1 DateCtrl standalone (no checkbox, no time)
-        self.dc2EmbedDate = DateCtrl(panel,
+        # 2.1 DateComboRouterCtrl standalone (no checkbox, no time)
+        self.dc2EmbedDate = DateComboRouterCtrl(panel,
             year=2026, month=1, day=31)
-        dc2Grid.Add(wx.StaticText(panel, label="2.1 DateCtrl:"), 0,
+        dc2Grid.Add(wx.StaticText(panel, label="2.1 DateComboRouterCtrl:"), 0,
                      wx.ALIGN_CENTER_VERTICAL)
         dc2Grid.Add(self.dc2EmbedDate, 0, wx.ALIGN_CENTER_VERTICAL)
-        lbl_31 = wx.StaticText(panel, label="(standalone DateCtrl, no checkbox/time)")
+        lbl_31 = wx.StaticText(panel, label="(standalone DateComboRouterCtrl, no checkbox/time)")
         lbl_31.SetForegroundColour(wx.Colour(0, 128, 0))
         dc2Grid.Add(lbl_31, 0, wx.ALIGN_CENTER_VERTICAL)
 
-        # 2.2 DateCtrl standalone read-only
-        self.dc2EmbedDateRO = DateCtrl(panel,
+        # 2.2 DateComboRouterCtrl standalone read-only
+        self.dc2EmbedDateRO = DateComboRouterCtrl(panel,
             year=2026, month=1, day=19)
         self.dc2EmbedDateRO.SetReadOnly(True)
-        dc2Grid.Add(wx.StaticText(panel, label="2.2 DateCtrl:"), 0,
+        dc2Grid.Add(wx.StaticText(panel, label="2.2 DateComboRouterCtrl:"), 0,
                      wx.ALIGN_CENTER_VERTICAL)
         dc2Grid.Add(self.dc2EmbedDateRO, 0, wx.ALIGN_CENTER_VERTICAL)
-        lbl_32 = wx.StaticText(panel, label="(standalone DateCtrl, read-only)")
+        lbl_32 = wx.StaticText(panel, label="(standalone DateComboRouterCtrl, read-only)")
         lbl_32.SetForegroundColour(wx.Colour(128, 128, 128))
         dc2Grid.Add(lbl_32, 0, wx.ALIGN_CENTER_VERTICAL)
 
+        # 2.7 DateComboRouterCtrl with explicit ISO format (YMD-)
+        self.dc2Iso = DateComboRouterCtrl(panel,
+            year=2026, month=2, day=14, dateFormat="YMD-")
+        dc2Grid.Add(wx.StaticText(panel, label="2.7 DateComboRouterCtrl:"), 0,
+                     wx.ALIGN_CENTER_VERTICAL)
+        dc2Grid.Add(self.dc2Iso, 0, wx.ALIGN_CENTER_VERTICAL)
+        lbl_iso = wx.StaticText(panel, label="(explicit dateFormat='YMD-')")
+        lbl_iso.SetForegroundColour(wx.Colour(0, 0, 180))
+        dc2Grid.Add(lbl_iso, 0, wx.ALIGN_CENTER_VERTICAL)
+
+        # 2.8 DateComboRouterCtrl with European format (DMY.)
+        self.dc2Eur = DateComboRouterCtrl(panel,
+            year=2026, month=2, day=14, dateFormat="DMY.")
+        dc2Grid.Add(wx.StaticText(panel, label="2.8 DateComboRouterCtrl:"), 0,
+                     wx.ALIGN_CENTER_VERTICAL)
+        dc2Grid.Add(self.dc2Eur, 0, wx.ALIGN_CENTER_VERTICAL)
+        lbl_eur = wx.StaticText(panel, label="(explicit dateFormat='DMY.')")
+        lbl_eur.SetForegroundColour(wx.Colour(0, 0, 180))
+        dc2Grid.Add(lbl_eur, 0, wx.ALIGN_CENTER_VERTICAL)
+
         mainSizer.Add(dc2Grid, 0, wx.ALL | wx.EXPAND, 20)
 
-        # --- 3.3-3.6 DateTimeCombo (DateCtrl-based, same API as section 1) ---
+        # --- 3.3-3.6 DateTimeComboCtrl (DateComboRouterCtrl-based, same API as section 1) ---
         dc3Grid = wx.FlexGridSizer(cols=5, hgap=10, vgap=8)
 
         # Header row
@@ -286,7 +218,7 @@ class DemoFrame(wx.Frame):
         dc3Grid.Add(wx.StaticText(panel, label=""), 0)
 
         # 2.3 Planned Start (checked, with dropdowns)
-        self.dc3PlannedStartCombo = DateTimeCombo(
+        self.dc3PlannedStartCombo = DateTimeComboCtrl(
             panel,
             value=datetime.datetime(2026, 1, 20, 9, 0),
             hourChoices=[8, 9, 10, 11, 12],
@@ -301,7 +233,7 @@ class DemoFrame(wx.Frame):
                      wx.ALIGN_CENTER_VERTICAL)
 
         # 2.4 Due Date (unchecked)
-        self.dc3DueDateCombo = DateTimeCombo(
+        self.dc3DueDateCombo = DateTimeComboCtrl(
             panel,
             value=None,
             hourChoices=[17, 18, 19, 20, 21],
@@ -316,7 +248,7 @@ class DemoFrame(wx.Frame):
                      wx.ALIGN_CENTER_VERTICAL)
 
         # 2.5 Completed (read-only / editable toggle)
-        self.dc3CompletedCombo = DateTimeCombo(
+        self.dc3CompletedCombo = DateTimeComboCtrl(
             panel,
             value=datetime.datetime(2026, 1, 19, 14, 30)
         )
@@ -331,7 +263,7 @@ class DemoFrame(wx.Frame):
         dc3Grid.Add(lbl_dc3_ro, 0, wx.ALIGN_CENTER_VERTICAL)
 
         # 2.6 Reminder (checked, no time dropdowns)
-        self.dc3ReminderCombo = DateTimeCombo(
+        self.dc3ReminderCombo = DateTimeComboCtrl(
             panel,
             value=datetime.datetime(2026, 1, 21, 8, 0)
         )
@@ -387,7 +319,7 @@ class DemoFrame(wx.Frame):
             "Dropdown List Behavior:\n"
             "- None: NO dropdown (Up/Down arrows still increment/decrement)\n"
             "- [1,2,3,...]: provides dropdown with those choices\n\n"
-            "DateTimeCombo States (checkbox state determined by value):\n"
+            "DateTimeComboCtrl States (checkbox state determined by value):\n"
             "- value=datetime -> checkbox ON, fields editable\n"
             "- value=None -> checkbox OFF, fields disabled\n"
             "- SetEditable(False) -> checkbox ON but disabled, fields greyed (read-only)\n\n"
@@ -401,7 +333,7 @@ class DemoFrame(wx.Frame):
         self.Centre()
 
     def _onToggleDc3Completed(self, event):
-        """Toggle read-only/editable on the 2.5 Completed DateTimeCombo."""
+        """Toggle read-only/editable on the 2.5 Completed DateTimeComboCtrl."""
         if self.dc3CompletedCombo.IsEditable():
             self.dc3CompletedCombo.SetReadOnly()
         else:

--- a/taskcoachlib/gui/artprovider.py
+++ b/taskcoachlib/gui/artprovider.py
@@ -100,9 +100,21 @@ class ArtProvider(wx.ArtProvider):
 
         return result_image.ConvertToBitmap()
 
+    # Art ID for a transparent placeholder bitmap (real bitmap object with
+    # alpha=0). Needed where a wx.Bitmap object is required but should appear
+    # empty — e.g. icon picker "No icon" option, toolbar image list slots.
+    # NOTE: This may no longer be needed if all callers can handle
+    # wx.NullBitmap. Check icon picker and toolbar customization dialog.
+    TRANSPARENT_EMPTY_ICON = "transparent_empty_icon"
+
     def _CreateBitmap(self, artId, artClient, size) -> wx.Bitmap:
         if not artId or artId == "nobitmap":
-            return wx.Bitmap(*size)
+            return wx.NullBitmap
+
+        if artId == self.TRANSPARENT_EMPTY_ICON:
+            img = wx.Image(*size)
+            img.InitAlpha()
+            return img.ConvertToBitmap()
 
         # Try new format first: "16x16/iconname.png" (size-based directories)
         size_dir = "%dx%d" % (size[0], size[1])

--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -1267,7 +1267,7 @@ class DatesPage(ScrolledPage):
         # value=None means no date set, value=datetime means date exists
         value = plannedStartDateTime if plannedStartDateTime != date.DateTime() else None
 
-        self._plannedStartDateTimeCombo = widgets.DateTimeCombo(
+        self._plannedStartDateTimeCombo = widgets.DateTimeComboCtrl(
             self, value=value,
             suggestedValue=task.Task.suggestedPlannedStartDateTime(),
             hourChoices=lambda: get_suggested_hour_choices(self._DatesPage__settings),
@@ -1405,7 +1405,7 @@ class DatesPage(ScrolledPage):
         # value=None means no date set, value=datetime means date exists
         value = dueDateTime if dueDateTime != date.DateTime() else None
 
-        self._dueDateTimeCombo = widgets.DateTimeCombo(
+        self._dueDateTimeCombo = widgets.DateTimeComboCtrl(
             self, value=value,
             suggestedValue=task.Task.suggestedDueDateTime(),
             hourChoices=lambda: get_suggested_hour_choices(self._DatesPage__settings),
@@ -1439,7 +1439,7 @@ class DatesPage(ScrolledPage):
         self.__updatePresetSelection()
 
     def _addActualStartDateEntry(self):
-        """Add actual start date entry using DateTimeCombo."""
+        """Add actual start date entry using DateTimeComboCtrl."""
         actualStartDateTime = (
             self.items[0].actualStartDateTime()
             if len(self.items) == 1
@@ -1450,7 +1450,7 @@ class DatesPage(ScrolledPage):
         # value=None means no date set, value=datetime means date exists
         value = actualStartDateTime if actualStartDateTime != date.DateTime() else None
 
-        self._actualStartDateTimeCombo = widgets.DateTimeCombo(
+        self._actualStartDateTimeCombo = widgets.DateTimeComboCtrl(
             self, value=value,
             suggestedValue=task.Task.suggestedActualStartDateTime(),
             hourChoices=lambda: get_suggested_hour_choices(self._DatesPage__settings),
@@ -1480,7 +1480,7 @@ class DatesPage(ScrolledPage):
         self._currentActualStartDateTime = value
 
     def _addCompletionDateEntry(self):
-        """Add completion date entry using DateTimeCombo with AttributeSync."""
+        """Add completion date entry using DateTimeComboCtrl with AttributeSync."""
         completionDateTime = (
             self.items[0].completionDateTime()
             if len(self.items) == 1
@@ -1490,7 +1490,7 @@ class DatesPage(ScrolledPage):
         # value=None means no date set, value=datetime means date exists
         value = completionDateTime if completionDateTime != date.DateTime() else None
 
-        self._completionDateTimeCombo = widgets.DateTimeCombo(
+        self._completionDateTimeCombo = widgets.DateTimeComboCtrl(
             self, value=value,
             suggestedValue=task.Task.suggestedCompletionDateTime(),
             hourChoices=lambda: get_suggested_hour_choices(self._DatesPage__settings),
@@ -1877,7 +1877,7 @@ class DatesPage(ScrolledPage):
         self.__updateDurationModeDropdown()
 
     def addReminderEntry(self):
-        """Add reminder entry using DateTimeCombo."""
+        """Add reminder entry using DateTimeComboCtrl."""
         reminderDateTime = (
             self.items[0].reminder()
             if len(self.items) == 1
@@ -1888,7 +1888,7 @@ class DatesPage(ScrolledPage):
         # value=None means no date set, value=datetime means date exists
         value = reminderDateTime if reminderDateTime != date.DateTime() else None
 
-        self._reminderDateTimeCombo = widgets.DateTimeCombo(
+        self._reminderDateTimeCombo = widgets.DateTimeComboCtrl(
             self, value=value,
             suggestedValue=task.Task.suggestedReminderDateTime(),
             hourChoices=lambda: get_suggested_hour_choices(self._DatesPage__settings),
@@ -1950,7 +1950,7 @@ class DatesPage(ScrolledPage):
 
     def entries(self):
         # pylint: disable=E1101
-        # For DateTimeCombo controls, return the date control as the focusable widget
+        # For DateTimeComboCtrl controls, return the date control as the focusable widget
         return dict(
             firstEntry=self._plannedStartDateTimeCombo.GetDateCtrl(),
             plannedStartDateTime=self._plannedStartDateTimeCombo.GetDateCtrl(),
@@ -2089,7 +2089,7 @@ class BudgetPage(ScrolledPage):
             currentBudget,
             self.items,
             command.EditBudgetCommand,
-            wx.EVT_KILL_FOCUS,
+            widgets.EVT_VALUE_CHANGED,
             self.items[0].budgetChangedEventType(),
         )
         self.addEntry(
@@ -3670,7 +3670,7 @@ class EffortEditBook(Page):
 
         # --- Start row: Label, DateTime row (checkbox hidden), Button ---
         current_start_date_time = self.items[0].getStart()
-        self._startDateTimeCombo = widgets.DateTimeCombo(
+        self._startDateTimeCombo = widgets.DateTimeComboCtrl(
             self,
             value=current_start_date_time,
             showSeconds=True,
@@ -3805,7 +3805,7 @@ class EffortEditBook(Page):
         )
 
         # --- Stop row: Label, DateTime row (with checkbox), Button ---
-        self._stopDateTimeCombo = widgets.DateTimeCombo(
+        self._stopDateTimeCombo = widgets.DateTimeComboCtrl(
             self,
             value=current_stop_date_time,
             showSeconds=True,

--- a/taskcoachlib/gui/dialog/entry.py
+++ b/taskcoachlib/gui/dialog/entry.py
@@ -752,12 +752,12 @@ class RecurrenceEntry(wx.Panel):
         )
         maxPanel.SetSizerAndFit(panelSizer)
 
-        # Stop after date using new DateTimeCombo control
+        # Stop after date using DateTimeComboCtrl
         stopPanel = wx.Panel(self)
         panelSizer = wx.BoxSizer(wx.HORIZONTAL)
 
         # value=None means unchecked (no stop date); when user checks it, defaults to "now"
-        self._recurrenceStopDateTimeCombo = widgets.DateTimeCombo(
+        self._recurrenceStopDateTimeCombo = widgets.DateTimeComboCtrl(
             stopPanel,
             value=None,  # unchecked by default
             hourChoices=lambda: get_suggested_hour_choices(self._settings),

--- a/taskcoachlib/gui/dialog/preferences.py
+++ b/taskcoachlib/gui/dialog/preferences.py
@@ -1437,20 +1437,14 @@ class LanguagePage(SettingsPage):
         dateFormatPanel.SetSizer(dateFormatSizer)
         self.addEntry(_("Date format"), dateFormatPanel)
 
-        # Demo DateCtrl showing the selected format (interactive, starts with today)
-        from taskcoachlib.widgets.maskedtimectrl import DateCtrl
-        import datetime
-        today = datetime.date.today()
+        # Demo DateComboRouterCtrl showing the selected format (interactive, starts with today)
         demoPanel = wx.Panel(self)
         demoSizer = wx.BoxSizer(wx.HORIZONTAL)
         demoLabel = wx.StaticText(demoPanel, label=_("Preview:"))
         demoSizer.Add(demoLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10)
-        self._demoDateCtrl = DateCtrl(
-            demoPanel,
-            year=today.year, month=today.month, day=today.day,
-            dateFormat=currentFormat or None
-        )
-        demoSizer.Add(self._demoDateCtrl, 0, wx.ALIGN_CENTER_VERTICAL)
+        self._demoDatePanel = demoPanel
+        self._demoDateCtrl = None
+        self._rebuildDemoDateCtrl(currentFormat or None)
         demoPanel.SetSizer(demoSizer)
         self.addEntry("", demoPanel)
 
@@ -1492,21 +1486,13 @@ class LanguagePage(SettingsPage):
         self.addEntry(_("Time format"), timeFormatPanel)
 
         # Demo TimeCtrl showing the selected format (interactive, starts with current time)
-        # TimeCtrl now has built-in defaults from settings, so no need to pass choices
-        from taskcoachlib.widgets.maskedtimectrl import TimeCtrl
         timeDemoPanel = wx.Panel(self)
         timeDemoSizer = wx.BoxSizer(wx.HORIZONTAL)
         timeDemoLabel = wx.StaticText(timeDemoPanel, label=_("Preview:"))
         timeDemoSizer.Add(timeDemoLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10)
-        now = datetime.datetime.now()
-        # Pass explicit timeFormat to preview the selected format (not yet saved to settings)
-        effectiveFormat = currentTimeFormat if currentTimeFormat else "24"
-        self._demoTimeCtrl = TimeCtrl(
-            timeDemoPanel,
-            hours=now.hour, minutes=now.minute,
-            timeFormat=effectiveFormat
-        )
-        timeDemoSizer.Add(self._demoTimeCtrl, 0, wx.ALIGN_CENTER_VERTICAL)
+        self._demoTimePanel = timeDemoPanel
+        self._demoTimeCtrl = None
+        self._rebuildDemoTimeCtrl(currentTimeFormat if currentTimeFormat else "24")
         timeDemoPanel.SetSizer(timeDemoSizer)
         self.addEntry("", timeDemoPanel)
 
@@ -1733,66 +1719,56 @@ class LanguagePage(SettingsPage):
                 return choice.GetClientData(choice.GetSelection())
         return ""
 
-    def _onDateFormatChange(self, event):
-        """Handle date format dropdown change - update demo control and restart warning."""
-        choice = event.GetEventObject()
-        newFormat = choice.GetClientData(choice.GetSelection())
-
-        # Recreate the demo DateCtrl with new format, using today's date
-        from taskcoachlib.widgets.maskedtimectrl import DateCtrl
+    def _rebuildDemoDateCtrl(self, dateFormat):
+        """(Re)create the demo DateComboRouterCtrl with the given format."""
+        from taskcoachlib.widgets.maskedtimectrl import DateComboRouterCtrl
         import datetime
         today = datetime.date.today()
-        parent = self._demoDateCtrl.GetParent()
+        parent = self._demoDatePanel
         sizer = parent.GetSizer()
-
-        # Destroy old and create new with today's date
-        self._demoDateCtrl.Destroy()
-        self._demoDateCtrl = DateCtrl(
+        if self._demoDateCtrl:
+            self._demoDateCtrl.Destroy()
+        self._demoDateCtrl = DateComboRouterCtrl(
             parent,
-            year=today.year,
-            month=today.month,
-            day=today.day,
-            dateFormat=newFormat or None
+            year=today.year, month=today.month, day=today.day,
+            dateFormat=dateFormat
         )
         sizer.Add(self._demoDateCtrl, 0, wx.ALIGN_CENTER_VERTICAL)
         parent.Layout()
         parent.Fit()
 
-        # Update restart warning
-        self._updateRestartWarning()
+    def _rebuildDemoTimeCtrl(self, timeFormat):
+        """(Re)create the demo TimeCtrl with the given format."""
+        from taskcoachlib.widgets.maskedtimectrl import TimeCtrl
+        import datetime
+        now = datetime.datetime.now()
+        parent = self._demoTimePanel
+        sizer = parent.GetSizer()
+        if self._demoTimeCtrl:
+            self._demoTimeCtrl.Destroy()
+        self._demoTimeCtrl = TimeCtrl(
+            parent,
+            hours=now.hour, minutes=now.minute,
+            timeFormat=timeFormat
+        )
+        sizer.Add(self._demoTimeCtrl, 0, wx.ALIGN_CENTER_VERTICAL)
+        parent.Layout()
+        parent.Fit()
 
+    def _onDateFormatChange(self, event):
+        """Handle date format dropdown change - update demo control and restart warning."""
+        choice = event.GetEventObject()
+        newFormat = choice.GetClientData(choice.GetSelection())
+        self._rebuildDemoDateCtrl(newFormat or None)
+        self._updateRestartWarning()
         event.Skip()
 
     def _onTimeFormatChange(self, event):
         """Handle time format dropdown change - update demo control and restart warning."""
         choice = event.GetEventObject()
         newFormat = choice.GetClientData(choice.GetSelection())
-
-        # Recreate the demo TimeCtrl with new format, using current time
-        # TimeCtrl has built-in defaults, just pass the format to preview
-        from taskcoachlib.widgets.maskedtimectrl import TimeCtrl
-        import datetime
-        now = datetime.datetime.now()
-        parent = self._demoTimeCtrl.GetParent()
-        sizer = parent.GetSizer()
-
-        # Determine effective format for preview
-        effectiveFormat = newFormat if newFormat else "24"
-
-        # Destroy old and create new with current time
-        self._demoTimeCtrl.Destroy()
-        self._demoTimeCtrl = TimeCtrl(
-            parent,
-            hours=now.hour, minutes=now.minute,
-            timeFormat=effectiveFormat
-        )
-        sizer.Add(self._demoTimeCtrl, 0, wx.ALIGN_CENTER_VERTICAL)
-        parent.Layout()
-        parent.Fit()
-
-        # Update restart warning
+        self._rebuildDemoTimeCtrl(newFormat if newFormat else "24")
         self._updateRestartWarning()
-
         event.Skip()
 
     def _onDecimalSepChange(self, event):

--- a/taskcoachlib/gui/menu.py
+++ b/taskcoachlib/gui/menu.py
@@ -837,6 +837,7 @@ class TaskPriorityMenu(Menu):
         )
 
 
+
 class HelpMenu(Menu):
     def __init__(self, mainwindow, settings, iocontroller):
         super().__init__(mainwindow)
@@ -852,6 +853,8 @@ class HelpMenu(Menu):
             None,
             uicommand.HelpTranslate(),
             None,
+        )
+        self.appendUICommands(
             uicommand.HelpAbout(),
             uicommand.CheckForUpdate(settings=settings),
             uicommand.HelpLicense(),

--- a/taskcoachlib/gui/uicommand/uicommand.py
+++ b/taskcoachlib/gui/uicommand/uicommand.py
@@ -3126,6 +3126,7 @@ class CheckForUpdate(URLCommand):
         )
 
 
+
 class MainWindowRestore(base_uicommand.UICommand):
     def __init__(self, *args, **kwargs):
         super().__init__(

--- a/taskcoachlib/gui/viewer/inplace_editor.py
+++ b/taskcoachlib/gui/viewer/inplace_editor.py
@@ -61,7 +61,7 @@ class KillFocusAcceptsEditsMixin(object):
         if wx.Window.FindFocus() in window_and_all_children(self):
             return True
 
-        # Check if any DateTimeCombo has an open popup
+        # Check if any DateTimeComboCtrl has an open popup
         if hasattr(self, '_dateTimeCombo') and self._dateTimeCombo.HasOpenPopup():
             return True
 
@@ -189,22 +189,22 @@ class AmountCtrl(
 class DateTimeCtrl(
     EscapeKeyMixin, KillFocusAcceptsEditsMixin, hypertreelist.EditCtrl, Panel
 ):
-    """Inline date and time picker control using DateTimeCombo."""
+    """Inline date and time picker control using DateTimeComboCtrl."""
 
     def __init__(self, parent, wxId, item, column, owner, value, **kwargs):
         # TODO: The "relative" preset offset dropdown (showing durations like
         # "+1 day", "+1 week" relative to planned start) is not yet implemented
-        # in DateTimeCombo. This would need to be added as a duration field
+        # in DateTimeComboCtrl. This would need to be added as a duration field
         # with duration presets. For now, we ignore the relative parameter.
         kwargs.pop("relative", False)
         kwargs.pop("startDateTime", None)
         super().__init__(parent, wxId, item, column, owner)
         settings = kwargs["settings"]
 
-        # Convert empty DateTime to None for DateTimeCombo (unchecked state)
+        # Convert empty DateTime to None for DateTimeComboCtrl (unchecked state)
         combo_value = None if value == date.DateTime() else value
 
-        self._dateTimeCombo = widgets.DateTimeCombo(
+        self._dateTimeCombo = widgets.DateTimeComboCtrl(
             self,
             value=combo_value,
             hourChoices=lambda: get_suggested_hour_choices(settings),

--- a/taskcoachlib/gui/viewer/task.py
+++ b/taskcoachlib/gui/viewer/task.py
@@ -57,7 +57,7 @@ class DueDateTimeCtrl(inplace_editor.DateTimeCtrl):
     TODO: The old smartdatetimectrl had a "relative preset" dropdown that showed
     duration offsets like "+1 day", "+1 week" relative to the planned start date.
     This feature would need to be reimplemented as a separate duration field with
-    duration presets in DateTimeCombo. The settings key "feature.task_duration_presets"
+    duration presets in DateTimeComboCtrl. The settings key "feature.task_duration_presets"
     stores the user's custom duration choices. For now, due dates are edited as
     absolute datetime values only.
     """

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,10 +41,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "64"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.1.64
+patch = "65"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.1.65
 
-release_day = "2"  # Day of the release (1-31)
+release_day = "4"  # Day of the release (1-31)
 release_month = "February"  # Month of the release
 release_year = "2026"  # Year of the release
 

--- a/taskcoachlib/widgets/__init__.py
+++ b/taskcoachlib/widgets/__init__.py
@@ -33,8 +33,10 @@ from .maskedtimectrl import (
     DurationCtrlVerbose as MaskedDurationCtrlVerbose,
     TimeCtrl as MaskedTimeCtrl,
     TimeWithSecondsCtrl as MaskedTimeWithSecondsCtrl,
-    DateCtrl as MaskedDateCtrl,
-    DateTimeCombo,
+    DateCtrl,
+    DateComboCustomCtrl,
+    DateComboRouterCtrl,
+    DateTimeComboCtrl,
     EVT_VALUE_CHANGED,
 )
 from .textctrl import (

--- a/taskcoachlib/widgets/maskedtimectrl.py
+++ b/taskcoachlib/widgets/maskedtimectrl.py
@@ -68,6 +68,7 @@ IMPORTANT - Focus Event Handling for External Code:
 """
 
 import wx
+import wx.adv
 import math
 import datetime
 import time
@@ -780,7 +781,7 @@ def drawFocusRect(win, dc, x, y, w, h):
 
 
 class NumericField:
-    """A numeric subfield within a FieldsCtrl."""
+    """A numeric subfield within a MaskedFieldsCtrl."""
 
     def __init__(self, name, width, minVal, maxVal, value, choices, observer, padZeros=True):
         self.__name = name
@@ -807,7 +808,7 @@ class NumericField:
         oldValue = self.__value
         value = max(self.__minVal, min(self.__maxVal, int(value)))
         self.__value = value
-        # Always validate (e.g., DateCtrl adjusts day when month changes)
+        # Always validate (e.g., DateComboCustomCtrl adjusts day when month changes)
         result = self.__observer.ValidateChange(self, value)
         if result is None:
             # Validation rejected - restore old value
@@ -972,7 +973,7 @@ class NumericField:
         return False
 
 
-class FieldsCtrl(wx.Panel):
+class MaskedFieldsCtrl(wx.Panel):
     """
     Base control with explicit subfields and labels.
     Visually identical to smartdatetimectrl Entry - single painted field.
@@ -1411,7 +1412,7 @@ class FieldsCtrl(wx.Panel):
         wx.PostEvent(self, event)
 
 
-class DurationCtrl(FieldsCtrl):
+class DurationCtrl(MaskedFieldsCtrl):
     """Duration control: DDDd HH:MM[:SS] with translatable 'd' suffix.
 
     Args:
@@ -1535,7 +1536,7 @@ class DurationCtrl(FieldsCtrl):
         self.SetDuration(duration)
 
 
-class DurationCtrlVerbose(FieldsCtrl):
+class DurationCtrlVerbose(MaskedFieldsCtrl):
     """Duration control with full word suffixes: 000 days 00 hours 00 mins [00 secs].
 
     Args:
@@ -1661,7 +1662,7 @@ class DurationCtrlVerbose(FieldsCtrl):
         self.SetDuration(duration)
 
 
-class TimeCtrl(FieldsCtrl):
+class TimeCtrl(MaskedFieldsCtrl):
     """Simple time control: HH:MM (24-hour) or HH:MM AM/PM (12-hour).
 
     Supports both 24-hour and 12-hour time formats. The format can be
@@ -1768,7 +1769,7 @@ class TimeCtrl(FieldsCtrl):
         self.SetFieldValue('minute', t.minute)
 
 
-class TimeWithSecondsCtrl(FieldsCtrl):
+class TimeWithSecondsCtrl(MaskedFieldsCtrl):
     """Time control with seconds: HH:MM:SS (24-hour) or HH:MM:SS AM/PM (12-hour).
 
     Supports both 24-hour and 12-hour time formats. The format can be
@@ -1952,8 +1953,8 @@ class _CalendarComboPopup(wx.ComboPopup):
         size = self._getExtent(dc)
         return size
 
-    def _getDateCtrl2(self):
-        """Get the DateCtrl (ComboCtrl) that owns this popup."""
+    def _getDateComboCustomCtrl(self):
+        """Get the DateComboCustomCtrl (ComboCtrl) that owns this popup."""
         combo = self.GetComboCtrl()
         if combo:
             if hasattr(combo, '_dateCtrl') and hasattr(combo, '_setDateFromCalendar'):
@@ -1962,7 +1963,7 @@ class _CalendarComboPopup(wx.ComboPopup):
 
     def OnPopup(self):
         """Called when popup is shown — sync selection from parent or text."""
-        dc2 = self._getDateCtrl2()
+        dc2 = self._getDateComboCustomCtrl()
         if dc2:
             self._selection = dc2._dateCtrl.GetDate()
             self._font = dc2._dateCtrl.GetFont()
@@ -2001,7 +2002,7 @@ class _CalendarComboPopup(wx.ComboPopup):
         if keyCode in (wx.WXK_ESCAPE, wx.WXK_F4):
             self.Dismiss()
         elif keyCode == wx.WXK_RETURN:
-            dc2 = self._getDateCtrl2()
+            dc2 = self._getDateComboCustomCtrl()
             if dc2:
                 dc2._setDateFromCalendar(self._highlightedDate)
             self.Dismiss()
@@ -2253,7 +2254,7 @@ class _CalendarComboPopup(wx.ComboPopup):
                 and event.GetY() >= y
                 and event.GetY() < y + self._maxDim
             ):
-                dc2 = self._getDateCtrl2()
+                dc2 = self._getDateComboCustomCtrl()
                 if dc2:
                     dc2._setDateFromCalendar(
                         datetime.date(year=year, month=month, day=day)
@@ -2280,10 +2281,10 @@ class _CalendarComboPopup(wx.ComboPopup):
         pass
 
 
-class _EmbeddedDateCtrl(FieldsCtrl):
+class DateCtrl(MaskedFieldsCtrl):
     """Date control designed for embedding inside a ComboCtrl.
 
-    A clean copy of DateCtrl with all popup/frame/calendar logic removed.
+    Raw masked date fields with all popup/frame/calendar logic removed.
     The parent ComboCtrl owns the dropdown — this control only handles
     subfield editing, keyboard navigation, and date validation.
 
@@ -2337,7 +2338,7 @@ class _EmbeddedDateCtrl(FieldsCtrl):
 
         Uses IsThisEnabled() (own state) instead of IsEnabled() (parent chain)
         so that disabling the parent ComboCtrl for read-only visuals doesn't
-        trigger the "N/A" branch. Only a direct Enable(False) on DateCtrl
+        trigger the "N/A" branch. Only a direct Enable(False) on DateComboCustomCtrl
         (which propagates to this control's own state) shows "N/A".
 
         No frame drawing — the parent ComboCtrl provides the frame.
@@ -2403,7 +2404,8 @@ class _EmbeddedDateCtrl(FieldsCtrl):
 
         # F4/Enter open the parent ComboCtrl popup
         if keyCode in (wx.WXK_RETURN, wx.WXK_NUMPAD_ENTER, wx.WXK_F4):
-            self._comboCtrl.Popup()
+            if self._comboCtrl:
+                self._comboCtrl.Popup()
             return
 
         # Left/Right arrows navigate between subfields
@@ -2482,10 +2484,10 @@ class _EmbeddedDateCtrl(FieldsCtrl):
         self.SetFieldValue('date_day', d.day)
 
 
-class DateCtrl(wx.ComboCtrl):
-    """Date control: _EmbeddedDateCtrl inside a ComboCtrl.
+class DateComboCustomCtrl(wx.ComboCtrl):
+    """Date control: DateCtrl inside a ComboCtrl.
 
-    Uses _EmbeddedDateCtrl which has all popup/frame logic removed at the
+    Uses DateCtrl which has all popup/frame logic removed at the
     class level. The ComboCtrl provides the native dropdown button and
     manages popup positioning.
     """
@@ -2501,7 +2503,7 @@ class DateCtrl(wx.ComboCtrl):
         self.SetPopupControl(self._calendarPopup)
 
         # Clean embedded DateCtrl — no monkey-patches needed
-        self._dateCtrl = _EmbeddedDateCtrl(
+        self._dateCtrl = DateCtrl(
             self, comboCtrl=self, year=year, month=month, day=day,
             minDate=minDate, maxDate=maxDate, dateFormat=dateFormat
         )
@@ -2609,7 +2611,7 @@ class DateCtrl(wx.ComboCtrl):
         """Set read-only mode: values greyed but visible, dropdown disabled.
 
         Disables the ComboCtrl (greys the dropdown button) and sets inner
-        _EmbeddedDateCtrl to read-only. The inner control's _onPaint uses
+        DateCtrl to read-only. The inner control's _onPaint uses
         IsThisEnabled() so it shows greyed values, not "N/A", even though
         the parent ComboCtrl is disabled.
         """
@@ -2624,7 +2626,7 @@ class DateCtrl(wx.ComboCtrl):
         return self.IsPopupShown()
 
     def Bind(self, eventType, handler, source=None, id=wx.ID_ANY, id2=wx.ID_ANY):
-        """Forward UI events to inner _EmbeddedDateCtrl.
+        """Forward UI events to inner DateCtrl.
 
         Events like EVT_VALUE_CHANGED, EVT_KEY_DOWN, EVT_KILL_FOCUS, and
         EVT_SET_FOCUS fire on the inner control, not the ComboCtrl wrapper.
@@ -2644,8 +2646,197 @@ class DateCtrl(wx.ComboCtrl):
     def SetFocus(self):
         self._dateCtrl.SetFocus()
 
-class DateTimeCombo(wx.EvtHandler):
-    """Composite date/time control with checkbox, DateCtrl, and TimeCtrl.
+
+class _NativeDateCtrl(wx.Panel):
+    """Windows wrapper around wx.adv.DatePickerCtrl.
+
+    Provides the same public API as DateComboCustomCtrl so
+    DateComboRouterCtrl callers don't need platform branches.
+
+    Uses the Win32 Date-Time Picker control underneath, which provides:
+    - Native rendering matching Windows theme
+    - Correct tab navigation
+    - Screen reader accessibility
+    - Built-in dropdown calendar popup
+    """
+
+    def __init__(self, parent, year=None, month=None, day=None,
+                 minDate=None, maxDate=None, dateFormat=None):
+        super().__init__(parent)
+
+        today = datetime.date.today()
+        if year is None:
+            year = today.year
+        if month is None:
+            month = today.month
+        if day is None:
+            day = today.day
+
+        self._readOnly = False
+        self._showingNA = False
+
+        # Create native date picker (wx.DateTime months are 0-based)
+        wxdt = wx.DateTime.FromDMY(day, month - 1, year)
+        self._picker = wx.adv.DatePickerCtrl(
+            self, dt=wxdt, style=wx.adv.DP_DROPDOWN
+        )
+
+        # Set date range if specified
+        if minDate is not None or maxDate is not None:
+            wxMin = self._date_to_wxdt(minDate) if minDate else wx.DefaultDateTime
+            wxMax = self._date_to_wxdt(maxDate) if maxDate else wx.DefaultDateTime
+            self._picker.SetRange(wxMin, wxMax)
+
+        # Apply custom date format via Win32 DTM_SETFORMATW
+        if dateFormat is not None:
+            self.SetDateFormat(dateFormat)
+
+        # Bridge native EVT_DATE_CHANGED → app's EVT_VALUE_CHANGED
+        self._picker.Bind(wx.adv.EVT_DATE_CHANGED, self._onDateChanged)
+
+        # Layout: picker fills the panel
+        sizer = wx.BoxSizer(wx.HORIZONTAL)
+        sizer.Add(self._picker, 1, wx.EXPAND)
+        self.SetSizer(sizer)
+        self.SetMinSize(self._picker.GetBestSize())
+
+        # Paint handler for "N/A" when disabled (picker hidden)
+        self.bindPaintNA = lambda evt: self._onPaintNA(evt)
+        self.Bind(wx.EVT_PAINT, self.bindPaintNA)
+
+    # --- Date conversion helpers ---
+
+    @staticmethod
+    def _wxdt_to_date(wxdt):
+        """wx.DateTime → datetime.date"""
+        return datetime.date(wxdt.GetYear(), wxdt.GetMonth() + 1, wxdt.GetDay())
+
+    @staticmethod
+    def _date_to_wxdt(d):
+        """datetime.date → wx.DateTime"""
+        return wx.DateTime.FromDMY(d.day, d.month - 1, d.year)
+
+    # --- N/A paint ---
+
+    def _onPaintNA(self, event):
+        """Paint 'N/A' centered when disabled. No-op when picker is visible."""
+        if not self._showingNA:
+            event.Skip()
+            return
+        dc = wx.PaintDC(self)
+        w, h = self.GetClientSize()
+        dc.SetBackground(wx.Brush(
+            wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW)))
+        dc.Clear()
+        dc.SetFont(self._picker.GetFont())
+        dc.SetTextForeground(
+            wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
+        text = "N/A"
+        tw, th = dc.GetTextExtent(text)
+        dc.DrawText(text, (w - tw) // 2, (h - th) // 2)
+
+    # --- Event bridge ---
+
+    def _onDateChanged(self, event):
+        """Bridge native EVT_DATE_CHANGED → app's EVT_VALUE_CHANGED."""
+        evt = ValueChangedEvent(self)
+        wx.PostEvent(self, evt)
+
+    # --- Public API (matching DateComboCustomCtrl) ---
+
+    def GetDate(self):
+        """Return current date as datetime.date."""
+        return self._wxdt_to_date(self._picker.GetValue())
+
+    def SetDate(self, d):
+        """Set date from datetime.date."""
+        self._picker.SetValue(self._date_to_wxdt(d))
+
+    def SetReadOnly(self, readOnly=True):
+        """Set read-only mode: picker greyed but values visible, not 'N/A'."""
+        self._readOnly = readOnly
+        self._showingNA = False
+        self._picker.Show()
+        self._picker.Enable(not readOnly)
+        self.Refresh()
+
+    def IsReadOnly(self):
+        return self._readOnly
+
+    def Enable(self, enable=True):
+        """Enable or disable. When disabled, hides picker and paints 'N/A'."""
+        super().Enable(enable)
+        if enable:
+            self._showingNA = False
+            self._picker.Show()
+            self._picker.Enable(True)
+        else:
+            self._picker.Hide()
+            self._showingNA = True
+        self.Refresh()
+        return True
+
+    def SetFocus(self):
+        self._picker.SetFocus()
+
+    def HasOpenPopup(self):
+        """Native popup state is not queryable — return False."""
+        return False
+
+    def DismissPopup(self):
+        """No-op — native control manages its own popup."""
+        pass
+
+    def Bind(self, eventType, handler, source=None, id=wx.ID_ANY, id2=wx.ID_ANY):
+        """Route EVT_VALUE_CHANGED to this panel; others to super()."""
+        if eventType in (EVT_VALUE_CHANGED, wx.EVT_KEY_DOWN,
+                         wx.EVT_KILL_FOCUS, wx.EVT_SET_FOCUS):
+            # These fire on the inner picker — bind there
+            if eventType == EVT_VALUE_CHANGED:
+                # EVT_VALUE_CHANGED fires on this panel (posted by _onDateChanged)
+                super().Bind(eventType, handler, source, id, id2)
+            else:
+                self._picker.Bind(eventType, handler, source, id, id2)
+        else:
+            super().Bind(eventType, handler, source, id, id2)
+
+    def SetDateFormat(self, dateFormat):
+        """Set display format using Win32 DTM_SETFORMATW message.
+
+        Args:
+            dateFormat: 4-char format string (e.g. "YMD-", "MDY/", "DMY.")
+                       as used by getLocaleDateFormat().
+        """
+        if wx.Platform != '__WXMSW__':
+            return  # DTM_SETFORMATW is Windows-only
+
+        field_order, separator = getLocaleDateFormat(override=dateFormat)
+        dtp_map = {'year': 'yyyy', 'month': 'MM', 'date_day': 'dd'}
+        fmt = separator.join(dtp_map[f] for f in field_order)
+
+        try:
+            import ctypes
+            DTM_SETFORMATW = 0x1032  # DTM_FIRST (0x1000) + 50
+            hwnd = self._picker.GetHandle()
+            ctypes.windll.user32.SendMessageW(hwnd, DTM_SETFORMATW, 0, fmt)
+        except Exception:
+            pass  # Silently fail on non-Windows or if handle unavailable
+
+
+def DateComboRouterCtrl(*args, **kwargs):
+    """Router that returns the platform-appropriate date combo control.
+
+    - Windows: _NativeDateCtrl (native Win32 Date-Time Picker)
+    - Elsewhere (Linux, macOS): DateComboCustomCtrl (custom masked fields
+      + calendar popup)
+    """
+    if wx.Platform == '__WXMSW__':
+        return _NativeDateCtrl(*args, **kwargs)
+    return DateComboCustomCtrl(*args, **kwargs)
+
+
+class DateTimeComboCtrl(wx.EvtHandler):
+    """Composite date/time control with checkbox, DateComboCustomCtrl, and TimeCtrl.
 
     Inherits wx.EvtHandler so it can host event handlers directly.
     DTC owns the change event — fires EVT_VALUE_CHANGED on sub-control
@@ -2664,7 +2855,7 @@ class DateTimeCombo(wx.EvtHandler):
 
     For flexible table layouts, get individual widgets with:
     - GetCheckBox() - wx.CheckBox (no label)
-    - GetDateCtrl() - DateCtrl
+    - GetDateCtrl() - DateComboCustomCtrl
     - GetTimeCtrl() - TimeCtrl or TimeWithSecondsCtrl
 
     Args:
@@ -2690,7 +2881,7 @@ class DateTimeCombo(wx.EvtHandler):
         self._checkbox.SetValue(checked)
         self._checkbox.Bind(wx.EVT_CHECKBOX, self._onCheckboxChanged)
 
-        self._dateCtrl = DateCtrl(parent, year=display_value.year,
+        self._dateCtrl = DateComboRouterCtrl(parent, year=display_value.year,
                                    month=display_value.month, day=display_value.day)
 
         if showSeconds:
@@ -2815,10 +3006,10 @@ class DateTimeCombo(wx.EvtHandler):
 
         panel.SetSizer(sizer)
 
-        # Re-apply enabled state after reparenting. wx.ComboCtrl (DateCtrl)
+        # Re-apply enabled state after reparenting. wx.ComboCtrl (DateComboCustomCtrl)
         # loses its native visual state (button greying, background color)
         # when reparented, because the platform re-creates theme state for
-        # the new parent hierarchy. FieldsCtrl-based controls don't have
+        # the new parent hierarchy. MaskedFieldsCtrl-based controls don't have
         # this issue since they paint everything in _onPaint.
         self._updateEnabled()
 
@@ -2829,10 +3020,10 @@ class DateTimeCombo(wx.EvtHandler):
 
     def HasOpenPopup(self):
         """Return True if any child control has an open popup."""
-        # DateCtrl provides public HasOpenPopup()
+        # DateComboCustomCtrl provides public HasOpenPopup()
         if self._dateCtrl.HasOpenPopup():
             return True
-        # TimeCtrl uses FieldsCtrl._popup (same module, acceptable)
+        # TimeCtrl uses MaskedFieldsCtrl._popup (same module, acceptable)
         if hasattr(self._timeCtrl, '_popup') and self._timeCtrl._popup is not None:
             return True
         return False


### PR DESCRIPTION
- Rename control classes: MaskedDateCtrl → DateCtrl, DateComboCtrl → DateComboCustomCtrl, new DateComboRouterCtrl factory function
- Add _NativeDateCtrl wrapping wx.adv.DatePickerCtrl for Windows
- DateComboRouterCtrl returns native control on Windows, custom on Linux/macOS
- Migrate budget editor from EVT_KILL_FOCUS to EVT_VALUE_CHANGED
- Fix nobitmap black square (return wx.NullBitmap), add TRANSPARENT_EMPTY_ICON
- Clean up demo script: remove Wayland patch, private imports; add format tests
- Add demo menu icons and TestDemosMenu in Help menu
- Document platform routing requirements in DATETIME_CONTROLS.md
- Add TASK_STATUS_SORT.md documenting composite sort key mechanism
- Add planned start dates to all Welcome.tsk tasks for status-sort testing
- Bump version 2.0.1.64 → 2.0.1.65

minor problem with date setting in Windows version #356