### PR TITLE
Rewrite icon picker with ListCtrl, fix sash cursor, cleanup icon handling

### DIFF
--- a/docs/AUI.md
+++ b/docs/AUI.md
@@ -5,7 +5,8 @@ This document covers AUI-related topics for Task Coach, which uses wxPython's AG
 ## Contents
 
 1. [Layout Persistence](#layout-persistence)
-2. [Related Documentation](#related-documentation)
+2. [Sash Cursor Seep-Through Fix](#sash-cursor-seep-through-fix)
+3. [Related Documentation](#related-documentation)
 
 ---
 
@@ -112,6 +113,33 @@ The name is determined by `viewer.settingsSection()` in `taskcoachlib/gui/viewer
 | `taskcoachlib/gui/viewer/container.py` | `addViewer()` - adds panes to AUI manager |
 | `taskcoachlib/widgets/frame.py` | `addPane()` - configures AuiPaneInfo |
 | `taskcoachlib/config/settings.py` | Stores perspective in INI file |
+
+---
+
+## Sash Cursor Seep-Through Fix
+
+### Problem
+
+When a dialog or popup window is positioned over the main window's sash areas, the sash resize cursor incorrectly "seeps through" and appears when hovering over empty areas of the foreground window. Controls in the dialog block this correctly, but empty panel areas do not.
+
+**Key observation:** This is purely a visual cursor artifact - the sash cannot actually be dragged through the popup window.
+
+### Root Cause
+
+`wx.lib.agw.aui.AuiManager.OnSetCursor()` receives `EVT_SET_CURSOR` events and performs hit testing on sash rectangles without checking if another window is occluding the frame. Controls block the cursor seep-through because they handle `EVT_SET_CURSOR` themselves and set their own cursor. Empty areas let the event propagate to the main frame.
+
+### Solution
+
+Make dialogs handle `EVT_SET_CURSOR` the same way controls do - set a standard cursor without calling `Skip()`. This prevents the event from propagating to the main window's AuiManager.
+
+Implemented via monkey-patch on `wx.Dialog` at application startup in `taskcoachlib/widgets/__init__.py`.
+
+### Related Files
+
+| File | Purpose |
+|------|---------|
+| `taskcoachlib/widgets/__init__.py` | `_install_dialog_cursor_fix()` - patches wx.Dialog |
+| `wx/lib/agw/aui/framemanager.py` | System file - `OnSetCursor()` that causes the issue |
 
 ---
 

--- a/docs/scripts/icon_picker_refactoring_demo.py
+++ b/docs/scripts/icon_picker_refactoring_demo.py
@@ -45,6 +45,9 @@ import wx
 import wx.adv
 import wx.lib.buttons as buttons
 
+# Production IconPicker imported inside DemoFrame.__init__ after wx.App exists
+# (module-level _("No icon") requires wx.App for gettext initialization)
+
 
 # --- Test data with hints ---
 
@@ -1306,10 +1309,8 @@ class IconPickerButtonMF(buttons.ThemedGenBitmapTextButton):
     - GTK/Linux: MiniFrame with proper focus and caret visibility
     - macOS: Regular frame behavior (caret works natively)
 
-    The button always displays with active/enabled appearance, even when
-    "No icon" is selected. A transparent placeholder bitmap is required because
-    GenBitmapButton.SetBitmapLabel() calls bitmap.ConvertToImage() which fails
-    on wx.NullBitmap.
+    TEST: Removing placeholder bitmap - handle "No icon" by not calling
+    SetBitmapLabel at all.
     """
 
     PADDING = 8
@@ -1325,18 +1326,10 @@ class IconPickerButtonMF(buttons.ThemedGenBitmapTextButton):
         self._fixed_width = fixed_width
         self._popup_open = False
 
-        # Create transparent placeholder bitmap for "No icon" state.
-        # Required because GenBitmapButton.SetBitmapLabel() calls ConvertToImage()
-        # which fails on wx.NullBitmap with "invalid bitmap" assertion.
-        self._empty_bmp = wx.Bitmap(self.ICON_SIZE, self.ICON_SIZE, 32)
-        self._empty_bmp.UseAlpha()
-        dc = wx.MemoryDC(self._empty_bmp)
-        dc.SetBackground(wx.Brush(wx.Colour(0, 0, 0, 0)))
-        dc.Clear()
-        dc.SelectObject(wx.NullBitmap)
-
-        # Initialize with placeholder bitmap
-        super().__init__(parent, wx.ID_ANY, self._empty_bmp, "", style=wx.BORDER_NONE)
+        # Initialize with minimal bitmap to satisfy constructor, then clear it
+        # TEST: handle "No icon" without placeholder bitmap
+        super().__init__(parent, wx.ID_ANY, wx.Bitmap(1, 1), "", style=wx.BORDER_NONE)
+        self.bmpLabel = None  # Clear immediately - no placeholder needed
 
         # Enable focus indicator (disabled by default with BORDER_NONE)
         self.SetUseFocusIndicator(True)
@@ -1382,15 +1375,17 @@ class IconPickerButtonMF(buttons.ThemedGenBitmapTextButton):
         if self._current_bmp and self._current_bmp.IsOk():
             self.SetBitmapLabel(self._current_bmp)
         else:
-            # Use placeholder bitmap for "No icon" - required by GenBitmapButton
-            self.SetBitmapLabel(self._empty_bmp)
+            # TEST: No icon - set internal state directly, skip SetBitmapLabel
+            self.bmpLabel = None
+            self.bmpDisabled = None
+            self.bmpFocus = None
+            self.bmpSelected = None
         if not self._fixed_width:
             self.SetInitialSize()
             self.GetParent().Layout()
         self.Refresh()
 
     def DrawLabel(self, dc, width, height, dx=0, dy=0):
-        # Always reserve ICON_SIZE space for consistent layout
         bmp = self.bmpLabel
         has_valid_bmp = bmp is not None and bmp.IsOk()
 
@@ -1404,8 +1399,8 @@ class IconPickerButtonMF(buttons.ThemedGenBitmapTextButton):
             bw, bh = bmp.GetWidth(), bmp.GetHeight()
             hasMask = bmp.GetMask() is not None
         else:
-            # No icon, but still reserve space for consistent layout
-            bw, bh = self.ICON_SIZE, self.ICON_SIZE
+            # No icon - no space reserved
+            bw, bh = 0, 0
             hasMask = False
 
         if not self.up:
@@ -1421,7 +1416,8 @@ class IconPickerButtonMF(buttons.ThemedGenBitmapTextButton):
         # Account for arrow width in available space
         arrow_space = self.ARROW_WIDTH + self.PADDING
         if self._fixed_width:
-            available_width = width - bw - self.PADDING * 3 - arrow_space
+            icon_space = bw + self.PADDING if has_valid_bmp else 0
+            available_width = width - icon_space - self.PADDING * 2 - arrow_space
             if available_width > 0:
                 label = wx.Control.Ellipsize(label, dc, wx.ELLIPSIZE_END, available_width)
 
@@ -1431,10 +1427,9 @@ class IconPickerButtonMF(buttons.ThemedGenBitmapTextButton):
         pos_x = self.PADDING + dx
         if has_valid_bmp:
             dc.DrawBitmap(bmp, pos_x, (height - bh) // 2 + dy, hasMask)
-        # Always advance past icon space for consistent text positioning
-        pos_x += bw + self.PADDING
+            pos_x += bw + self.PADDING
 
-        # Draw text (after icon space)
+        # Draw text
         dc.DrawText(label, pos_x, (height - th) // 2 + dy)
 
         # Draw dropdown arrow (right-aligned) using native renderer
@@ -1450,12 +1445,15 @@ class IconPickerButtonMF(buttons.ThemedGenBitmapTextButton):
         dc.SetFont(self.GetFont())
         label = self.GetLabel()
         tw, th = dc.GetTextExtent(label)
-        # Always include ICON_SIZE for consistent button size
-        bw, bh = self.ICON_SIZE, self.ICON_SIZE
+        # Only include icon size if there's an icon
         if self.bmpLabel and self.bmpLabel.IsOk():
             bw, bh = self.bmpLabel.GetWidth(), self.bmpLabel.GetHeight()
+            icon_space = bw + self.PADDING
+        else:
+            bh = 0
+            icon_space = 0
         # Include arrow width in size calculation
-        width = self.PADDING + bw + self.PADDING + tw + self.PADDING + self.ARROW_WIDTH + self.PADDING
+        width = self.PADDING + icon_space + tw + self.PADDING + self.ARROW_WIDTH + self.PADDING
         height = max(th, bh) + self.PADDING * 2
         if self._fixed_width:
             width = self._fixed_width
@@ -1495,6 +1493,15 @@ class IconPickerButtonMF(buttons.ThemedGenBitmapTextButton):
 
 class DemoFrame(wx.Frame):
     def __init__(self):
+        # Initialize artprovider (must be done after wx.App exists)
+        from taskcoachlib.gui import artprovider
+        artprovider.init()
+
+        # Import production IconPicker here (after wx.App exists)
+        # Module-level _("No icon") in iconpicker.py requires wx.App for gettext
+        from taskcoachlib.widgets.iconpicker import IconPicker as ProductionIconPicker
+        self.ProductionIconPicker = ProductionIconPicker
+
         super().__init__(None, title="Icon Picker Demo - Full Features", size=(750, 900))
         panel = wx.Panel(self, style=wx.TAB_TRAVERSAL)
         sizer = wx.BoxSizer(wx.VERTICAL)
@@ -1565,20 +1572,20 @@ class DemoFrame(wx.Frame):
 
         sizer.Add(wx.StaticLine(panel), 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 2)
 
-        # === 4. MiniFrame-based Icon Picker (Recommended - cross-platform) ===
-        section_mf = wx.StaticText(panel, label="=== 4. MiniFrame-based Icon Picker (Recommended) ===")
+        # === 4. Production IconPicker (from taskcoachlib.widgets.iconpicker) ===
+        section_mf = wx.StaticText(panel, label="=== 4. Production IconPicker (Real Control) ===")
         section_mf.SetFont(section_mf.GetFont().Bold())
         sizer.Add(section_mf, 0, wx.LEFT | wx.TOP, 10)
 
-        # Control 4a: MiniFrame button auto width - starts with "No icon" to test visual appearance
-        sizer.Add(wx.StaticText(panel, label="4a. MINIFRAME (Auto width): Starts with 'No icon' - button should look active"), 0, wx.LEFT | wx.TOP, 5)
-        self._btn_mf_auto = IconPickerButtonMF(panel, items, current_key="")
+        # Control 4a: Production IconPicker - starts with "No icon" to test visual appearance
+        sizer.Add(wx.StaticText(panel, label="4a. PRODUCTION (Auto width): Starts with 'No icon' - button should look active"), 0, wx.LEFT | wx.TOP, 5)
+        self._btn_mf_auto = self.ProductionIconPicker(panel, currentIcon="")
         sizer.Add(self._btn_mf_auto, 0, wx.LEFT, 10)
 
-        # Control 4b: MiniFrame button 120px with comparison standard button
-        sizer.Add(wx.StaticText(panel, label="4b. MINIFRAME (120px) + Standard Button for focus comparison:"), 0, wx.LEFT | wx.TOP, 5)
+        # Control 4b: Production IconPicker 120px with comparison standard button
+        sizer.Add(wx.StaticText(panel, label="4b. PRODUCTION (120px) + Standard Button for focus comparison:"), 0, wx.LEFT | wx.TOP, 5)
         row_4b = wx.BoxSizer(wx.HORIZONTAL)
-        self._btn_mf_narrow = IconPickerButtonMF(panel, items, current_key="weather_lightning_icon", fixed_width=120)
+        self._btn_mf_narrow = self.ProductionIconPicker(panel, currentIcon="weather_lightning_icon", fixedWidth=120)
         row_4b.Add(self._btn_mf_narrow, 0)
         row_4b.Add((10, 0))  # Spacer
         self._btn_compare = wx.Button(panel, label="Standard Button")

--- a/taskcoachlib/gui/artprovider.py
+++ b/taskcoachlib/gui/artprovider.py
@@ -18,7 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from taskcoachlib import patterns, operating_system
 from taskcoachlib.i18n import _
-from taskcoachlib.meta.debug import log_step
 from taskcoachlib.tools import wxhelper
 import numpy as np
 import wx
@@ -108,7 +107,7 @@ class ArtProvider(wx.ArtProvider):
     TRANSPARENT_EMPTY_ICON = "transparent_empty_icon"
 
     def _CreateBitmap(self, artId, artClient, size) -> wx.Bitmap:
-        if not artId or artId == "nobitmap":
+        if not artId:
             return wx.NullBitmap
 
         if artId == self.TRANSPARENT_EMPTY_ICON:
@@ -133,14 +132,12 @@ class ArtProvider(wx.ArtProvider):
         if os.path.exists(icon_path):
             image = wx.Image(icon_path)
             if not image.IsOk():
-                log_step("ERROR! Icon file exists but failed to load:", icon_path, prefix="ICON")
                 return wx.NullBitmap
             bitmap = image.ConvertToBitmap()
             if artClient == wx.ART_FRAME_ICON:
                 bitmap = self.convertAlphaToMask(bitmap)
             return bitmap
         else:
-            log_step("ERROR! Icon not found:", repr(artId), "(tried", new_icon_path, "and", legacy_icon_path + ")", prefix="ICON")
             return wx.NullBitmap
 
     @staticmethod

--- a/taskcoachlib/gui/dialog/toolbar.py
+++ b/taskcoachlib/gui/dialog/toolbar.py
@@ -50,14 +50,14 @@ class _ToolBarEditorInterior(wx.Panel):
         self.__imgListIndex = dict()
         empty = wx.Image(16, 16)
         empty.Replace(0, 0, 0, 255, 255, 255)
-        self.__imgListIndex["nobitmap"] = self.__imgList.Add(
+        self.__imgListIndex[None] = self.__imgList.Add(
             empty.ConvertToBitmap()
         )
         for uiCmd in toolbar.uiCommands():
             if (
                 uiCmd is not None
                 and not isinstance(uiCmd, int)
-                and uiCmd.bitmap != "nobitmap"
+                and uiCmd.bitmap is not None
             ):
                 self.__imgListIndex[uiCmd.bitmap] = self.__imgList.Add(
                     wx.ArtProvider.GetBitmap(
@@ -288,9 +288,9 @@ class _ToolBarEditorInterior(wx.Panel):
     def __GetItemTextAndImage(self, uiCmd):
         """Get display text and image index for a uiCommand."""
         if uiCmd is None:
-            return _("Separator"), self.__imgListIndex.get("nobitmap", -1)
+            return _("Separator"), self.__imgListIndex.get(None, -1)
         elif isinstance(uiCmd, int):
-            return _("Spacer"), self.__imgListIndex.get("nobitmap", -1)
+            return _("Spacer"), self.__imgListIndex.get(None, -1)
         else:
             return uiCmd.getHelpText(), self.__imgListIndex.get(uiCmd.bitmap, -1)
 

--- a/taskcoachlib/gui/uicommand/base_uicommand.py
+++ b/taskcoachlib/gui/uicommand/base_uicommand.py
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import wx
 from taskcoachlib import operating_system
 from taskcoachlib.gui.newid import IdProvider
+from taskcoachlib.meta.debug import log_step
 
 
 """ User interface commands (subclasses of UICommand) are actions that can
@@ -40,7 +41,7 @@ class UICommand(object):
         self,
         menuText="",
         helpText="",
-        bitmap="nobitmap",
+        bitmap=None,
         kind=wx.ITEM_NORMAL,
         id=None,
         bitmap2=None,
@@ -109,8 +110,18 @@ class UICommand(object):
             bitmap1 = self.__getBitmap(self.bitmap)
             bitmap2 = self.__getBitmap(self.bitmap2)
             menuItem.SetBitmaps(bitmap1, bitmap2)
-        elif self.bitmap and self.kind == wx.ITEM_NORMAL:
-            menuItem.SetBitmap(self.__getBitmap(self.bitmap))
+        elif self.kind == wx.ITEM_NORMAL:
+            if self.bitmap is None:
+                return  # No icon intended - correct, do nothing
+
+            bitmap = self.__getBitmap(self.bitmap)
+            if not bitmap.IsOk():
+                # TRAP: bitmap name given but invalid - this is an error
+                log_step("ERROR: invalid bitmap '%s' for menu item '%s'" %
+                         (self.bitmap, menuItem.GetItemLabelText()), prefix="ICON")
+                return
+
+            menuItem.SetBitmap(bitmap)
 
     def removeFromMenu(self, menu, window):
         for menuItem in self.menuItems:

--- a/taskcoachlib/gui/uicommand/settings_uicommand.py
+++ b/taskcoachlib/gui/uicommand/settings_uicommand.py
@@ -89,7 +89,7 @@ class UICheckCommand(BooleanSettingsCommand):
         # all platforms, most notably Gtk where providing our own bitmap causes
         # "(python:8569): Gtk-CRITICAL **: gtk_check_menu_item_set_active:
         # assertion `GTK_IS_CHECK_MENU_ITEM (check_menu_item)' failed"
-        return "nobitmap"
+        return None
 
 
 class UIRadioCommand(BooleanSettingsCommand):

--- a/taskcoachlib/widgets/__init__.py
+++ b/taskcoachlib/widgets/__init__.py
@@ -61,3 +61,28 @@ from .numericctrl import NumericCtrl
 from .currencyctrl import CurrencyCtrl
 from . import masked
 from wx.lib import sized_controls
+import wx
+
+
+def _install_dialog_cursor_fix():
+    """Prevent cursor seep-through from main window behind dialogs.
+
+    Dialogs with empty areas (no controls) let EVT_SET_CURSOR propagate
+    to the parent window, causing sash resize cursors to show through.
+    This patch makes all dialogs handle EVT_SET_CURSOR with a standard
+    cursor, preventing propagation - same pattern controls use.
+    """
+    _original_dialog_init = wx.Dialog.__init__
+
+    def _patched_dialog_init(self, *args, **kwargs):
+        _original_dialog_init(self, *args, **kwargs)
+        self.Bind(wx.EVT_SET_CURSOR, _on_set_cursor_standard)
+
+    def _on_set_cursor_standard(event):
+        # Set standard arrow cursor - prevents seep-through from parent
+        event.SetCursor(wx.Cursor(wx.CURSOR_ARROW))
+
+    wx.Dialog.__init__ = _patched_dialog_init
+
+
+_install_dialog_cursor_fix()

--- a/taskcoachlib/widgets/iconpicker.py
+++ b/taskcoachlib/widgets/iconpicker.py
@@ -19,58 +19,73 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import wx
 import wx.lib.buttons as buttons
 
+from taskcoachlib.meta.debug import log_step
 
-class _IconVListBox(wx.VListBox):
-    """Virtual list box with icon, label, and hints columns."""
+
+class _IconListCtrl(wx.ListCtrl):
+    """List control with 3 columns: Name (with icon), Hints, Internal."""
 
     ICON_SIZE = 16
-    ITEM_HEIGHT = 24
-    PADDING = 4
 
     def __init__(self, parent):
-        super().__init__(parent, style=wx.BORDER_NONE | wx.WANTS_CHARS | wx.TAB_TRAVERSAL | wx.VSCROLL)
+        super().__init__(parent, style=wx.LC_REPORT | wx.LC_SINGLE_SEL | wx.BORDER_NONE)
+
+        # Image list for icons
+        self._image_list = wx.ImageList(self.ICON_SIZE, self.ICON_SIZE)
+        self.SetImageList(self._image_list, wx.IMAGE_LIST_SMALL)
+
+        # 3 columns: Name (with icon), Hints, Internal
+        self.InsertColumn(0, _("Name"), width=200)
+        self.InsertColumn(1, _("Hints"), width=300)
+        self.InsertColumn(2, _("Internal"), width=100)
+
         self._items = []
         self._all_items = []
+        self._image_map = {}  # key -> image list index
         self._on_select_callback = None
-        self._max_label_width = 100
-        self._max_hints_width = 100
-        self._total_width = 300
-        self.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_LISTBOX))
-        self.Bind(wx.EVT_LEFT_DOWN, self._on_left_down)
-        self.Bind(wx.EVT_LEFT_DCLICK, self._on_left_dclick)
-        self.Bind(wx.EVT_KEY_DOWN, self._on_key_down)
-        self.Bind(wx.EVT_MOTION, self._on_motion)
+
         # Debounce timer for search filtering
         self._filter_timer = wx.Timer(self)
         self.Bind(wx.EVT_TIMER, self._on_filter_timer, self._filter_timer)
         self._pending_filter = ""
 
+        self.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self._on_item_activated)
+        self.Bind(wx.EVT_KEY_DOWN, self._on_key_down)
+
     def SetItems(self, items):
         """Set items: list of (key, label, bitmap, hints, enabled) tuples."""
         self._all_items = list(items)
         self._items = list(items)
-        self._calculate_column_widths()
-        self.SetItemCount(len(self._items))
-        self.Refresh()
+        self._rebuild_list()
 
-    def _calculate_column_widths(self):
-        dc = wx.ClientDC(self)
-        dc.SetFont(self.GetFont())
-        max_label = 0
-        max_hints = 0
-        for item in self._all_items:
-            label_width = dc.GetTextExtent(item[1])[0]
-            hints_width = dc.GetTextExtent(item[3])[0] if item[3] else 0
-            max_label = max(max_label, label_width)
-            max_hints = max(max_hints, hints_width)
-        self._max_label_width = max_label + 10
-        self._max_hints_width = max_hints + 10
-        self._total_width = (self.PADDING + self.ICON_SIZE + self.PADDING +
-                             self._max_label_width + self.PADDING +
-                             self._max_hints_width + self.PADDING)
+    def _rebuild_list(self):
+        """Rebuild the list from current _items."""
+        self.DeleteAllItems()
 
-    def GetPreferredWidth(self):
-        return self._total_width
+        for i, item in enumerate(self._items):
+            key, label, bmp, hints, enabled = item
+
+            # Add bitmap to image list if not already there
+            if key not in self._image_map:
+                if bmp and bmp.IsOk():
+                    if not enabled:
+                        # Greyscale for disabled items
+                        img = bmp.ConvertToImage().ConvertToGreyscale()
+                        idx = self._image_list.Add(img.ConvertToBitmap())
+                    else:
+                        idx = self._image_list.Add(bmp)
+                else:
+                    idx = -1  # No image
+                self._image_map[key] = idx
+
+            # Insert row: Name (with icon), Hints, Internal
+            idx = self.InsertItem(i, label, self._image_map.get(key, -1))
+            self.SetItem(idx, 1, hints or "")
+            self.SetItem(idx, 2, key)
+
+            # Grey out disabled items
+            if not enabled:
+                self.SetItemTextColour(idx, wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
 
     def FilterItems(self, filter_text):
         """Start debounced filter - waits 300ms after last keystroke."""
@@ -90,148 +105,56 @@ class _IconVListBox(wx.VListBox):
                 item for item in self._all_items
                 if self._matches_any_term(item, terms)
             ]
-        self.SetItemCount(len(self._items))
+        self._rebuild_list()
+
+        # Select first enabled item
         for i, item in enumerate(self._items):
             if item[4]:  # enabled
-                self.SetSelection(i)
+                self.Select(i)
+                self.EnsureVisible(i)
                 break
-        else:
-            self.SetSelection(wx.NOT_FOUND)
-        self.RefreshAll()
 
     def _matches_any_term(self, item, terms):
-        """Return True if ANY term is found in item's label or hints (OR search)."""
+        """Return True if ANY term is found in item's label, hints, or key (OR search)."""
+        key = item[0].lower()
         label = item[1].lower()
         hints = item[3].lower()
-        searchable = label + " " + hints
+        searchable = key + " " + label + " " + hints
         return any(term in searchable for term in terms)
 
     def GetSelectedItem(self):
-        sel = self.GetSelection()
-        if sel != wx.NOT_FOUND and 0 <= sel < len(self._items):
+        """Return the selected item tuple, or None."""
+        sel = self.GetFirstSelected()
+        if sel != -1 and 0 <= sel < len(self._items):
             return self._items[sel]
         return None
 
     def SelectByKey(self, key):
+        """Select item by key."""
         for i, item in enumerate(self._items):
             if item[0] == key:
-                self.SetSelection(i)
+                self.Select(i)
+                self.EnsureVisible(i)
                 return
 
     def SetSelectCallback(self, callback):
+        """Set callback for double-click/enter selection."""
         self._on_select_callback = callback
 
-    def _find_next_enabled(self, start, direction=1):
-        i = start
-        while 0 <= i < len(self._items):
-            if self._items[i][4]:  # enabled is index 4 now
-                return i
-            i += direction
-        return None
-
-    def OnMeasureItem(self, n):
-        return self.ITEM_HEIGHT
-
-    def OnDrawItem(self, dc, rect, n):
-        if n < 0 or n >= len(self._items):
-            return
-        key, label, bmp, hints, enabled = self._items[n]
-        is_selected = self.IsSelected(n)
-
-        # Get theme colors based on state
-        if not enabled:
-            text_color = wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
-            hints_color = wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
-        elif is_selected:
-            text_color = wx.SystemSettings.GetColour(wx.SYS_COLOUR_HIGHLIGHTTEXT)
-            hints_color = wx.SystemSettings.GetColour(wx.SYS_COLOUR_HIGHLIGHTTEXT)
-        else:
-            text_color = wx.SystemSettings.GetColour(wx.SYS_COLOUR_LISTBOXTEXT)
-            hints_color = wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
-
-        # Draw icon
-        x = rect.x + self.PADDING
-        if bmp and bmp.IsOk():
-            bmp_y = rect.y + (rect.height - bmp.GetHeight()) // 2
-            if not enabled:
-                img = bmp.ConvertToImage().ConvertToGreyscale()
-                dc.DrawBitmap(img.ConvertToBitmap(), x, bmp_y, True)
-            else:
-                dc.DrawBitmap(bmp, x, bmp_y, True)
-
-        # Draw label
-        label_x = x + self.ICON_SIZE + self.PADDING
-        text_y = rect.y + (rect.height - dc.GetCharHeight()) // 2
-        dc.SetTextForeground(text_color)
-        display_label = wx.Control.Ellipsize(label, dc, wx.ELLIPSIZE_END, self._max_label_width)
-        dc.DrawText(display_label, label_x, text_y)
-
-        # Draw hints (grey, after label column)
-        if hints:
-            hints_x = label_x + self._max_label_width + self.PADDING
-            dc.SetTextForeground(hints_color)
-            display_hints = wx.Control.Ellipsize(hints, dc, wx.ELLIPSIZE_END, self._max_hints_width)
-            dc.DrawText(display_hints, hints_x, text_y)
-
-    def OnDrawBackground(self, dc, rect, n):
-        if n < 0 or n >= len(self._items):
-            return
-        is_selected = self.IsSelected(n)
-        bg_color = wx.SystemSettings.GetColour(wx.SYS_COLOUR_LISTBOX)
-        dc.SetBrush(wx.Brush(bg_color))
-        dc.SetPen(wx.TRANSPARENT_PEN)
-        dc.DrawRectangle(rect)
-        if is_selected:
-            highlight = wx.SystemSettings.GetColour(wx.SYS_COLOUR_HIGHLIGHT)
-            dc.SetBrush(wx.Brush(highlight))
-            dc.DrawRectangle(rect)
-
-    def _on_left_down(self, event):
-        item_idx = self.VirtualHitTest(event.GetPosition().y)
-        if item_idx != wx.NOT_FOUND and 0 <= item_idx < len(self._items):
-            item = self._items[item_idx]
-            if item[4]:  # enabled
-                self.SetSelection(item_idx)
-                if self._on_select_callback:
-                    self._on_select_callback(*item)
-        event.Skip()
-
-    def _on_left_dclick(self, event):
-        self._on_left_down(event)
+    def _on_item_activated(self, event):
+        """Handle double-click or enter on item."""
+        item = self.GetSelectedItem()
+        if item and item[4] and self._on_select_callback:  # enabled
+            self._on_select_callback(*item)
 
     def _on_key_down(self, event):
         key = event.GetKeyCode()
         if key == wx.WXK_RETURN or key == wx.WXK_NUMPAD_ENTER:
-            sel = self.GetSelection()
-            if sel != wx.NOT_FOUND and 0 <= sel < len(self._items):
-                item = self._items[sel]
-                if item[4] and self._on_select_callback:
-                    self._on_select_callback(*item)
-        elif key == wx.WXK_DOWN:
-            sel = self.GetSelection()
-            next_idx = self._find_next_enabled(sel + 1 if sel != wx.NOT_FOUND else 0, 1)
-            if next_idx is not None:
-                self.SetSelection(next_idx)
-                self.Refresh()
-        elif key == wx.WXK_UP:
-            sel = self.GetSelection()
-            if sel == wx.NOT_FOUND:
-                sel = len(self._items)
-            prev_idx = self._find_next_enabled(sel - 1, -1)
-            if prev_idx is not None:
-                self.SetSelection(prev_idx)
-                self.Refresh()
+            item = self.GetSelectedItem()
+            if item and item[4] and self._on_select_callback:  # enabled
+                self._on_select_callback(*item)
         else:
             event.Skip()
-
-    def _on_motion(self, event):
-        item_idx = self.VirtualHitTest(event.GetPosition().y)
-        if item_idx != wx.NOT_FOUND and 0 <= item_idx < len(self._items):
-            if self._items[item_idx][4]:  # enabled
-                if item_idx != self.GetSelection():
-                    self.SetSelection(item_idx)
-                    self.Refresh()
-        event.Skip()
 
 
 class _IconDialog(wx.Dialog):
@@ -251,7 +174,7 @@ class _IconDialog(wx.Dialog):
         self._search.ShowCancelButton(True)
         sizer.Add(self._search, 0, wx.EXPAND | wx.ALL, 5)
 
-        self._listbox = _IconVListBox(panel)
+        self._listbox = _IconListCtrl(panel)
         self._listbox.SetItems(items)
         self._listbox.SetSelectCallback(self._on_item_selected)
         sizer.Add(self._listbox, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
@@ -261,26 +184,25 @@ class _IconDialog(wx.Dialog):
         # Dialog layout: panel (search + list) + button bar
         dlgSizer = wx.BoxSizer(wx.VERTICAL)
         dlgSizer.Add(panel, 1, wx.EXPAND)
-        btnSizer = self.CreateButtonSizer(wx.OK | wx.CANCEL)
-        if btnSizer:
-            dlgSizer.Add(btnSizer, 0, wx.EXPAND | wx.ALL, 5)
+
+        # Button bar: Clear + OK + Cancel (all in standard sizer for consistent padding)
+        btnSizer = self.CreateStdDialogButtonSizer(wx.OK | wx.CANCEL)
+        self._clearBtn = wx.Button(self, wx.ID_CLEAR, _("Clear"))
+        # Insert Clear at the beginning (index 0)
+        btnSizer.Insert(0, self._clearBtn, 0, wx.LEFT | wx.RIGHT, 5)
+        btnSizer.Insert(1, (0, 0), 1)  # Stretch spacer after Clear
+        dlgSizer.Add(btnSizer, 0, wx.EXPAND | wx.ALL, 5)
+
         self.SetSizer(dlgSizer)
         self.Bind(wx.EVT_BUTTON, self._on_ok, id=wx.ID_OK)
+        self.Bind(wx.EVT_BUTTON, self._on_clear, id=wx.ID_CLEAR)
 
-        # Calculate dialog size - show all items, limited by screen height
-        list_height = len(items) * _IconVListBox.ITEM_HEIGHT
-        search_height = self._search.GetBestSize().GetHeight() + 12
-        btn_height = 40  # OK/Cancel button bar + padding
-        content_width = self._listbox.GetPreferredWidth() + 24
-        total_height = search_height + list_height + btn_height + 16
-
-        # Limit to 75% of screen height
+        # Dialog size: fixed width, 75% of screen height
         display = wx.Display(wx.Display.GetFromWindow(parent))
         screen_height = display.GetClientArea().GetHeight()
-        max_height = int(screen_height * 0.75)
-        total_height = min(total_height, max_height)
+        total_height = int(screen_height * 0.75)
 
-        self._desired_size = wx.Size(content_width, total_height)
+        self._desired_size = wx.Size(600, total_height)
 
         def _on_shown(evt):
             self.SetSize(self._desired_size)
@@ -331,6 +253,11 @@ class _IconDialog(wx.Dialog):
             self.EndModal(wx.ID_OK)
         # If nothing valid selected, don't close
 
+    def _on_clear(self, event):
+        """Clear button — select no icon."""
+        self._selected_item = ("", _("No icon"), None, "", True)
+        self.EndModal(wx.ID_OK)
+
     def _on_item_selected(self, key, label, bmp, hints, enabled):
         if enabled:
             self._selected_item = (key, label, bmp, hints, enabled)
@@ -370,18 +297,11 @@ class IconPicker(buttons.ThemedGenBitmapTextButton):
         self._current_bmp = None
         self._previous_key = ""
 
-        # Create transparent placeholder bitmap for "No icon" state.
-        # Required because GenBitmapButton.SetBitmapLabel() calls ConvertToImage()
-        # which fails on wx.NullBitmap with "invalid bitmap" assertion.
-        self._empty_bmp = wx.Bitmap(self.ICON_SIZE, self.ICON_SIZE, 32)
-        self._empty_bmp.UseAlpha()
-        dc = wx.MemoryDC(self._empty_bmp)
-        dc.SetBackground(wx.Brush(wx.Colour(0, 0, 0, 0)))
-        dc.Clear()
-        dc.SelectObject(wx.NullBitmap)
-
-        # Initialize with placeholder bitmap
-        super().__init__(parent, wx.ID_ANY, self._empty_bmp, "", style=wx.BORDER_NONE)
+        # Initialize button - GenBitmapButton requires a bitmap in constructor,
+        # but we immediately clear it. For "no icon" state, bmpLabel stays None.
+        # Never call SetBitmapLabel(None) - that hits wxPython bug #2093.
+        super().__init__(parent, wx.ID_ANY, wx.Bitmap(1, 1), "", style=wx.BORDER_NONE)
+        self.bmpLabel = None  # Clear - start with no icon
         self.SetUseFocusIndicator(True)
 
         self._load_icons()
@@ -392,18 +312,11 @@ class IconPicker(buttons.ThemedGenBitmapTextButton):
         self.Bind(wx.EVT_KEY_DOWN, self._on_key_down)
 
     def _load_icons(self):
-        """Load icons from artprovider.
-
-        If noIcon=True, "No icon" is added as the first item with key="".
-        """
+        """Load icons from artprovider."""
         # Import here to avoid circular import (widgets <- gui <- widgets)
         from taskcoachlib.gui import artprovider
 
-        # Add "No icon" as first item if enabled
-        if self._noIcon:
-            no_icon_item = ("", self.NO_ICON_LABEL, self._empty_bmp, "", True)
-            self._items.append(no_icon_item)
-            self._items_dict[""] = no_icon_item
+        # Note: "No icon" is handled via Clear button in dialog, not in list
 
         # Load icons from artprovider.chooseableItems
         # Sort by name for consistent ordering
@@ -434,6 +347,41 @@ class IconPicker(buttons.ThemedGenBitmapTextButton):
         rect = wx.Rect(3, 3, w - 6, h - 6)
         wx.RendererNative.Get().DrawFocusRect(self, dc, rect)
 
+    def SetBitmapLabel(self, bitmap, createOthers=True):
+        """Set bitmap label. Passing None/invalid bitmap is an error.
+
+        For "no icon" state, set bmpLabel=None directly instead of calling this.
+        This avoids wxPython bug #2093 where GenBitmapButton crashes on NullBitmap.
+        """
+        if bitmap is None or not bitmap.IsOk():
+            log_step("ERROR: SetBitmapLabel called with invalid bitmap - use bmpLabel=None instead",
+                     prefix="ICON")
+            return  # Ignore the call, don't crash
+        super().SetBitmapLabel(bitmap, createOthers)
+
+    def _get_icon_size(self):
+        """Return (width, height) of current icon, or (0, 0) if no icon."""
+        if self.bmpLabel and self.bmpLabel.IsOk():
+            return self.bmpLabel.GetWidth(), self.bmpLabel.GetHeight()
+        return 0, 0
+
+    def _get_layout_metrics(self):
+        """Return layout metrics for button content.
+
+        Returns (text_start_x, non_text_width, icon_size) where:
+        - text_start_x: x position where text drawing starts
+        - non_text_width: total width used by padding and icon (for width calculations)
+        - icon_size: (width, height) of icon, or (0, 0) if none
+        """
+        bw, bh = self._get_icon_size()
+        if bw > 0:
+            text_x = self.PADDING + bw + self.PADDING
+            overhead = bw + self.PADDING * 3
+        else:
+            text_x = self.PADDING
+            overhead = self.PADDING * 2
+        return text_x, overhead, (bw, bh)
+
     def _set_current(self, item):
         self._current_key = item[0]
         self._current_label = item[1]
@@ -445,8 +393,12 @@ class IconPicker(buttons.ThemedGenBitmapTextButton):
         if self._current_bmp and self._current_bmp.IsOk():
             self.SetBitmapLabel(self._current_bmp)
         else:
-            # Use placeholder bitmap for "No icon" - required by GenBitmapButton
-            self.SetBitmapLabel(self._empty_bmp)
+            # No icon - set internal state directly, never call SetBitmapLabel(None)
+            # This avoids wxPython bug #2093
+            self.bmpLabel = None
+            self.bmpDisabled = None
+            self.bmpFocus = None
+            self.bmpSelected = None
         if not self._fixedWidth:
             self.InvalidateBestSize()
             self.SetInitialSize()
@@ -457,22 +409,19 @@ class IconPicker(buttons.ThemedGenBitmapTextButton):
         self.Refresh()
 
     def DrawLabel(self, dc, width, height, dx=0, dy=0):
-        # Always reserve ICON_SIZE space for consistent layout
-        bmp = self.bmpLabel
-        has_valid_bmp = bmp is not None and bmp.IsOk()
+        text_x, overhead, (bw, bh) = self._get_layout_metrics()
 
-        if has_valid_bmp:
+        # Get the appropriate bitmap for current state
+        bmp = self.bmpLabel
+        if bmp and bmp.IsOk():
             if self.bmpDisabled and not self.IsEnabled():
                 bmp = self.bmpDisabled
             if self.bmpFocus and self.hasFocus:
                 bmp = self.bmpFocus
             if self.bmpSelected and not self.up:
                 bmp = self.bmpSelected
-            bw, bh = bmp.GetWidth(), bmp.GetHeight()
             hasMask = bmp.GetMask() is not None
         else:
-            # No icon, but still reserve space for consistent layout
-            bw, bh = self.ICON_SIZE, self.ICON_SIZE
             hasMask = False
 
         if not self.up:
@@ -485,35 +434,27 @@ class IconPicker(buttons.ThemedGenBitmapTextButton):
             dc.SetTextForeground(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
 
         label = self.GetLabel()
-        available_width = width - bw - self.PADDING * 3
+        available_width = width - overhead
         if available_width > 0:
             label = wx.Control.Ellipsize(label, dc, wx.ELLIPSIZE_END, available_width)
 
         tw, th = dc.GetTextExtent(label)
 
         # Draw icon if present
-        pos_x = self.PADDING + dx
-        if has_valid_bmp:
-            dc.DrawBitmap(bmp, pos_x, (height - bh) // 2 + dy, hasMask)
-        # Always advance past icon space for consistent text positioning
-        pos_x += bw + self.PADDING
+        if bw > 0 and bmp:
+            dc.DrawBitmap(bmp, self.PADDING + dx, (height - bh) // 2 + dy, hasMask)
 
-        dc.DrawText(label, pos_x, (height - th) // 2 + dy)
+        dc.DrawText(label, text_x + dx, (height - th) // 2 + dy)
 
     def DoGetBestSize(self):
+        _, overhead, (bw, bh) = self._get_layout_metrics()
         dc = wx.ClientDC(self)
         dc.SetFont(self.GetFont())
-        label = self.GetLabel()
-        tw, th = dc.GetTextExtent(label)
-        # Always include ICON_SIZE for consistent button size
-        bw, bh = self.ICON_SIZE, self.ICON_SIZE
-        if self.bmpLabel and self.bmpLabel.IsOk():
-            bw, bh = self.bmpLabel.GetWidth(), self.bmpLabel.GetHeight()
-        height = max(th, bh) + self.PADDING * 2
+        tw, th = dc.GetTextExtent(self.GetLabel())
+        height = max(th, bh) + self.PADDING * 2 if bh > 0 else th + self.PADDING * 2
         if self._fixedWidth:
             return wx.Size(self._fixedWidth, height)
-        width = self.PADDING + bw + self.PADDING + tw + self.PADDING
-        return wx.Size(width, height)
+        return wx.Size(overhead + tw, height)
 
     def _on_click(self, event):
         dialog = _IconDialog(self.GetTopLevelParent(), self._items, self._current_key)
@@ -537,7 +478,10 @@ class IconPicker(buttons.ThemedGenBitmapTextButton):
         self._setSelectionByValue(newValue)
 
     def _setSelectionByValue(self, newValue):
-        if newValue in self._items_dict:
+        if newValue == "" and self._noIcon:
+            # No icon selected - create item tuple directly
+            self._set_current(("", self.NO_ICON_LABEL, None, "", True))
+        elif newValue in self._items_dict:
             self._set_current(self._items_dict[newValue])
         elif self._items:
             self._set_current(self._items[0])

--- a/tools/icon_grid_browser_data/nuvola_local_zip.json
+++ b/tools/icon_grid_browser_data/nuvola_local_zip.json
@@ -2,168 +2,781 @@
   "_comment": "Auto-maintained catalog for nuvola_local_zip theme pack. Icons/sizes are additive only.",
   "icons": {
     "devices/print_printer.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["printer", "print", "paper", "output", "document", "hardware", "device"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "printer",
+        "print",
+        "paper",
+        "output",
+        "document",
+        "hardware",
+        "device"
+      ]
     },
     "devices/cdaudio_mount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["cd", "audio", "disc", "mount", "music", "media", "optical"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "cd",
+        "audio",
+        "disc",
+        "mount",
+        "music",
+        "media",
+        "optical"
+      ]
     },
     "devices/samba_mount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["samba", "network", "share", "windows", "mount", "drive", "smb"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "samba",
+        "network",
+        "share",
+        "windows",
+        "mount",
+        "drive",
+        "smb"
+      ]
     },
     "devices/cdrom_unmount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["cdrom", "disc", "unmount", "eject", "cd", "optical", "media"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "cdrom",
+        "disc",
+        "unmount",
+        "eject",
+        "cd",
+        "optical",
+        "media"
+      ]
     },
     "devices/mo_mount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["mo", "magneto", "optical", "disk", "mount", "storage", "removable"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "mo",
