### PR TITLE
Add configurable status sort priority to Statuses preferences tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.68-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.68-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.68_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.68_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.68_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.68-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.1.69-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.1.69-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.1.69_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.1.69_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.1.69_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.1.69-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.68-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.68-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.68_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.68_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.1.68-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.1.68-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.1.69-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.1.69-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.1.69_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.1.69_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.1.69-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.1.69-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.68_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.1.68_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.1.69_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.1.69_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.68-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.1.68-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.69-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.1.69-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.68-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.1.68-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.1.69-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.1.69-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.68-x86_64.AppImage
-chmod +x TaskCoach-2.0.1.68-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.1.69-x86_64.AppImage
+chmod +x TaskCoach-2.0.1.69-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.1.68-x86_64.AppImage
+./TaskCoach-2.0.1.69-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/docs/APPEARANCE_STYLES.md
+++ b/docs/APPEARANCE_STYLES.md
@@ -255,8 +255,9 @@ an `"appearance"` page).
 | `taskcoachlib/domain/category/category.py` | `stylePriority` attribute |
 | `taskcoachlib/domain/categorizable/categorizable.py` | Legacy category color/font mixers |
 | `taskcoachlib/command/categoryCommands.py` | `EditStylePriorityCommand` |
-| `taskcoachlib/config/defaults.py` | Default status icons/colors/fonts |
-| `taskcoachlib/gui/dialog/editor.py` | `TaskAppearancePage` (Appearance tab) |
+| `taskcoachlib/config/defaults.py` | Default status icons/colors/fonts/sort priorities |
+| `taskcoachlib/gui/dialog/editor.py` | `TaskAppearancePage` (Appearance tab in editor) |
+| `taskcoachlib/gui/dialog/preferences.py` | `StatusesPage` (Statuses tab in preferences) |
 
 ---
 

--- a/docs/TASK_STATUS_SORT.md
+++ b/docs/TASK_STATUS_SORT.md
@@ -6,7 +6,9 @@ When "Sort by status first" is enabled (the default), tasks organize by status r
 
 ## Current Implementation
 
-The current system uses a numeric priority system where each status has a distinct sort priority via the `statusSortPriority` attribute:
+The system uses a numeric priority system where each status has a distinct sort priority via the `statusSortPriority` attribute. These priorities are **user-configurable** via the Preferences > Statuses tab.
+
+### Default Priorities
 
 | Priority | Status    |
 |----------|-----------|
@@ -24,6 +26,15 @@ Higher priority values sort first (descending), ensuring:
 - **Active** tasks in the middle (normal work in progress)
 - **Inactive** tasks lower (future work)
 - **Completed** tasks at the bottom
+
+### User Configuration
+
+Priorities can be changed in Preferences > Statuses using the "Sort Priority" dropdown (1-6) for each status. When a priority is changed, all other priorities are automatically adjusted using insert-before semantics to ensure no duplicates:
+
+- **Moving up** (e.g., 6 to 2): all priorities in [2, 6) shift up by 1
+- **Moving down** (e.g., 1 to 4): all priorities in (1, 4] shift down by 1
+
+Priorities are stored in the `[statussortpriority]` section of the settings file and loaded into status singletons at application startup.
 
 ### Sort Key Construction
 
@@ -68,6 +79,8 @@ sort_key = [not completed(), not inactive()] + [column_sort_key]
 
 ## Core Files
 
-- `taskcoachlib/domain/task/sorter.py` - Composite key logic
-- `taskcoachlib/domain/task/status.py` - Status definitions with statusSortPriority
+- `taskcoachlib/domain/task/sorter.py` - Composite key logic, subscribes to priority changes
+- `taskcoachlib/domain/task/status.py` - Status definitions with statusSortPriority, `loadSortPrioritiesFromSettings()`
 - `taskcoachlib/domain/task/task.py` - Status computation methods
+- `taskcoachlib/config/defaults.py` - Default priorities in `statussortpriority` section
+- `taskcoachlib/gui/dialog/preferences.py` - Statuses tab with priority dropdowns

--- a/taskcoachlib/application/application.py
+++ b/taskcoachlib/application/application.py
@@ -483,6 +483,10 @@ class Application(object, metaclass=patterns.Singleton):
         # 5. Acquire INI lock (needs wxApp for error dialog)
         self.settings.acquire_ini_lock()
 
