### PR TITLE
Add hover outline, optimize mouse-move CPU, fix DnD crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.0-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.0-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.0_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.0_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.0_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.0-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.1-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.1-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.1_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.1_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.1_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.1-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.0-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.0-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.0_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.0_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.2.0-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.2.0-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.1-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.1-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.1_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.1_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.2.1-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.2.1-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.0_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.2.0_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.1_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.2.1_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.0-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.2.0-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.1-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.2.1-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.0-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.2.0-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.1-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.2.1-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.0-x86_64.AppImage
-chmod +x TaskCoach-2.0.2.0-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.1-x86_64.AppImage
+chmod +x TaskCoach-2.0.2.1-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.2.0-x86_64.AppImage
+./TaskCoach-2.0.2.1-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/README_INSTALL_MACOS.md
+++ b/README_INSTALL_MACOS.md
@@ -7,7 +7,7 @@ Download the DMG for your Mac from the [latest release](https://github.com/taskc
 - **Apple Silicon** (M1/M2/M3/M4): `TaskCoach-<version>-macos-arm64.dmg`
 - **Intel**: `TaskCoach-<version>-macos-intel.dmg`
 
-Where `<version>` is the release version (e.g., `2.0.2.0`).
+Where `<version>` is the release version (e.g., `2.0.2.1`).
 
 Not sure which Mac you have? Click the Apple menu → "About This Mac". Look for "Chip" (Apple Silicon) or "Processor" (Intel).
 

--- a/README_INSTALL_WINDOWS.md
+++ b/README_INSTALL_WINDOWS.md
@@ -7,7 +7,7 @@ Download the installer from the [latest release](https://github.com/taskcoach/ta
 - **Installer**: `TaskCoach-<version>-windows-x64-setup.exe` - Standard installation
 - **Portable**: `TaskCoach-<version>-windows-x64-portable.zip` - No installation required
 
-Where `<version>` is the release version (e.g., `2.0.2.0`).
+Where `<version>` is the release version (e.g., `2.0.2.1`).
 
 ## Security Warning
 

--- a/docs/LIST_MANAGEMENT.md
+++ b/docs/LIST_MANAGEMENT.md
@@ -2,13 +2,33 @@
 
 ## Table of Contents
 
-1. [Overview](#overview)
-2. [Selection SSOT Principle](#selection-ssot-principle)
-3. [Multi-Window Architecture](#multi-window-architecture)
-4. [Select Next After Deletion](#select-next-after-deletion)
-5. [Status Bar Updates](#status-bar-updates)
-6. [Scroll After Rebuild (Tree Views)](#scroll-after-rebuild-tree-views)
-7. [Key Files](#key-files)
+1. [TODO](#todo)
+2. [Overview](#overview)
+3. [Selection SSOT Principle](#selection-ssot-principle)
+4. [Multi-Window Architecture](#multi-window-architecture)
+5. [Select Next After Deletion](#select-next-after-deletion)
+6. [Status Bar Updates](#status-bar-updates)
+7. [Scroll After Rebuild (Tree Views)](#scroll-after-rebuild-tree-views)
+8. [Row Hover Outline](#row-hover-outline)
+9. [Mouse-Move Handler Inventory (Tree Views)](#mouse-move-handler-inventory-tree-views)
+10. [Vampire CPU Usage](#vampire-cpu-usage)
+11. [AUI Sash Resize Throttle](#aui-sash-resize-throttle)
+12. [Key Files](#key-files)
+
+---
+
+## TODO
+
+1. **Selection highlight outline:** Add the same two-tone border outline
+   (currently used for hover) around the currently selected row(s) as well.
+   This would provide a stronger, more accessible visual indicator for
+   selection — especially on low-contrast themes or when custom row colors
+   make the default selection highlight hard to see. The hover outline
+   infrastructure (`_hoverItem`, `PaintLevel`, `_refreshHoverLine`) could be
+   reused or extended to also draw around selected items using a different
+   color pair (e.g. `SYS_COLOUR_HIGHLIGHT` / `SYS_COLOUR_HIGHLIGHTTEXT`).
+2. **Eliminate UpdateUI polling entirely:** See [Vampire CPU Usage](#vampire-cpu-usage)
+   for Option A (all buttons always enabled) and Option B (event-driven updates).
 
 ---
 
@@ -212,13 +232,303 @@ List-only viewers (effort, attachments) always use `ensureSelectionVisible` (nat
 
 ---
 
+## Row Hover Outline
+
+A two-tone (fg/bg) hover outline on all list and tree view rows, following the
+W3C WCAG C40 technique used by Chrome/Edge focus indicators. An inner line uses
+`SYS_COLOUR_WINDOWTEXT` and an outer line uses `SYS_COLOUR_WINDOW`, guaranteeing
+visibility on any background including selected, custom-colored, and unfocused
+rows. Line thickness is configurable via **Preferences > Theme > Hoverover
+Highlight** (default 1, 0 to disable). The setting is re-read on each row
+change, so changes take effect immediately without restart.
+
+The expensive `OnBeforeShowToolTip()` call (HitTest + full tooltip data
+extraction traversing notes, categories, attachments, descriptions) is deferred
+from every mouse-move event to a 200ms timer callback. Only the mouse position
+is stored on motion; data extraction runs once after the cursor is still.
+
+### Two-Tone Strategy (W3C WCAG C40)
+
+The outline uses two contrasting 1px lines — inner `SYS_COLOUR_WINDOWTEXT` (fg)
+and outer `SYS_COLOUR_WINDOW` (bg) — so at least one line is always visible
+regardless of the row's background color (normal, selected, custom, focused or
+unfocused). This is the same technique Chrome/Edge use for keyboard focus
+indicators.
+
+Reference: [W3C WCAG Technique C40 — Creating a two-color focus indicator to
+ensure sufficient contrast](https://www.w3.org/WAI/WCAG21/Techniques/css/C40)
+
+### Tree Views (HyperTreeList)
+
+```
+EVT_MOUSE_EVENTS on TreeListMainWindow
+    │
+    ├── OnMouse() fast-path (hypertreelist.py)
+    │   └── event.Moving() and not dragging?
+    │       ├── Same row (Y-bounds cache hit) → return (zero work)
+    │       └── New row → HitTest → SetHoverItem(item)
+    │           ├── _readHoverSetting()            ← re-read config
+    │           ├── _refreshHoverLine(prevItem)     ← erase old outline
+    │           └── _refreshHoverLine(newItem)      ← trigger repaint
+    │
+    └── event.Skip() → tooltip __OnMotion also fires
+```
+
+**State:** `TreeListMainWindow._hoverItem` — the currently hovered item, or `None`.
+
+**Drawing:** In `PaintLevel()` in `hypertreelist.py`, after row lines and before
+DC restore. Draws outer 1px bg rect (inflated by 1), then inner 1px fg rect.
+Skipped for drag items.
+
+**Cleanup:** `EVT_LEAVE_WINDOW` → `SetHoverItem(None)`.
+
+**Ghosting prevention:** `_refreshHoverLine()` inflates the invalidation rect by
+3px (1px inner + 1px outer + safety) so the full two-tone outline is erased on
+repaint.
+
+### List Views (VirtualListCtrl)
+
+```
+EVT_MOTION on VirtualListCtrl
+    │
+    ├── _onHoverMotion()
+    │   └── HitTest → update _hover_row
+    │       ├── _refreshHoverRow(old)   ← padded RefreshRect
+    │       └── _refreshHoverRow(new)   ← padded RefreshRect
+    │       └── CallAfter(_drawHoverOutline)
+    │
+    └── event.Skip()
+```
+
+Native `wx.ListCtrl` has no PaintItem hook, so the outline is drawn post-paint
+via `wx.ClientDC` + `wx.CallAfter`. `EVT_PAINT` also triggers a deferred redraw
+to survive native repaints.
+
+**Cleanup:** `EVT_LEAVE_WINDOW` → reset `_hover_row`, padded refresh.
+
+### Settings
+
+`hoverlinewidth` in `[window]` — integer, default 1. 0 disables hover, >0
+enables the two-tone outline. User-facing path: **Preferences > Theme >
+Hoverover Highlight**. Read into a local cache at init, on
+`RefreshAllItems()`, and re-read on each row change via `_readHoverSetting()`.
+
+---
+
+## Mouse-Move Handler Inventory (Tree Views)
+
+Only two handlers fire on mouse motion. Both call `event.Skip()` so the chain is not broken.
+
+| Handler | File | Purpose |
+|---------|------|---------|
+| `OnMouse` fast-path | `hypertreelist.py` | Row-bounds cache → HitTest only on row change → update `_hoverItem` |
+| `__OnMotion` (ToolTipMixin) | `tooltip.py` | Store position, start 200ms timer |
+| `__OnTimer` (ToolTipMixin) | `tooltip.py` | Call `OnBeforeShowToolTip()` → build tooltip |
+
+**Hover fast-path:** `OnMouse` short-circuits for `event.Moving()` before the
+full HitTest + button/drag/tooltip processing (~200 lines skipped). A Y-bounds
+cache skips HitTest entirely when the mouse stays on the same row.
+
+**Drag fast-path:** During drag, a row+column bounds cache skips HitTest when
+the mouse stays on the same cell. Only `dragImage.Move()` runs per pixel.
+
+**Tooltip:** `OnBeforeShowToolTip()` (which does HitTest + `getItemTooltipData()`
+traversing notes, categories, attachments, descriptions) is deferred to the timer
+callback. On every mouse move, only the position is stored and the timer restarted.
+The expensive data extraction runs once after 200ms of stillness.
+
+**Removed:** `_onHoverMotion` (was in `treectrl.py`) — performed a duplicate
+HitTest on every pixel. Hover tracking is now integrated into `OnMouse` fast-path.
+
+---
+
+## Vampire CPU Usage
+
+wx's default `EVT_UPDATE_UI` mechanism is a polling loop that silently
+consumes CPU even when the application is minimized and the user is doing
+nothing.
+
+### The Problem
+
+Two always-running repeating timers keep the wx event loop alive:
+
+| Timer | File | Interval | Purpose |
+|-------|------|----------|---------|
+| Signal check | `application.py:801` | 500ms | Wakes event loop so SIGINT/SIGTERM work (Linux/Mac) |
+| Global scheduler | `scheduler.py:88` | 1000ms | Fires `timer.second` for reminders, effort tracking |
+
+Every timer tick generates an event. After each event, wx fires `EVT_IDLE`.
+During idle, wx fires `EVT_UPDATE_UI` for **every visible toolbar button**
+(~30 items across all viewer toolbars). Each one calls `enabled()` to check
+whether the button should be greyed out.
+
+```
+signal_check_timer fires (every 500ms)
+  -> event queue briefly empty -> EVT_IDLE fires
+  -> wx checks: interval elapsed since last UpdateUI? yes
+  -> EVT_UPDATE_UI x ~30 visible toolbar buttons
+  -> each calls enabled() to poll state
+  -> repeat forever, even when minimized
+```
+
+This happens even when no state has changed, because UpdateUI is a **polling**
+mechanism — it re-checks every button on every idle cycle regardless.
+
+### What `enabled()` actually does
+
+Each `onUpdateUI` call runs `event.Enable(bool(self.enabled(event)))`. For
+simple commands like `FileOpen` this is a trivial `return True`. But ~15 of the
+~30 toolbar buttons inherit `NeedsSelectionMixin`, which does real work:
+
+```python
+# mixin_uicommand.py — NeedsSelectionMixin
+def enabled(self, event):
+    return super().enabled(event) and self.viewer.curselection()
+
+# base.py — Viewer.curselection()
+def curselection(self):
+    return self.widget.curselection()  # walks GetSelections() on the tree
+```
+
+So for Edit, Delete, TaskMarkInactive, TaskMarkActive, TaskMarkCompleted,
+NewSubItem, and others, every 200ms wx:
+
+1. Calls `widget.curselection()` → iterates all selected tree items → maps
+   each to a domain object via `GetItemPyData()`
+2. Some also call `curselectionIsInstanceOf()` → iterates again with
+   `isinstance()` checks on every selected item
+
+All to answer "should this button be greyed out?" — when nothing has changed.
+This is pure waste. The correct approach would be event-driven: update button
+states only when selection or data actually changes, not by continuous polling.
+
+### TODO: Eliminate UpdateUI polling entirely
+
+**Q1: Can we piggyback on the 1-second scheduler tick?** The global scheduler
+timer already fires every second (`scheduler.py:88`). Instead of wx polling
+`enabled()` via UpdateUI, we could update toolbar button states once per second
+in the scheduler callback. This would consolidate the work into one place and
+eliminate the UpdateUI overhead entirely.
+
+**Q2: Can we make it event-driven instead?** Selection changes already fire
+`EVT_TREE_SEL_CHANGED` → `onSelect()`. Data changes fire
+`onPresentationChanged()`. Undo/redo state changes when commands execute. We
+could call `UpdateWindowUI()` explicitly at these points and disable the
+polling entirely via `wx.UpdateUIEvent.SetMode(wx.UPDATE_UI_PROCESS_SPECIFIED)`.
+This way button states update immediately on real changes and never poll.
+
+**Q3: Why are static buttons being polled?** Buttons like `FileOpen`, `Print`,
+`TaskNew`, `ViewExpandAll`, `ViewCollapseAll` are **always enabled** — their
+`enabled()` just returns `True`. Yet wx polls them every 200ms anyway. These
+should either be excluded from UpdateUI entirely (don't bind `EVT_UPDATE_UI`
+for them) or their `onUpdateUI` should be a no-op that skips `event.Enable()`.
+
+**Q4: Why grey out buttons at all?** The simplest fix: keep all buttons always
+enabled and make `doCommand()` no-op when the action doesn't apply (no
+selection, wrong item type, etc.). This eliminates the entire UpdateUI
+mechanism — no polling, no `enabled()` calls, no `EVT_UPDATE_UI` bindings,
+zero idle CPU. The greyed-out visual is a minor UX hint that doesn't justify
+continuous CPU polling. Clicking "Delete" with nothing selected simply does
+nothing. This is how many modern apps work (e.g. VS Code toolbar buttons
+don't grey out). The `doCommand()` methods already guard against invalid state
+in many cases via `onCommandActivate()` which checks `self.enabled(event)`.
+
+**Recommended approach (Option A — simplest):** Make all buttons always enabled.
+Remove all `EVT_UPDATE_UI` bindings from `bind()` in `base_uicommand.py`. Keep
+the `enabled()` check inside `onCommandActivate()` so commands still no-op
+when they don't apply. Remove `SetUpdateInterval` since it's no longer needed.
+This is the simplest change with the largest impact — eliminates the entire
+UpdateUI polling loop in one stroke.
+
+**Alternative approach (Option B — event-driven):** Combine Q2 and Q3. Remove
+`EVT_UPDATE_UI` bindings from always-enabled buttons (Q3). For the rest, switch
+to `UPDATE_UI_PROCESS_SPECIFIED` mode and explicitly trigger
+`UpdateWindowUI()` on selection change, data change, and undo/redo (Q2). The
+`SetUpdateInterval(200)` stays as a safety fallback. This preserves the
+greyed-out visual feedback for context-sensitive buttons while eliminating the
+continuous polling overhead.
+
+### Additional idle handlers that fire on every cycle
+
+| Handler | File | Cost |
+|---------|------|------|
+| `onIdle` | `taskbaricon.py:124` | Compares tooltip text + icon strings |
+| `_OnIdle` | `powermgt/idle.py:401` | Two `time.time()` calls + state check |
+| `_on_idle` | `windowdimensionstracker.py:469` | Checks ready flag (cheap early return) |
+
+### The Fix: SetUpdateInterval
+
+`wx.UpdateUIEvent.SetUpdateInterval(200)` in `application.py:OnInit` throttles
+UpdateUI processing to fire at most every 200ms instead of on every idle cycle.
+This is wx's official recommended API for this exact problem.
+
+**Before:** ~30 `enabled()` calls on every idle cycle (hundreds/sec during
+mouse motion, ~2/sec when idle via timer ticks).
+
+**After:** ~30 `enabled()` calls at most every 200ms (~5 batches/sec max),
+regardless of how many idle cycles occur.
+
+### Why only toolbar items, not menu items?
+
+wx only fires `EVT_UPDATE_UI` for **currently visible** UI elements. Toolbar
+buttons are always visible, so they get polled continuously. Menu items only
+receive UpdateUI **when the menu is opened**. This is why the log shows only
+toolbar button names (TaskNew, Edit, Delete, EffortStart, etc.) and not the
+full set of 48+ UICommand subclasses.
+
+Duplicate entries (ResetFilter x2, EditToolBarPerspective x3, EffortStop x2)
+appear because those buttons exist on **multiple viewer toolbars** — each
+viewer panel has its own toolbar with its own bindings.
+
+### Debug logging points (removed — documented for reference)
+
+The following `log_step()` probes were inserted to diagnose the CPU usage and
+then removed. Re-add any of them to trace a specific path:
+
+| Probe | File:line | Prefix | What it traces |
+|-------|-----------|--------|----------------|
+| OnMouse same-row | `hypertreelist.py:OnMouse` fast-path | `OnMouse` | Mouse motion within same row (should be majority) |
+| OnMouse new-row | `hypertreelist.py:OnMouse` fast-path | `OnMouse` | Mouse crossing to a new row (triggers HitTest) |
+| OnMouse fallthrough | `hypertreelist.py:OnMouse` after fast-path | `OnMouse` | Non-motion events (clicks, drag) entering full handler |
+| Tooltip motion | `tooltip.py:__OnMotion` | `TOOLTIP` | Timer stop/restart on every mouse move |
+| UpdateUI poll | `base_uicommand.py:onUpdateUI` | `UpdateUI` | Each toolbar button's enabled() poll |
+| Taskbar idle | `taskbaricon.py:onIdle` | `EVT_IDLE` | Tray icon tooltip/icon string comparison |
+| Power mgmt idle | `powermgt/idle.py:_OnIdle` | `EVT_IDLE` | Idle-time state machine check |
+| Window dims idle | `windowdimensionstracker.py:_on_idle` | `EVT_IDLE` | Window position/size readiness check |
+| Autosaver idle | `autosaver.py:on_idle` | `EVT_IDLE` | Dirty-file save during idle |
+
+### All Repeating Timers
+
+| Timer | File | Interval | Always? | Purpose |
+|-------|------|----------|---------|---------|
+| Signal check | `application.py:801` | 500ms | Yes (Linux/Mac) | SIGINT/SIGTERM handling |
+| Global scheduler | `scheduler.py:88` | 1000ms | Yes | Reminders, effort display |
+| Effort refresher | `refresher.py:146` | 1000ms | Only while tracking | Updates effort time display |
+| Notification center | `notifier_universal.py:294` | 1000ms | While notifications shown | Timeout-based dismissal |
+| Notification anim | `notifier_universal.py:44,91` | 100ms | During fade-in only (~1s) | Fade-in/move animation |
+| Editor time spent | `editor.py:4240` | 1000ms | While editor open + tracking | Time spent display |
+| Editor Mac poll | `editor.py:4457` | 1000ms | macOS only, editor open | Window close detection |
+
+Only the first two (signal check, global scheduler) run at all times. All
+others are conditional and stop when their context ends.
+
+---
+
+## AUI Sash Resize Throttle
+
+AUI's `LIVE_RESIZE` mode calls `Update()` on every mouse move during sash drag, which triggers expensive `DoUpdate` repaints (50-190ms). A throttle wrapper in `frame.py` (`_install_sash_resize_optimization`) limits updates to ~30fps during sash drag (action == 3) to reduce CPU load and flickering.
+
+---
+
 ## Key Files
 
 | File | Purpose |
 |------|---------|
 | `taskcoachlib/gui/viewer/base.py` | Base viewer with `curselection()`, `onSelect()`, `onPresentationChanged()` |
 | `taskcoachlib/gui/status.py` | Status bar with 500ms debounce |
-| `taskcoachlib/widgets/treectrl.py` | Tree widget with selection handling, scroll methods |
+| `taskcoachlib/widgets/treectrl.py` | Tree widget with selection handling, scroll methods, hover tracking |
 | `taskcoachlib/widgets/listctrl.py` | List widget with selection handling |
-| `taskcoachlib/patches/hypertreelist.py` | Patched upstream widget — DO NOT MODIFY (see `CRITICAL_WXPYTHON_PATCH.md`) |
+| `taskcoachlib/widgets/tooltip.py` | Tooltip mixin with deferred data prep |
+| `taskcoachlib/widgets/frame.py` | AUI frame with sash resize throttle |
+| `taskcoachlib/patches/hypertreelist.py` | Patched upstream widget — hover outline, drag highlight |
 

--- a/taskcoachlib/application/application.py
+++ b/taskcoachlib/application/application.py
@@ -417,6 +417,10 @@ class wxApp(wx.App):
         self.reopenCallback()
 
     def OnInit(self):
+        # Throttle UpdateUI processing to every 200ms instead of every idle
+        # cycle.  Without this, wx fires 20+ UpdateUI handlers on EVERY idle
+        # event (including between mouse-move events), causing measurable CPU.
+        wx.UpdateUIEvent.SetUpdateInterval(200)
         if operating_system.isWindows():
             self.Bind(wx.EVT_QUERY_END_SESSION, self.onQueryEndSession)
         return True

--- a/taskcoachlib/config/defaults.py
+++ b/taskcoachlib/config/defaults.py
@@ -504,6 +504,7 @@ defaults = {
         "blinktaskbariconwhentrackingeffort": "True",
         # Theme: 'automatic' (detect from system), 'light', or 'dark'
         "theme": "automatic",
+        "hoverlinewidth": "1",
     },
     "effortdialog": {
         "size": "(-1, -1)",  # Size of the dialogs, calculated by default

--- a/taskcoachlib/domain/effort/composite.py
+++ b/taskcoachlib/domain/effort/composite.py
@@ -57,6 +57,11 @@ class BaseCompositeEffort(base.BaseEffort):  # pylint: disable=W0223
             return duration.round(seconds=rounding, alwaysUp=roundUp)
         return duration
 
+    def timeSpent(self, now=None):
+        """Return the total time spent for this composite (no rounding).
+        Required by BaseEffort.sendDurationChangedMessage()."""
+        return self.totalTimeSpent()
+
     def totalTimeSpent(
         self, recursive=False, rounding=0, roundUp=False, consolidate=False
     ):

--- a/taskcoachlib/gui/dialog/preferences.py
+++ b/taskcoachlib/gui/dialog/preferences.py
@@ -835,7 +835,7 @@ class ThemePage(SettingsPage):
     pageIcon = "nuvola_apps_fsview"
 
     def __init__(self, *args, **kwargs):
-        super().__init__(columns=6, growableColumn=-1, *args, **kwargs)
+        super().__init__(columns=7, growableColumn=6, *args, **kwargs)
 
         # --- Mode Dropdown ---
         is_dark = detect_dark_theme()
@@ -886,12 +886,14 @@ class ThemePage(SettingsPage):
             _("System"),
             _("Dark"),
             "",
+            "",
             flags=[
                 wx.ALL | wx.ALIGN_LEFT,
                 wx.ALL | wx.ALIGN_CENTER,
                 wx.ALL | wx.ALIGN_CENTER,
                 wx.ALL | wx.ALIGN_CENTER,
                 wx.ALL | wx.ALIGN_CENTER,
+                wx.ALL,
                 wx.ALL,
             ],
         )
@@ -935,6 +937,7 @@ class ThemePage(SettingsPage):
                 "",
                 darkPicker,
                 resetBtn,
+                "",
                 flags=[
                     wx.ALL | wx.ALIGN_LEFT | wx.ALIGN_CENTRE_VERTICAL,
                     wx.ALL | wx.ALIGN_CENTER | wx.ALIGN_CENTRE_VERTICAL,
@@ -942,6 +945,7 @@ class ThemePage(SettingsPage):
                     wx.ALL | wx.ALIGN_CENTER | wx.ALIGN_CENTRE_VERTICAL,
                     wx.ALL | wx.ALIGN_CENTER | wx.ALIGN_CENTRE_VERTICAL,
                     wx.ALL | wx.ALIGN_CENTER | wx.ALIGN_CENTRE_VERTICAL,
+                    wx.ALL,
                 ],
             )
 
@@ -1027,6 +1031,7 @@ class ThemePage(SettingsPage):
             self._otherMonthDarkCheck,
             self._otherMonthDarkPanel,
             otherMonthResetBtn,
+            "",
             flags=[
                 wx.ALL | wx.ALIGN_LEFT | wx.ALIGN_CENTRE_VERTICAL,
                 wx.ALL | wx.ALIGN_CENTER | wx.ALIGN_CENTRE_VERTICAL,
@@ -1034,6 +1039,7 @@ class ThemePage(SettingsPage):
                 wx.ALL | wx.ALIGN_CENTER | wx.ALIGN_CENTRE_VERTICAL,
                 wx.ALL | wx.ALIGN_CENTER | wx.ALIGN_CENTRE_VERTICAL,
                 wx.ALL | wx.ALIGN_CENTER | wx.ALIGN_CENTRE_VERTICAL,
+                wx.ALL,
             ],
         )
 
@@ -1065,6 +1071,7 @@ class ThemePage(SettingsPage):
                 "",
                 darkPicker,
                 resetBtn,
+                "",
                 flags=[
                     wx.ALL | wx.ALIGN_LEFT | wx.ALIGN_CENTRE_VERTICAL,
                     wx.ALL | wx.ALIGN_CENTER | wx.ALIGN_CENTRE_VERTICAL,
@@ -1072,6 +1079,7 @@ class ThemePage(SettingsPage):
                     wx.ALL | wx.ALIGN_CENTER | wx.ALIGN_CENTRE_VERTICAL,
                     wx.ALL | wx.ALIGN_CENTER | wx.ALIGN_CENTRE_VERTICAL,
                     wx.ALL | wx.ALIGN_CENTER | wx.ALIGN_CENTRE_VERTICAL,
+                    wx.ALL,
                 ],
             )
 
@@ -1087,12 +1095,14 @@ class ThemePage(SettingsPage):
             "",
             _("Dark"),
             "",
+            "",
             flags=[
                 wx.ALL | wx.ALIGN_LEFT,
                 wx.ALL,
                 wx.ALL | wx.ALIGN_CENTER,
                 wx.ALL,
                 wx.ALL | wx.ALIGN_CENTER,
+                wx.ALL,
                 wx.ALL,
             ],
         )
@@ -1129,6 +1139,7 @@ class ThemePage(SettingsPage):
             "",
             darkSquigglePicker,
             squiggleResetBtn,
+            "",
             flags=[
                 wx.ALL | wx.ALIGN_LEFT | wx.ALIGN_CENTRE_VERTICAL,
                 wx.ALL | wx.ALIGN_CENTER | wx.ALIGN_CENTRE_VERTICAL,
@@ -1136,11 +1147,32 @@ class ThemePage(SettingsPage):
                 wx.ALL | wx.ALIGN_CENTER | wx.ALIGN_CENTRE_VERTICAL,
                 wx.ALL | wx.ALIGN_CENTER | wx.ALIGN_CENTRE_VERTICAL,
                 wx.ALL | wx.ALIGN_CENTER | wx.ALIGN_CENTRE_VERTICAL,
+                wx.ALL,
             ],
         )
 
         self._colorSettings.append(("spellcheck_light", "squiggle_color", lightSquigglePicker))
         self._colorSettings.append(("spellcheck_dark", "squiggle_color", darkSquigglePicker))
+
+        self.addLine()
+
+        # --- Section: Hoverover Highlight ---
+        hoverPanel = wx.Panel(self)
+        hoverSpin = widgets.SpinCtrl(
+            hoverPanel, min=0, max=5, size=(65, -1),
+            value=self.getint("window", "hoverlinewidth"))
+        hoverHint = wx.StaticText(hoverPanel,
+            label=_("Two-tone outline thickness per line in pixels when hovering over a row (0 to disable)"))
+        hoverHint.SetForegroundColour(
+            wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT))
+        sizer = wx.BoxSizer(wx.HORIZONTAL)
+        sizer.Add(hoverSpin, 0, wx.ALIGN_TOP)
+        sizer.Add(hoverHint, 1, wx.ALIGN_TOP | wx.LEFT, 8)
+        hoverPanel.SetSizer(sizer)
+        self.addEntry(_("Hoverover Highlight"), hoverPanel)
+        self._integerSettings.append(("window", "hoverlinewidth", hoverSpin))
+
+
 
         # Detect system theme changes while preferences are open
         self.Bind(wx.EVT_IDLE, self._onIdle)

--- a/taskcoachlib/gui/dialog/toolbar.py
+++ b/taskcoachlib/gui/dialog/toolbar.py
@@ -274,6 +274,8 @@ class _ToolBarEditorInterior(wx.Panel):
             return _("Separator"), -1
         elif isinstance(uiCmd, int):
             return _("Spacer"), -1
+        elif uiCmd.icon_id is None:
+            return uiCmd.getHelpText(), -1
         else:
             return uiCmd.getHelpText(), image_list_cache.get_index(uiCmd.icon_id)
 

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,10 +41,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.2"  # Major.Minor.Milestone
-patch = "0"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.2.0
+patch = "1"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.2.1
 
-release_day = "18"  # Day of the release (1-31)
+release_day = "19"  # Day of the release (1-31)
 release_month = "February"  # Month of the release
 release_year = "2026"  # Year of the release
 

--- a/taskcoachlib/patches/hypertreelist.py
+++ b/taskcoachlib/patches/hypertreelist.py
@@ -2262,6 +2262,10 @@ class TreeListMainWindow(CustomTreeCtrl):
         self._owner = parent
         self._main_column = 0
         self._dragItem = None
+        self._hoverItem = None
+        self._hoverLineWidth = 0
+        self._dragCacheColX0 = 0
+        self._dragCacheColX1 = 0
         self._editCtrl = None  # Track the current in-place edit control
 
         self._imgWidth = self._imgWidth2 = 0
@@ -2940,6 +2944,32 @@ class TreeListMainWindow(CustomTreeCtrl):
         if self._dragItem:
             self.RefreshLine(self._dragItem)
 
+    def SetHoverItem(self, item=None):
+        """Sets the hovered item for outline drawing. Refreshes previous and new."""
+        self._readHoverSetting()
+        prevItem = self._hoverItem
+        self._hoverItem = item
+        if prevItem:
+            self._refreshHoverLine(prevItem)
+        if self._hoverItem:
+            self._refreshHoverLine(self._hoverItem)
+
+    def _readHoverSetting(self):
+        """Re-read hover border width from config (called on each row change)."""
+        if hasattr(self, '_hoverSettingGetter'):
+            self._hoverLineWidth = self._hoverSettingGetter()
+
+    def _refreshHoverLine(self, item):
+        """Like RefreshLine but inflated by pen width so the full outline is erased."""
+        if self._dirty or self._freezeCount:
+            return
+        pad = self._hoverLineWidth + 1  # both lines inside row, small safety
+        x, y = self.CalcScrolledPosition(0, item.GetY())
+        w = self.GetClientSize().x
+        h = self.GetLineHeight(item)
+        rect = wx.Rect(x, y - pad, w, h + 2 * pad)
+        self.Refresh(True, rect)
+
     def SetDropHighlight(self, item=None, column=-1):
         """
         Sets the visual feedback for drag and drop operations.
@@ -3542,7 +3572,23 @@ class TreeListMainWindow(CustomTreeCtrl):
                 dc.DrawLine(0, y_top, total_width, y_top)
                 dc.DrawLine(0, y_top+h, total_width, y_top+h)
 
-
+            # Two-tone hover outline: fgcolor inner + bgcolor outer, each
+            # _hoverLineWidth thick.  Both drawn inside the row rect so
+            # adjacent rows don't overwrite.  W3C WCAG C40 technique.
+            if self._hoverLineWidth > 0 and item == self._hoverItem and item != self._dragItem:
+                row_off = 1 if draw_row_lines else 0
+                hover_w = self._owner.GetHeaderWindow().GetWidth()
+                pw = self._hoverLineWidth
+                outer = wx.Rect(0, item.GetY() + row_off, hover_w - 1, h - row_off)
+                inner = wx.Rect(outer)
+                inner.Deflate(pw, pw)
+                fg = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOWTEXT)
+                bg = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW)
+                dc.SetBrush(wx.TRANSPARENT_BRUSH)
+                dc.SetPen(wx.Pen(bg, pw))
+                dc.DrawRectangle(outer)
+                dc.SetPen(wx.Pen(fg, pw))
+                dc.DrawRectangle(inner)
 
         # restore DC objects
         dc.SetBrush(wx.WHITE_BRUSH)
@@ -3873,6 +3919,25 @@ class TreeListMainWindow(CustomTreeCtrl):
             self._hasFocus = True
             self.SetFocusIgnoringChildren()
 
+        # ── Fast path for pure mouse motion ──────────────────────────
+        if event.Moving() and not self._isDragging:
+            ux, uy = self.CalcUnscrolledPosition(event.GetX(), event.GetY())
+            cur = self._hoverItem
+            if cur is not None:
+                iy = cur.GetY()
+                ih = self.GetLineHeight(cur)
+                if iy <= uy < iy + ih:
+                    return  # Same row — zero work
+            # Row changed — need HitTest
+            flags = 0
+            item, flags, column = self._anchor.HitTest(
+                wx.Point(ux, uy), self, flags, self._curColumn, 0)
+            new_hover = item if item else None
+            if new_hover != self._hoverItem:
+                self.SetHoverItem(new_hover)
+            return
+        # ── End fast path ────────────────────────────────────────────
+
         # determine event
         p = wx.Point(event.GetX(), event.GetY())
         flags = 0
@@ -3942,6 +4007,14 @@ class TreeListMainWindow(CustomTreeCtrl):
                     # Don't highlight target items if dragging full-screen.
                     return
 
+                # Row+column bounds cache: skip HitTest if still on same cell
+                if self._dropTarget is not None:
+                    dty = self._dropTarget.GetY()
+                    dth = self.GetLineHeight(self._dropTarget)
+                    if (dty <= pt.y < dty + dth and
+                            self._dragCacheColX0 <= pt.x < self._dragCacheColX1):
+                        return  # Same cell — dragImage already moved
+
                 # Check if mouse is outside client area - don't highlight items
                 w, h = self.GetSize()
                 mouseOutside = p.x < 0 or p.x > w or p.y < 0 or p.y > h
@@ -3967,6 +4040,17 @@ class TreeListMainWindow(CustomTreeCtrl):
                         self.RefreshLine(item)
                         self._countDrag = self._countDrag + 1
                     self._dropTarget = item
+
+                    # Cache column X bounds for same-cell short-circuit
+                    if column >= 0:
+                        header = self._owner.GetHeaderWindow()
+                        x0 = sum(header.GetColumnWidth(c) for c in range(column))
+                        x1 = x0 + header.GetColumnWidth(column)
+                        self._dragCacheColX0 = x0
+                        self._dragCacheColX1 = x1
+                    else:
+                        self._dragCacheColX0 = 0
+                        self._dragCacheColX1 = 0
 
                     self.Update()
 

--- a/taskcoachlib/widgets/frame.py
+++ b/taskcoachlib/widgets/frame.py
@@ -71,9 +71,8 @@ class AuiManagedFrameWithDynamicCenterPane(wx.Frame):
 
         self.manager = aui.AuiManager(self, agwStyle)
 
-        # Install optimization for sash resize to reduce flickering
-        # TEMPORARILY DISABLED for testing - uncomment to re-enable
-        # _install_sash_resize_optimization(self.manager)
+        # Throttle AUI sash resize updates to ~30fps to reduce flickering
+        _install_sash_resize_optimization(self.manager)
 
         self.manager.SetAutoNotebookStyle(
             aui.AUI_NB_TOP

--- a/taskcoachlib/widgets/listctrl.py
+++ b/taskcoachlib/widgets/listctrl.py
@@ -52,6 +52,9 @@ class VirtualListCtrl(
         # Override GetEffectiveMinSize() which returns BestSize - allows sizer to shrink widget
         self.SetMinSize((100, 50))
         self.__parent = parent
+        self._hover_row = -1
+        self._hoverLineWidth = 0
+        self._syncHoverSettings()
         self.bindEventHandlers(selectCommand, editCommand)
 
     def bindEventHandlers(self, selectCommand, editCommand):
@@ -65,12 +68,74 @@ class VirtualListCtrl(
             self.editCommand = editCommand
             self.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.onItemActivated)
         self.Bind(wx.EVT_SET_FOCUS, self.onSetFocus)
+        self.Bind(wx.EVT_MOTION, self._onHoverMotion)
+        self.Bind(wx.EVT_LEAVE_WINDOW, self._onHoverLeave)
+        self.Bind(wx.EVT_PAINT, self._onPaintHover)
 
     def onSetFocus(self, event):  # pylint: disable=W0613
         # Send a child focus event to let the AuiManager know we received focus
         # so it will activate our pane
         wx.PostEvent(self, wx.ChildFocusEvent(self))
         event.Skip()
+
+    def _syncHoverSettings(self):
+        """Read hover settings from config into local cache."""
+        self._hoverLineWidth = self.__parent.settings.getint("window", "hoverlinewidth")
+
+    def _refreshHoverRow(self, row):
+        """Refresh a row with padding to cover pen bleed from hover outline."""
+        try:
+            rect = self.GetItemRect(row)
+        except Exception:
+            return
+        pad = self._hoverLineWidth + 1  # both lines inside row, small safety
+        rect.Inflate(pad, pad)
+        self.RefreshRect(rect)
+
+    def _onHoverMotion(self, event):
+        row, flags = super().HitTest(event.GetPosition())
+        if row != self._hover_row:
+            self._syncHoverSettings()
+            old = self._hover_row
+            self._hover_row = row
+            if self._hoverLineWidth:
+                if old >= 0:
+                    self._refreshHoverRow(old)
+                if row >= 0:
+                    self._refreshHoverRow(row)
+                wx.CallAfter(self._drawHoverOutline)
+        event.Skip()
+
+    def _onHoverLeave(self, event):
+        if self._hover_row >= 0:
+            old = self._hover_row
+            self._hover_row = -1
+            self._refreshHoverRow(old)
+        event.Skip()
+
+    def _drawHoverOutline(self):
+        """Two-tone hover outline: fgcolor inner + bgcolor outer."""
+        if self._hover_row < 0 or not self._hoverLineWidth:
+            return
+        try:
+            outer = self.GetItemRect(self._hover_row)
+        except Exception:
+            return
+        pw = self._hoverLineWidth
+        inner = wx.Rect(outer)
+        inner.Deflate(pw, pw)
+        fg = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOWTEXT)
+        bg = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW)
+        dc = wx.ClientDC(self)
+        dc.SetBrush(wx.TRANSPARENT_BRUSH)
+        dc.SetPen(wx.Pen(bg, pw))
+        dc.DrawRectangle(outer)
+        dc.SetPen(wx.Pen(fg, pw))
+        dc.DrawRectangle(inner)
+
+    def _onPaintHover(self, event):
+        event.Skip()
+        wx.CallAfter(self._drawHoverOutline)
 
     def GetMainWindow(self):
         # Override to return self for drop target support.
@@ -139,6 +204,7 @@ class VirtualListCtrl(
                 background_color = wx.SystemSettings.GetColour(
                     wx.SYS_COLOUR_LISTBOX
                 )
+
         item_attribute_arguments = [foreground_color, background_color]
         font = item.font(recursive=True)
         if font is None:
@@ -178,6 +244,7 @@ class VirtualListCtrl(
         self.editCommand(event)
 
     def RefreshAllItems(self, count):
+        self._syncHoverSettings()
         self.SetItemCount(count)
         if count == 0:
             self.DeleteAllItems()

--- a/taskcoachlib/widgets/tooltip.py
+++ b/taskcoachlib/widgets/tooltip.py
@@ -34,6 +34,7 @@ class ToolTipMixin(object):
 
         self.__tip = None
         self.__position = (0, 0)
+        self.__pending_xy = (0, 0)
         self.__text = None
         self.__frozen = True
 
@@ -105,12 +106,9 @@ class ToolTipMixin(object):
             self.__tip = None
 
         if self.__enabled:
-            newTip = self.OnBeforeShowToolTip(x, y)
-            if newTip is not None:
-                self.__tip = newTip
-                self.__tip.Bind(wx.EVT_MOTION, self.__OnTipMotion)
-                self.__position = (x + 20, y + 10)
-                self.__timer.Start(200, True)
+            self.__position = (x + 20, y + 10)
+            self.__pending_xy = (x, y)
+            self.__timer.Start(200, True)
 
         event.Skip()
 
@@ -139,7 +137,12 @@ class ToolTipMixin(object):
             self.__timer.Stop()
 
     def __OnTimer(self, event):  # pylint: disable=W0613
-        self.ShowTip(*self.GetMainWindow().ClientToScreen(*self.__position))
+        x, y = self.__pending_xy
+        newTip = self.OnBeforeShowToolTip(x, y)
+        if newTip is not None:
+            self.__tip = newTip
+            self.__tip.Bind(wx.EVT_MOTION, self.__OnTipMotion)
+            self.ShowTip(*self.GetMainWindow().ClientToScreen(*self.__position))
 
 
 if operating_system.isWindows():

--- a/taskcoachlib/widgets/treectrl.py
+++ b/taskcoachlib/widgets/treectrl.py
@@ -231,6 +231,8 @@ class TreeListCtrl(
             **kwargs
         )
         self.bindEventHandlers(selectCommand, editCommand, dragAndDropCommand)
+        self.GetMainWindow().Bind(wx.EVT_LEAVE_WINDOW, self._onHoverLeave)
+        self._syncHoverSettings()
 
     def bindEventHandlers(
         self, selectCommand, editCommand, dragAndDropCommand
@@ -256,6 +258,18 @@ class TreeListCtrl(
         wx.PostEvent(self, wx.ChildFocusEvent(self))
         event.Skip()
 
+    def _syncHoverSettings(self):
+        """Read hover settings from config and push to main window."""
+        mw = self.GetMainWindow()
+        mw._hoverLineWidth = self.__adapter.settings.getint("window", "hoverlinewidth")
+        # Store getter so OnMouse fast-path can re-read on row change
+        if not hasattr(mw, '_hoverSettingGetter'):
+            mw._hoverSettingGetter = lambda: self.__adapter.settings.getint("window", "hoverlinewidth")
+
+    def _onHoverLeave(self, event):
+        self.GetMainWindow().SetHoverItem(None)
+        event.Skip()
+
     def getItemTooltipData(self, item):
         return self.__adapter.getItemTooltipData(item)
 
@@ -277,6 +291,7 @@ class TreeListCtrl(
             return []
 
     def RefreshAllItems(self, count=0):  # pylint: disable=W0613
+        self._syncHoverSettings()
         self.Freeze()
         self.StopEditing()
         self.__refreshing = True  # Suppress selection events during rebuild


### PR DESCRIPTION
- Two-tone (fg/bg) row hover outline on all tree/list views (W3C WCAG C40)
- Configurable via Preferences > Theme > Hoverover Highlight (default 1, 0 to disable)
- Defer tooltip data extraction from every mouse-move to 200ms timer callback
- OnMouse fast-path: row-bounds cache skips HitTest on same-row motion
- Drag fast-path: row+column bounds cache skips HitTest on same-cell drag
- Remove redundant _onHoverMotion (was duplicate HitTest per pixel)
- Throttle UpdateUI polling to 200ms via SetUpdateInterval
- Migrate all legacy icons to themed structure, refactor icon system
- Fix broken icon in toolbar editor for controls without icons (search, tree/list dropdown)
- Fix AttributeError crash on drag-drop when effort viewer grouped by date is open
- Update LIST_MANAGEMENT.md with hover, mouse-move, Vampire CPU docs, and TODOs
- Bump version to 2.0.2.1

Drag & Drop a task and its subtree into a task doesn't create a subtrees of the target task #383