+        "magneto",
+        "optical",
+        "disk",
+        "mount",
+        "storage",
+        "removable"
+      ]
     },
     "devices/cdwriter_mount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["cdwriter", "cd", "burn", "disc", "mount", "write", "optical"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "cdwriter",
+        "cd",
+        "burn",
+        "disc",
+        "mount",
+        "write",
+        "optical"
+      ]
     },
     "devices/samba_unmount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["samba", "network", "share", "windows", "unmount", "drive", "smb"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "samba",
+        "network",
+        "share",
+        "windows",
+        "unmount",
+        "drive",
+        "smb"
+      ]
     },
     "devices/memory.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["memory", "ram", "dimm", "chip", "hardware", "module", "computer"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "memory",
+        "ram",
+        "dimm",
+        "chip",
+        "hardware",
+        "module",
+        "computer"
+      ]
     },
     "devices/3floppy_mount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["floppy", "disk", "mount", "save", "storage", "removable", "legacy"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "floppy",
+        "disk",
+        "mount",
+        "save",
+        "storage",
+        "removable",
+        "legacy"
+      ]
     },
     "devices/tablet.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["tablet", "graphics", "pen", "stylus", "drawing", "input", "wacom"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "tablet",
+        "graphics",
+        "pen",
+        "stylus",
+        "drawing",
+        "input",
+        "wacom"
+      ]
     },
     "devices/cdwriter_unmount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["cdwriter", "cd", "burn", "disc", "unmount", "eject", "optical"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "cdwriter",