+        # 5b. Load status sort priorities from settings
+        from taskcoachlib.domain.task import status as task_status
+        task_status.loadSortPrioritiesFromSettings(self.settings)
+
         # 6. Continue with rest of initialization
         self.init(**kwargs)
 

--- a/taskcoachlib/config/defaults.py
+++ b/taskcoachlib/config/defaults.py
@@ -588,6 +588,14 @@ defaults = {
         "inactivetasks": "led_grey_icon",
         "duesoontasks": "led_orange_icon",
     },
+    "statussortpriority": {
+        "inactivetasks": "2",
+        "latetasks": "4",
+        "activetasks": "3",
+        "duesoontasks": "5",
+        "overduetasks": "6",
+        "completedtasks": "1",
+    },
     "version": {
         "python": "",  # Filled in by the Settings class when saving the settings
         "wxpython": "",  # Idem

--- a/taskcoachlib/config/settings.py
+++ b/taskcoachlib/config/settings.py
@@ -283,7 +283,10 @@ class Settings(CachingConfigParser):
         ):
             result = "Task Coach"
         elif section == "editor" and option == "preferencespages":
-            result = result.replace("colors", "appearance")
+            # Migrate legacy page names saved in .ini files from older versions.
+            # Each step must be kept so upgrades from any prior version work.
+            result = result.replace("colors", "appearance")  # pre-1.x "colors" tab
+            result = result.replace("appearance", "statuses")  # renamed to "Statuses" tab
         elif section in orderingViewers and option == "columnsalwaysvisible":
             # XXX: remove 'ordering' from always visible columns. This wasn't in any official release
             # but I need it so that people can test without resetting their .ini file...

--- a/taskcoachlib/domain/task/sorter.py
+++ b/taskcoachlib/domain/task/sorter.py
@@ -45,6 +45,12 @@ class Sorter(base.TreeSorter):
             task.Task.completionDateTimeChangedEventType(),
         ):
             pub.subscribe(self.onAttributeChanged, eventType)
+        pub.subscribe(self._onStatusSortPriorityChanged,
+                      "settings.statussortpriority.changed")
+
+    def _onStatusSortPriorityChanged(self):
+        """Re-sort when status sort priorities change in settings."""
+        self.reset()
 
     def setTreeMode(self, treeMode=True):
         self.__treeMode = treeMode

--- a/taskcoachlib/domain/task/status.py
+++ b/taskcoachlib/domain/task/status.py
@@ -130,3 +130,10 @@ completed = TaskStatus(
     _("Show/hide completed tasks"),
     statusSortPriority=1,
 )
+
+
+def loadSortPrioritiesFromSettings(settings):
+    """Load status sort priorities from settings into status singletons."""
+    for s in (inactive, late, active, duesoon, overdue, completed):
+        key = "%stasks" % s.statusString
+        s.statusSortPriority = int(settings.get("statussortpriority", key))

--- a/taskcoachlib/gui/dialog/preferences.py
+++ b/taskcoachlib/gui/dialog/preferences.py
@@ -333,17 +333,16 @@ class SettingsPageBase(widgets.ScrolledBookPage):
         self._fontSettings.append((section, setting, font_button))
 
     def addAppearanceHeader(self):
-        # Row 0: Group headers - "" | Light (spanning 4) | Dark (spanning 4) | ""
-        emptyLabel = wx.StaticText(self, label="")
+        # Row 0: Group headers - only Light and Dark bold headers (cols 2-5, 6-9)
         lightLabel = wx.StaticText(self, label=_("Light Theme"))
         darkLabel = wx.StaticText(self, label=_("Dark Theme"))
         boldFont = lightLabel.GetFont().Bold()
         lightLabel.SetFont(boldFont)
         darkLabel.SetFont(boldFont)
 
-        pos = self._position.next(1)
-        self._sizer.Add(emptyLabel, pos, span=(1, 1),
-                        flag=wx.ALL | wx.ALIGN_CENTER, border=self._borderWidth)
+        # Skip cols 0-1 (Label, Priority have no bold group header)
+        self._position.next(1)
+        self._position.next(1)
         pos = self._position.next(4)
         self._sizer.Add(lightLabel, pos, span=(1, 4),
                         flag=wx.ALL | wx.ALIGN_CENTER, border=self._borderWidth)
