### PR TITLE
Fix packaging to include all files under taskcoachlib/

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
-recursive-include taskcoachlib/gui/icons *.png
+graft taskcoachlib
+global-exclude *.py[cod]
+global-exclude __pycache__
 include icons.in/taskcoach.png
 include build.in/linux_common/taskcoach.desktop
 include build.in/debian/taskcoach.appdata.xml

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from setuptools import setup
+from setuptools import setup, find_namespace_packages
 import platform
 import re
 import os
@@ -70,21 +70,6 @@ try:
     import distro
 except ImportError:
     distro = None
-
-
-def findPackages(base):
-    if not os.path.exists(base):
-        return list()
-
-    result = [base.replace("/", ".")]
-
-    for name in os.listdir(base):
-        fname = os.path.join(base, name)
-        if os.path.isdir(fname) and os.path.exists(
-            os.path.join(fname, "__init__.py")
-        ):
-            result.extend(findPackages(fname))
-    return result
 
 
 def majorAndMinorPythonVersion():
@@ -162,11 +147,7 @@ setupOptions = {
     "install_requires": install_requires,
     "extras_require": extras_require,
     "tests_require": tests_requires,
-    "packages": findPackages("taskcoachlib") + findPackages("buildlib"),
-    "package_data": {
-        "taskcoachlib.gui": ["icons/*.png"],
-        "taskcoachlib.i18n": ["locales/*.po"],
-    },
+    "packages": find_namespace_packages(include=["taskcoachlib", "taskcoachlib.*"]),
     "include_package_data": True,
     "scripts": ["taskcoach.py"],
     "classifiers": [


### PR DESCRIPTION
Three build platforms (Debian, RPM, Arch) go through setup.py which silently dropped files from taskcoachlib/gui/icons/: icon_library.py, 652 PNGs in subdirectories, 7 JSON theme files, splash.jpg, and icon_overview.html.

Root cause: gui/icons/ has no __init__.py so the custom findPackages() skipped it, and package_data used a shallow glob that missed subdirectories.

Replace findPackages() + manual package_data with
find_namespace_packages() + MANIFEST.in graft. This is the current PyPA best practice: find_namespace_packages discovers all directories (even without __init__.py), and graft + include_package_data bridges all data files into wheels and installs.

crash running 2.0.1.68 #371