+        "cd",
+        "burn",
+        "disc",
+        "unmount",
+        "eject",
+        "optical"
+      ]
     },
     "devices/raid.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["raid", "server", "storage", "drives", "array", "disk", "hardware"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "raid",
+        "server",
+        "storage",
+        "drives",
+        "array",
+        "disk",
+        "hardware"
+      ]
     },
     "devices/dvd_mount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["dvd", "disc", "mount", "video", "movie", "optical", "media"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "dvd",
+        "disc",
+        "mount",
+        "video",
+        "movie",
+        "optical",
+        "media"
+      ]
     },
     "devices/mouse.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["mouse", "pointer", "click", "input", "cursor", "device", "hardware"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "mouse",
+        "pointer",
+        "click",
+        "input",
+        "cursor",
+        "device",
+        "hardware"
+      ]
     },
     "devices/usbpendrive_mount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["usb", "pendrive", "flash", "mount", "storage", "thumb", "removable"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "usb",
+        "pendrive",
+        "flash",
+        "mount",
+        "storage",
+        "thumb",
+        "removable"
+      ]
     },
     "devices/printer1.png": {
-      "sizes": [16, 32, 48, 64, 128],
-      "hints": ["printer", "print", "paper", "output", "document", "hardware", "device"]
+      "sizes": [
+        16,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "printer",
+        "print",
+        "paper",
+        "output",
+        "document",
+        "hardware",
+        "device"
+      ]
     },
     "devices/dvd_unmount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["dvd", "disc", "unmount", "eject", "video", "optical", "media"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "dvd",