@@ -353,17 +352,22 @@ class SettingsPageBase(widgets.ScrolledBookPage):
         # Empty cell for reset column
         self._position.next(1)
 
-        # Row 1: Partial horizontal lines under Light and Dark headers
-        self._sizer.Add(wx.StaticLine(self), (1, 1), span=(1, 4),
+        # Row 1: Separator lines under Label, Priority, Light and Dark
+        self._sizer.Add(wx.StaticLine(self), (1, 0), span=(1, 1),
                         flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=self._borderWidth)
-        self._sizer.Add(wx.StaticLine(self), (1, 5), span=(1, 4),
+        self._sizer.Add(wx.StaticLine(self), (1, 1), span=(1, 1),
+                        flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=self._borderWidth)
+        self._sizer.Add(wx.StaticLine(self), (1, 2), span=(1, 4),
+                        flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=self._borderWidth)
+        self._sizer.Add(wx.StaticLine(self), (1, 6), span=(1, 4),
                         flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=self._borderWidth)
         # Advance cursor past the line row
-        self._position.next(10)
+        self._position.next(11)
 
-        # Row 2: Sub-headers
+        # Row 2: Sub-headers - Label left-aligned, Priority centered, rest centered
         self.addEntry(
-            "",
+            _("Label"),
+            _("Priority"),
             _("Foreground"),
             _("Background"),
             _("Font"),
@@ -373,7 +377,10 @@ class SettingsPageBase(widgets.ScrolledBookPage):
             _("Font"),
             _("Icon"),
             "",
-            flags=[wx.ALL | wx.ALIGN_CENTER] * 10,
+            flags=[
+                wx.ALL | wx.ALIGN_LEFT | wx.ALIGN_CENTRE_VERTICAL,  # Label
+                wx.ALL | wx.ALIGN_CENTER,                            # Priority
+            ] + [wx.ALL | wx.ALIGN_CENTER] * 9,
         )
 
     def _createIconEntry(self, excluded_icons=None):
@@ -429,6 +436,14 @@ class SettingsPageBase(widgets.ScrolledBookPage):
         iconSetting,
         text,
     ):
+        # Priority dropdown
+        priorityChoice = wx.Choice(self, choices=[str(i) for i in range(1, 7)])
+        currentPriority = int(self.get("statussortpriority", fgColorSetting))
+        priorityChoice.SetSelection(currentPriority - 1)
+        self._priorityChoices.append((fgColorSetting, priorityChoice))
+        self._previousPriorities[priorityChoice] = currentPriority
+        priorityChoice.Bind(wx.EVT_CHOICE, self._onPriorityChanged)
+
         # Light controls
         lightFg, lightBg, lightFont, lightIcon = self._createAppearanceControls(
             fgColorSection, fgColorSetting,
@@ -444,7 +459,7 @@ class SettingsPageBase(widgets.ScrolledBookPage):
             iconSection + "_dark", iconSetting,
         )
 
-        # Reset button
+        # Reset button (resets appearance only, not priority)
         resetBtn = wx.Button(self, label=_("Reset"), size=(60, -1))
         resetBtn.Bind(wx.EVT_BUTTON, lambda evt, s=fgColorSetting,
                       lf=lightFg, lb=lightBg, lfn=lightFont, li=lightIcon,
@@ -453,11 +468,13 @@ class SettingsPageBase(widgets.ScrolledBookPage):
 
         self.addEntry(
             text,
+            priorityChoice,
             lightFg, lightBg, lightFont, lightIcon,
             darkFg, darkBg, darkFont, darkIcon,
             resetBtn,
             flags=(
-                wx.ALIGN_LEFT | wx.ALIGN_CENTRE_VERTICAL,
+                wx.ALL | wx.ALIGN_LEFT | wx.ALIGN_CENTRE_VERTICAL,
+                wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.ALIGN_CENTER_HORIZONTAL,
                 wx.ALL | wx.EXPAND | wx.ALIGN_CENTER_VERTICAL,
                 wx.ALL | wx.EXPAND | wx.ALIGN_CENTER_VERTICAL,
                 wx.ALL | wx.EXPAND | wx.ALIGN_CENTER_VERTICAL,
@@ -470,9 +487,10 @@ class SettingsPageBase(widgets.ScrolledBookPage):
             ),
         )
 
-    def _onResetAppearanceRow(self, setting, lightFg, lightBg, lightFont, lightIcon,
+    def _onResetAppearanceRow(self, setting,
+                              lightFg, lightBg, lightFont, lightIcon,
                               darkFg, darkBg, darkFont, darkIcon):
-        """Reset all appearance controls in a row to their defaults."""
+        """Reset appearance controls in a row to defaults (not priority)."""
         import ast
         from taskcoachlib.config import defaults as defaults_mod
         defs = defaults_mod.defaults
@@ -1904,14 +1922,16 @@ class LanguagePage(SettingsPage):
         self.set("spellcheck", "language", selectedSpellLang)
 
 
-class TaskAppearancePage(SettingsPage):
-    pageName = "appearance"
-    pageTitle = _("Task appearance")
+class StatusesPage(SettingsPage):
+    pageName = "statuses"
+    pageTitle = _("Statuses")
     pageIcon = "palette_icon"
 
     def __init__(self, *args, **kwargs):
-        super().__init__(columns=10, growableColumn=-1, *args, **kwargs)
+        super().__init__(columns=11, growableColumn=-1, *args, **kwargs)
         self._objectIcons = self._collectObjectIcons()
+        self._priorityChoices = []  # [(setting, choiceCtrl), ...]
+        self._previousPriorities = {}  # choiceCtrl -> int
         self.addAppearanceHeader()
         for status in task.Task.possibleStatuses():
             setting = "%stasks" % status
@@ -1931,12 +1951,31 @@ class TaskAppearancePage(SettingsPage):
         for section, setting, iconEntry in self._iconSettings:
             iconEntry.Bind(wx.EVT_COMBOBOX,
                            lambda evt, ie=iconEntry: self._onStatusIconChanged(evt, ie))
+        # Separator lines under the table, matching header lines
+        lineRow = self._position.next(11)  # consume full row, get row number
+        self._sizer.Add(wx.StaticLine(self), (lineRow[0], 0), span=(1, 1),
+                        flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=self._borderWidth)
+        self._sizer.Add(wx.StaticLine(self), (lineRow[0], 1), span=(1, 1),
+                        flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=self._borderWidth)
+        self._sizer.Add(wx.StaticLine(self), (lineRow[0], 2), span=(1, 4),
+                        flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=self._borderWidth)
+        self._sizer.Add(wx.StaticLine(self), (lineRow[0], 6), span=(1, 4),
+                        flag=wx.EXPAND | wx.LEFT | wx.RIGHT, border=self._borderWidth)
+        # Reset priorities button placed directly in col 1 (priority column)
+        resetPrioritiesBtn = wx.Button(self, label=_("Reset"), size=(60, -1))
+        resetPrioritiesBtn.Bind(wx.EVT_BUTTON, self._onResetPriorities)
+        resetRow = self._position.next(11)  # consume full row, get row number
+        self._sizer.Add(resetPrioritiesBtn, (resetRow[0], 1), span=(1, 1),
+                        flag=wx.ALL | wx.ALIGN_CENTER, border=self._borderWidth)
+        # Note text spanning all columns, left-aligned
         noteText = wx.StaticText(self, label=_(
             "These appearance settings can be overridden "
             "for individual tasks in the task edit dialog."
         ))
         noteText.SetForegroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
-        self.addEntry("", noteText, flags=(wx.ALL | wx.ALIGN_LEFT, wx.ALL | wx.EXPAND))
+        noteRow = self._position.next(11)  # consume full row
+        self._sizer.Add(noteText, (noteRow[0], 0), span=(1, 11),
+                        flag=wx.ALL | wx.ALIGN_LEFT, border=self._borderWidth)
         self.fit()
 
     def _collectObjectIcons(self):
@@ -1962,6 +2001,49 @@ class TaskAppearancePage(SettingsPage):
         """Handle icon selection change. Excluded icons are handled by IconPicker."""
         # The new IconPicker prevents selection of excluded icons internally
         event.Skip()
+
+    def _onPriorityChanged(self, event):
+        """Handle priority dropdown change with insert-before semantics."""
+        changed = event.GetEventObject()
+        newPriority = changed.GetSelection() + 1  # 0-indexed -> 1-indexed
+        oldPriority = self._previousPriorities[changed]
+        if newPriority == oldPriority:
+            return
+        for setting, ctrl in self._priorityChoices:
+            if ctrl is changed:
+                continue
+            p = ctrl.GetSelection() + 1
+            if newPriority < oldPriority:
+                # Moving up: priorities in [new, old) get +1
+                if newPriority <= p < oldPriority:
+                    ctrl.SetSelection(p)  # p+1 in 0-indexed = p
+            else:
+                # Moving down: priorities in (old, new] get -1
+                if oldPriority < p <= newPriority:
+                    ctrl.SetSelection(p - 2)  # p-1 in 0-indexed = p-2
+        # Update all previous priorities
+        for setting, ctrl in self._priorityChoices:
+            self._previousPriorities[ctrl] = ctrl.GetSelection() + 1
+
+    def _onResetPriorities(self, event):
+        """Reset all priority dropdowns to their defaults."""
+        from taskcoachlib.config import defaults as defaults_mod
+        defs = defaults_mod.defaults
+        for setting, ctrl in self._priorityChoices:
+            defaultPriority = int(defs["statussortpriority"][setting])
+            ctrl.SetSelection(defaultPriority - 1)
+        for setting, ctrl in self._priorityChoices:
+            self._previousPriorities[ctrl] = ctrl.GetSelection() + 1
+
+    def ok(self):
+        # Save priority values to settings
+        from taskcoachlib.domain.task import status as task_status
+        for setting, ctrl in self._priorityChoices:
+            value = str(ctrl.GetSelection() + 1)
+            self.set("statussortpriority", setting, value)
+        task_status.loadSortPrioritiesFromSettings(self.settings)
+        pub.sendMessage("settings.statussortpriority.changed")
+        super().ok()
 
 
 class FeaturesPage(SettingsPage):
@@ -2677,7 +2759,7 @@ class Preferences(widgets.NotebookDialog):
         "reminder",
         "presets",
         "theme",
-        "appearance",
+        "statuses",
         "features",
         "icons",
     ]
@@ -2689,7 +2771,7 @@ class Preferences(widgets.NotebookDialog):
         presets=DurationPresetsPage,
         save=SavePage,
         language=LanguagePage,
-        appearance=TaskAppearancePage,
+        statuses=StatusesPage,
         features=FeaturesPage,
         icons=IconsPage,
     )

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,8 +41,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.1"  # Major.Minor.Milestone
-patch = "68"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.1.68
+patch = "69"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.1.69
 
 release_day = "9"  # Day of the release (1-31)
 release_month = "February"  # Month of the release

--- a/tests/unittests/guiTests/PreferencesTest.py
+++ b/tests/unittests/guiTests/PreferencesTest.py
@@ -34,14 +34,16 @@ class PreferencesTest(test.wxTestCase):
     # pylint: disable=W0212
 
     def testCancel(self):
-        self.preferences[5]._colorSettings[4][2].SetColour(self.newColor)
+        # Page 7 = Statuses tab; color index 8 = active tasks light fg
+        self.preferences[7]._colorSettings[8][2].SetColour(self.newColor)
         self.preferences.cancel()
         self.assertEqual(
             self.originalColor, self.settings.get("fgcolor", "activetasks")
         )
 
     def testOk(self):
-        self.preferences[5]._colorSettings[4][2].SetColour(self.newColor)
+        # Page 7 = Statuses tab; color index 8 = active tasks light fg
+        self.preferences[7]._colorSettings[8][2].SetColour(self.newColor)
         self.preferences.ok()
         self.assertEqual(
             self.newColor,


### PR DESCRIPTION
Rename TaskAppearancePage to StatusesPage, add per-status priority dropdowns (1-6) with insert-before reordering semantics, persist priorities to settings, reload into status singletons at startup, and re-sort tasks live on change. Includes config defaults, settings migration chain, documentation updates, and version bump to 2.0.1.69.

sort-by-status-first isn't working! #355