+        "disc",
+        "unmount",
+        "eject",
+        "video",
+        "optical",
+        "media"
+      ]
     },
     "devices/hdd_mount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["hdd", "harddrive", "disk", "mount", "storage", "drive", "internal"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "hdd",
+        "harddrive",
+        "disk",
+        "mount",
+        "storage",
+        "drive",
+        "internal"
+      ]
     },
     "devices/zip_unmount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["zip", "disk", "unmount", "eject", "removable", "iomega", "storage"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "zip",
+        "disk",
+        "unmount",
+        "eject",
+        "removable",
+        "iomega",
+        "storage"
+      ]
     },
     "devices/camera_mount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["camera", "photo", "digital", "mount", "picture", "device", "image"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "camera",
+        "photo",
+        "digital",
+        "mount",
+        "picture",
+        "device",
+        "image"
+      ]
     },
     "devices/pda.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["pda", "handheld", "palm", "mobile", "device", "pocket", "stylus"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "pda",
+        "handheld",
+        "palm",
+        "mobile",
+        "device",
+        "pocket",
+        "stylus"
+      ]
     },
     "devices/pda_blue.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["pda", "handheld", "palm", "mobile", "device", "blue", "pocket"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "pda",
+        "handheld",
+        "palm",
+        "mobile",
+        "device",
+        "blue",
+        "pocket"
+      ]
     },
     "devices/modem.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["modem", "dialup", "internet", "network", "connection", "hardware", "led"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "modem",
+        "dialup",
+        "internet",
+        "network",
+        "connection",
+        "hardware",
+        "led"
+      ]
     },
     "devices/nfs_unmount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["nfs", "network", "share", "unmount", "drive", "unix", "storage"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "nfs",
+        "network",
+        "share",
+        "unmount",
+        "drive",
+        "unix",
+        "storage"
+      ]
     },
     "devices/pda_black.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["pda", "handheld", "palm", "mobile", "device", "black", "pocket"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "pda",
+        "handheld",
+        "palm",
+        "mobile",
+        "device",
+        "black",
+        "pocket"
+      ]
     },
     "devices/ipod.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["ipod", "music", "player", "apple", "mp3", "portable", "audio"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "ipod",
+        "music",
+        "player",
+        "apple",
+        "mp3",
+        "portable",
+        "audio"
+      ]
     },
     "devices/usbpendrive_unmount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["usb", "pendrive", "flash", "unmount", "eject", "thumb", "removable"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "usb",
+        "pendrive",
+        "flash",
+        "unmount",
+        "eject",
+        "thumb",
+        "removable"
+      ]
     },
     "devices/blockdevice.png": {
-      "sizes": [16, 32, 48, 64, 128],
-      "hints": ["block", "device", "cubes", "storage", "partition", "disk", "volume"]
+      "sizes": [
+        16,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "block",
+        "device",
+        "cubes",
+        "storage",
+        "partition",
+        "disk",
+        "volume"
+      ]
     },
     "devices/3floppy_unmount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["floppy", "disk", "unmount", "eject", "save", "storage", "legacy"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "floppy",
+        "disk",
+        "unmount",
+        "eject",
+        "save",
+        "storage",
+        "legacy"
+      ]
     },
     "devices/nfs_mount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["nfs", "network", "share", "mount", "drive", "unix", "storage"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "nfs",
+        "network",
+        "share",
+        "mount",
+        "drive",
+        "unix",
+        "storage"
+      ]
     },
     "devices/camera.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["camera", "photo", "digital", "picture", "image", "device", "snapshot"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "camera",
+        "photo",
+        "digital",
+        "picture",
+        "image",
+        "device",
+        "snapshot"
+      ]
     },
     "devices/hdd_unmount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["hdd", "harddrive", "disk", "unmount", "eject", "drive", "internal"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "hdd",
+        "harddrive",
+        "disk",
+        "unmount",
+        "eject",
+        "drive",
+        "internal"
+      ]
     },
     "devices/5floppy_unmount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["floppy", "525", "disk", "unmount", "legacy", "storage", "vintage"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "floppy",
+        "525",
+        "disk",
+        "unmount",
+        "legacy",
+        "storage",
+        "vintage"
+      ]
     },
     "devices/zip_mount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["zip", "disk", "mount", "iomega", "removable", "storage", "cartridge"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "zip",
+        "disk",
+        "mount",
+        "iomega",
+        "removable",
+        "storage",
+        "cartridge"
+      ]
     },
     "devices/scanner.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["scanner", "scan", "flatbed", "image", "document", "hardware", "input"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "scanner",
+        "scan",
+        "flatbed",
+        "image",
+        "document",
+        "hardware",
+        "input"
+      ]
     },
     "devices/cdrom_mount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["cdrom", "cd", "disc", "mount", "optical", "media", "read"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "cdrom",
+        "cd",
+        "disc",
+        "mount",
+        "optical",
+        "media",
+        "read"
+      ]
     },
     "devices/mo_unmount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["mo", "magneto", "optical", "disk", "unmount", "eject", "removable"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "mo",
+        "magneto",
+        "optical",
+        "disk",
+        "unmount",
+        "eject",
+        "removable"
+      ]
     },
     "devices/camera_unmount.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["camera", "photo", "digital", "unmount", "eject", "device", "image"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "camera",
+        "photo",
+        "digital",
+        "unmount",
+        "eject",
+        "device",
+        "image"
+      ]
     },
     "devices/tv.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["tv", "television", "monitor", "screen", "video", "display", "broadcast"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "tv",
+        "television",
+        "monitor",
+        "screen",
+        "video",
+        "display",
+        "broadcast"
+      ]
     },
     "devices/joystick.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["joystick", "gamepad", "controller", "game", "input", "play", "gaming"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "joystick",
+        "gamepad",
+        "controller",
+        "game",
+        "input",
+        "play",
+        "gaming"
+      ]
     },
     "devices/print_class.png": {
-      "sizes": [16, 22, 32, 48, 64, 128],
-      "hints": ["printer", "class", "group", "print", "multiple", "network", "queue"]
+      "sizes": [
+        16,
+        22,
+        32,
+        48,
+        64,
+        128
+      ],
+      "hints": [
+        "printer",
+        "class",
+        "group",
+        "print",
+        "multiple",
+        "network",
+        "queue"
+      ]
     },
     "devices/5floppy_mount.png": {
       "sizes": [

--- a/tools/icon_grid_browser_data/papirus.json
+++ b/tools/icon_grid_browser_data/papirus.json
@@ -153806,6 +153806,2607 @@
       "sizes": [
         22
       ]
+    },
+    "emotes/face-crying.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-worried.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-smirk.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-angel.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-raspberry.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-plain.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-angry.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-smile.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        48
+      ]
+    },
+    "emotes/face-surprise.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-wink.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-laugh.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-sick.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-cool.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-kiss.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-sad.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-smile-big.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-monkey.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-glasses.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-embarrassed.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-devilish.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/emote-love.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-tired.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "emotes/face-uncertain.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48
+      ]
+    },
+    "devices/knemo-modem-error.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/gnome-dev-ethernet.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/camera-web.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/drive-virtual.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/media-memory-sd.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/audio-input-microphone.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/blueman-handheld.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/media-optical-mixed-cd.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/blueman-keyboard.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/blueman-laptop.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-disc-cdr.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/blueman-smart-phone.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-printer.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/audio-speaker-center.png": {
+      "sizes": [
+        16,
+        48
+      ]
+    },
+    "devices/hifi.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/device_serial.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/device_cpu.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-harddisk-1394.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-disc-cdrw.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/phone-htc-g1-white.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/audio-subwoofer.png": {
+      "sizes": [
+        16,
+        48
+      ]
+    },
+    "devices/stock_cell-phone.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/audio-speaker-front-left-of-center.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/drive-removable-media-usb.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/audio-card.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/media-flash.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/knemo-wireless-transmit.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/serial-port.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/media-flash-smart-media.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/display.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-harddisk-usb.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/bus-usb.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/memory.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/audio-speaker-right-back.png": {
+      "sizes": [
+        16,
+        48
+      ]
+    },
+    "devices/network-vpn.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/network-wired.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/multimedia-player-ipod-mini-blue.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/laptop.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-dvd.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/ipodtouchicon.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/media-cdrom.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/multimedia-player-ipod-shuffle.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/blueman-device.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/battery.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-cdrom-audio.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/blueman-camera.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/multimedia-player-ipod-mini-pink.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/media-floppy.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/bluetooth.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/audio-headphones.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-keyboard.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/media-floppy-3_5.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/i-network-printer.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/device_usb.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/blueman-loudspeaker.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/lan-segment.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/drive-removable-media-usb-pendrive.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/computer-laptop.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/knemo-wireless-idle.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/drive-harddisk-root.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-media-cf.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/media-optical-dvd.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/knemo-modem-idle.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/gnome-dev-battery.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/media-optical-data.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/cpu.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-wavelan.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/audio-speaker-center-back.png": {
+      "sizes": [
+        16,
+        48
+      ]
+    },
+    "devices/multimedia-player-ipod-mini-green.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/drive-optical.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/audio-speaker-front-right-of-center.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/drive-harddisk.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/phone-google-nexus-one.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/printer-network.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-removable-1394.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/unity-fallback-mount-helper.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-disc-dvdr-plus.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/camera-video.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-cdrom.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/knemo-wireless-transmit-receive.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/blueman-mouse.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-computer.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/knemo-monitor-offline.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/gnome-dev-media-sm.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/drive-harddisk-system.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/knemo-monitor-error.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/multimedia-player-ipod-standard-color.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/phone-nokia-n900.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/knemo-modem-transmit-receive.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/multimedia-player-ipod-nano-black.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/knemo-network-error.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/multimedia-player-ipod-standard-monochrome.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/media-optical.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/network-server.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/knemo-network-transmit.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/device-notifier.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/gnome-dev-disc-dvdram.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/input-keyboard.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/video-display.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/phone.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/camera-photo.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/headphones.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/blueman-desktop.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/audio-speaker-left-side.png": {
+      "sizes": [
+        16,
+        48
+      ]
+    },
+    "devices/multimedia-player-ipod-mini-gold.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/knemo-monitor-receive.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/blockdevice.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/drive-multidisk.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-media-sdmmc.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/media-memory.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/blueman-headset.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-printer-new.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/media-optical-video.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/camera.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-phone-manager.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/knemo-wireless-offline.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/gnome-dev-media-ms.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/server-database.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/media-optical-recordable.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/knemo-network-receive.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/computer.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/drive-removable-media.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/audio-speaker-right-side.png": {
+      "sizes": [
+        16,
+        48
+      ]
+    },
+    "devices/audio-speaker-left-back.png": {
+      "sizes": [
+        16,
+        48
+      ]
+    },
+    "devices/input-touchpad.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-harddisk.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/multimedia-player-ipod-mini-silver.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/scanner.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-mouse-ball.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/knemo-modem-receive.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/multimedia-player-ipod-nano-white.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/system.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-removable.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/smartphone.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/input-dialpad.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/knemo-wireless-receive.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/knemo-network-offline.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/knemo-monitor-transmit.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/vmware-memory.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/blueman-scanner.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-removable-usb.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/input-mouse.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/device_pci.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/knemo-network-idle.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/audio-speaker-right.png": {
+      "sizes": [
+        16,
+        48
+      ]
+    },
+    "devices/gnome-dev-memory.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/blueman-server.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/knemo-modem-transmit.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/drive-harddisk-ieee1394.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/audio-speakers.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/media-flash-sd-mmc.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/input-tablet.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/blueman-cellular.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-ipod.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/uninterruptible-power-supply.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/removable-media.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/tv.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/gnome-dev-disc-dvdr.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/phone-palm-pre.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/media-optical-dvd-video.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/media-tape.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/network-wireless.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/audio-speaker-left.png": {
+      "sizes": [
+        16,
+        48
+      ]
+    },
+    "devices/input-gaming.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/joystick.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/soundcard.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/multimedia-player.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/knemo-modem-offline.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/knemo-wireless-error.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/media-optical-audio.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-disc-dvdrom.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/multimedia-player-ipod-nano-green.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/gnome-dev-disc-dvdrw.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/knemo-monitor-idle.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/blueman-handsfree.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-mouse-optical.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/media-optical-blu-ray.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/knemo-network-transmit-receive.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/blueman-pointing.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/media-removable.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/gnome-dev-floppy.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/network-server-database.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/keyboard.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/knemo-monitor-transmit-receive.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/multimedia-player-ipod-U2-color.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/audio-headset.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "devices/multimedia-player-ipod-U2-monochrome.png": {
+      "sizes": [
+        16
+      ]
+    },
+    "devices/printer.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/steam_icon_1055540.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/cockatrice.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/org.gnome.Polari.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/fez.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/yast-sw_source.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/yast-timezone.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/qemu-system-x86_64-spice.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/aircrack-ng.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/FlashCS6.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/radeon-profile.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/xnretro.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/indicator-stickynotes.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/org.avidemux.Avidemux.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/gnome-robots.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/org.mpdevil.mpdevil.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/mdmsetup.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/distributor-logo-calculate-linux.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/GammaRay.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/org.gnome.design.VectorSlicer.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/wsw.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/designer5.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/PCSX2.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/dotmemory.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/so.libdb.gtkcord4.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/org.gnome.Meld.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/sgt-launcher.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/custom-toolbox.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/dupeguru.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/com.scoutshonour.dtipbijays.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/git.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/jami-gnome.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/device-notifier.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/pocket.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/com.github.davidmhewitt.torrential.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/statalogo_14.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/wassabee.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/io.elementary.videos.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/smc.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/lutris_shadwen.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/org.gnome.Four-in-a-row.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/guitarpro6.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/godot.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/starbound.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/four-in-a-row.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/half-life-alyx.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/steam_icon_546560.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/io.elementary.appcenter.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/input-tablet.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/ardour.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/tigervnc.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/com.github.basjam.valacompiler.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/messengerfordesktop.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/lutris_emily-is-away-too.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/org.gnome.NetworkDisplays.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/mx-alerts.png": {
+      "sizes": [
+        16,
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "panel/knemo-modem-error.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-wireless-transmit.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/network-vpn.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/network-wired.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-wireless-idle.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-modem-idle.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/drive-harddisk.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-wireless-transmit-receive.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-monitor-offline.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-monitor-error.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-modem-transmit-receive.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-network-error.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-network-transmit.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-monitor-receive.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-wireless-offline.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-network-receive.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-modem-receive.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-wireless-receive.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-network-offline.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-monitor-transmit.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-network-idle.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-modem-transmit.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/network-wireless.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-modem-offline.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-wireless-error.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-monitor-idle.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-network-transmit-receive.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/knemo-monitor-transmit-receive.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "panel/printer.png": {
+      "sizes": [
+        16,
+        22,
+        24
+      ]
+    },
+    "apps/display.png": {
+      "sizes": [
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "apps/printer.png": {
+      "sizes": [
+        22,
+        24,
+        32,
+        48,
+        64
+      ]
+    },
+    "status/bluetooth.png": {
+      "sizes": [
+        48
+      ]
+    },
+    "status/face-cool.png": {
+      "sizes": [
+        48
+      ]
     }
   }
 }


### PR DESCRIPTION
Icon Picker:
- Replace custom _IconVListBox with _IconListCtrl (wx.ListCtrl)
- Add 3 column headers: Name, Hints, Internal (technical key)
- 600px dialog width, 75% screen height
- Search now includes internal key name

Sash Cursor Fix:
- Prevent AUI sash resize cursor seep-through on popup dialogs
- Monkey-patch wx.Dialog to handle EVT_SET_CURSOR
- Document fix in docs/AUI.md

Icon Placeholder Cleanup:
- Eliminate "nobitmap" placeholder workarounds
- Use None consistently for no-icon state
- Simplify artprovider and uicommand icon handling