### PR TITLE
Fix editor segfaults, PEP 8 renames, icon cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.3-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.3-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.3_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.3_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.3_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.3-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.4-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.4-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.4_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.4_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.4_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.4-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.3-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.3-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.3_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.3_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.2.3-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.2.3-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.4-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.4-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.4_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.4_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.2.4-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.2.4-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.3_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.2.3_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.4_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.2.4_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.3-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.2.3-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.4-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.2.4-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.3-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.2.3-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.4-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.2.4-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.3-x86_64.AppImage
-chmod +x TaskCoach-2.0.2.3-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.4-x86_64.AppImage
+chmod +x TaskCoach-2.0.2.4-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.2.3-x86_64.AppImage
+./TaskCoach-2.0.2.4-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/README_INSTALL_MACOS.md
+++ b/README_INSTALL_MACOS.md
@@ -1,25 +1,35 @@
 # Installing Task Coach on macOS
 
-## Download
+## Table of Contents
+
+- [Download](#download)
+- [Installation](#installation)
+- [Security Warning](#security-warning)
+- [Launching Task Coach](#launching-task-coach)
+- [Uninstalling](#uninstalling)
+- [Troubleshooting](#troubleshooting)
+- [Why the Security Warning?](#why-the-security-warning)
+
+## <a id="download"></a>Download
 
 Download the DMG for your Mac from the [latest release](https://github.com/taskcoach/taskcoach/releases):
 
 - **Apple Silicon** (M1/M2/M3/M4): `TaskCoach-<version>-macos-arm64.dmg`
 - **Intel**: `TaskCoach-<version>-macos-intel.dmg`
 
-Where `<version>` is the release version (e.g., `2.0.2.2`).
+Where `<version>` is the release version (e.g., `2.0.2.4`).
 
 Not sure which Mac you have? Click the Apple menu → "About This Mac". Look for "Chip" (Apple Silicon) or "Processor" (Intel).
 
-## Installation
+## <a id="installation"></a>Installation
 
 1. Open the downloaded `.dmg` file
 2. Drag "Task Coach" to the "Applications" folder
 3. Eject the DMG (drag to trash or right-click → Eject)
 
-## Security Warning
+## <a id="security-warning"></a>Security Warning
 
-On first launch, macOS will block the app because it's not notarized by Apple. This is normal for open-source software - Apple charges $99/year for a developer account required for notarization.
+On first launch, macOS will block the app because it's not notarized by Apple. This is normal for open-source software - Apple charges $99/year for a developer account required for notarization. See [Why the Security Warning?](#why-the-security-warning) for details.
 
 ### Video Walkthrough
 
@@ -51,7 +61,7 @@ Click **Open** to launch Task Coach.
 
 After this one-time approval, Task Coach will open normally in the future.
 
-## Launching Task Coach
+## <a id="launching-task-coach"></a>Launching Task Coach
 
 After the initial setup, launch Task Coach from:
 
@@ -60,7 +70,7 @@ After the initial setup, launch Task Coach from:
 - Spotlight (Cmd+Space, type "Task Coach")
 - Dock (if you added it)
 
-## Uninstalling
+## <a id="uninstalling"></a>Uninstalling
 
 To uninstall Task Coach:
 
@@ -71,7 +81,7 @@ To uninstall Task Coach:
 
 Your task files (`.tsk`) are stored separately and won't be deleted.
 
-## Troubleshooting
+## <a id="troubleshooting"></a>Troubleshooting
 
 ### "Task Coach is damaged and can't be opened"
 
@@ -95,7 +105,7 @@ Try these steps:
 
 If you accidentally installed the Intel version on an Apple Silicon Mac, it may work via Rosetta 2, but you'll get better performance with the native arm64 version. Download the correct DMG and reinstall.
 
-## Why the Security Warning?
+## <a id="why-the-security-warning"></a>Why the Security Warning?
 
 Task Coach is open-source software that isn't notarized with Apple. Notarization requires:
 

--- a/README_INSTALL_WINDOWS.md
+++ b/README_INSTALL_WINDOWS.md
@@ -1,17 +1,29 @@
 # Installing Task Coach on Windows
 
-## Download
+## Table of Contents
+
+- [Download](#download)
+- [Security Warning](#security-warning)
+- [Installation](#installation)
+- [Portable Version](#portable-version)
+- [Launching Task Coach](#launching-task-coach)
+- [Troubleshooting Logging](#troubleshooting-logging)
+- [Uninstalling](#uninstalling)
+- [Troubleshooting](#troubleshooting)
+- [Why the Security Warning?](#why-the-security-warning)
+
+## <a id="download"></a>Download
 
 Download the installer from the [latest release](https://github.com/taskcoach/taskcoach/releases):
 
 - **Installer**: `TaskCoach-<version>-windows-x64-setup.exe` - Standard installation
 - **Portable**: `TaskCoach-<version>-windows-x64-portable.zip` - No installation required
 
-Where `<version>` is the release version (e.g., `2.0.2.2`).
+Where `<version>` is the release version (e.g., `2.0.2.4`).
 
-## Security Warning
+## <a id="security-warning"></a>Security Warning
 
-When you run the installer, Windows SmartScreen will show a security warning because the app is not signed with a Microsoft certificate. This is normal for open-source software that doesn't pay for code signing.
+When you run the installer, Windows SmartScreen will show a security warning because the app is not signed with a Microsoft certificate. This is normal for open-source software that doesn't pay for code signing. See [Why the Security Warning?](#why-the-security-warning) for details.
 
 ### Video Walkthrough
 
@@ -29,16 +41,16 @@ Windows shows "Windows protected your PC" with only a "Don't run" button visible
 
 After clicking "More info", Windows shows the app name and publisher, and reveals the "Run anyway" button. Click it to proceed with installation.
 
-## Installation
+## <a id="installation"></a>Installation
 
 After accepting the security warning, follow the installer prompts:
 
-1. Choose installation directory (default: `C:\Program Files\TaskCoach`)
+1. Choose installation directory (default: `%LOCALAPPDATA%\Programs\Task Coach`)
 2. Choose Start Menu folder
 3. Optionally create a desktop shortcut
 4. Click Install
 
-## Portable Version
+## <a id="portable-version"></a>Portable Version
 
 For the portable version:
 
@@ -46,7 +58,7 @@ For the portable version:
 2. Run `TaskCoach.bat` from the extracted folder (or `TaskCoach.vbs` for silent launch without a console window)
 3. Your data is stored in the same folder, making it easy to move between computers
 
-## Launching Task Coach
+## <a id="launching-task-coach"></a>Launching Task Coach
 
 After installation, launch Task Coach from:
 
@@ -54,7 +66,27 @@ After installation, launch Task Coach from:
 - Desktop shortcut (if created)
 - Search for "Task Coach" in the Start Menu
 
-## Uninstalling
+## <a id="troubleshooting-logging"></a>Troubleshooting Logging
+
+Task Coach normally launches without a console window, so diagnostic output is not visible. To see application output, open a Command Prompt and run `TaskCoach.bat`, which keeps the console window open showing all messages, warnings, and errors.
+
+### Installed version
+
+```cmd
+cd "%LOCALAPPDATA%\Programs\Task Coach"
+TaskCoach.bat
+```
+
+### Portable version
+
+```cmd
+cd "%USERPROFILE%\Downloads\TaskCoach"
+TaskCoach.bat
+```
+
+Replace the path with wherever you extracted the portable zip.
+
+## <a id="uninstalling"></a>Uninstalling
 
 To uninstall Task Coach:
 
@@ -64,7 +96,7 @@ To uninstall Task Coach:
 
 Or use the uninstaller in Start Menu → Task Coach → Uninstall.
 
-## Troubleshooting
+## <a id="troubleshooting"></a>Troubleshooting
 
 ### "Windows protected your PC" won't go away
 
@@ -83,7 +115,7 @@ Some antivirus software may flag the installer. This is a false positive common 
 2. Add an exception for the Task Coach installer
 3. Download again if your antivirus quarantined the file
 
-## Why the Security Warning?
+## <a id="why-the-security-warning"></a>Why the Security Warning?
 
 Task Coach is open-source software distributed without a paid code signing certificate. Microsoft charges hundreds of dollars per year for Extended Validation (EV) certificates, which is impractical for volunteer-maintained projects.
 
@@ -91,4 +123,4 @@ If you want to verify your download:
 
 - **Check the SHA256 hash** - Compare the hash on the [release page](https://github.com/taskcoach/taskcoach/releases) with your downloaded file using `certutil -hashfile <filename> SHA256`
 - **Review the source code** - The complete source is available on [GitHub](https://github.com/taskcoach/taskcoach)
-- **Scan the file** - Upload to [VirusTotal](https://www.virustotal.com) or use your antivirus software
+- **Scan the file** - Use your favorite antivirus software to scan the downloaded file

--- a/docs/ATTRIBUTE_PATTERN.md
+++ b/docs/ATTRIBUTE_PATTERN.md
@@ -50,6 +50,14 @@ The domain model's change-detection and event-notification pattern.
    [Case Study: Tree Mode Toggle](#case-study-tree-mode-toggle)).
    **Remaining:** Task dates, percentage, duration; Effort fields.
 
+3. **Modularize and clean up the signaling system.** The three independent
+   cleanup mechanisms (wx C++ destruction, `removeInstance()`, Python GC)
+   don't coordinate, causing zombie callbacks and 20+ silent `try/except`
+   guards. Target: a single automatic cleanup mechanism where destroying
+   an object removes all its subscriptions. See
+   [TODO.md #12 — Signaling System Cleanup](TODO.md#12-signaling-system-cleanup)
+   for the full plan and current band-aids.
+
 ---
 
 ## Signal Dispatch

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15,6 +15,7 @@ This document tracks planned improvements and known issues to address in future 
 9. [Preferences Page Alignment Overrides](#9-preferences-page-alignment-overrides) *(Done)*
 10. [Preferences Dialog: Dirty-Check and Button State](#10-preferences-dialog-dirty-check-and-button-state)
 11. [EVT_TEXT Compatibility Shim in MultiLineTextCtrl](#11-evt_text-compatibility-shim-in-multilinetextctrl)
+12. [Signaling System Cleanup](#12-signaling-system-cleanup)
 
 ---
 
@@ -411,6 +412,75 @@ No need to store "original values" — the settings object is the baseline.
 ## 11. EVT_TEXT Compatibility Shim in MultiLineTextCtrl
 
 `MultiLineTextCtrl` (StyledTextCtrl/Scintilla) overrides `Bind()` to remap `wx.EVT_TEXT` to `stc.EVT_STC_CHANGE` for compatibility with code written for `wx.TextCtrl`. If we keep Scintilla long-term, refactor all callers to use `EVT_STC_CHANGE` directly and remove the shim. File: `taskcoachlib/widgets/textctrl.py`.
+
+---
+
+## 12. Signaling System Cleanup
+
+### Problem
+
+The signaling/event system is fragmented across three independent mechanisms
+that don't coordinate lifecycle cleanup:
+
+1. **wx C++ destruction** — `Destroy()` frees the C++ widget tree. Python
+   wrappers become zombies (accessing them segfaults).
+2. **patterns.Observer.removeInstance()** — Removes pubsub + Publisher
+   subscriptions for a Python object. Must be called explicitly.
+3. **Python garbage collection** — Frees Python objects when refcount hits
+   zero. Triggers `__del__`.
+
+None of these know about each other. When wx destroys a widget, it doesn't
+call `removeInstance()`. When `removeInstance()` runs, it doesn't know if
+the wx widget is already dead. The result is 20+ `try/except RuntimeError:
+pass` guards scattered across the codebase — band-aids over missing lifecycle
+coordination.
+
+### Goal
+
+A single, automatic cleanup mechanism: when an object goes away, all its
+subscriptions (pubsub, Publisher, wx events) are automatically removed.
+No manual unsubscribe, no silent `except` guards, no zombie callbacks.
+
+### Current band-aids (February 2026)
+
+- `UICommand` was changed to inherit from `patterns.Observer` so
+  `removeInstance()` cleans up all subscription types automatically.
+- `toolbar.Clear()` and `menu.clearMenu()` call `removeInstance()` during
+  teardown.
+- `Editor.on_close_editor()` explicitly cleans up its UICommands.
+- 20+ `try/except RuntimeError: pass` blocks now log with `prefix="DEAD-OBJ"`
+  so zombie access is visible. These should eventually be eliminated, not
+  just logged.
+
+### Target architecture
+
+1. **Unify on one signal system.** Migrate all pypubsub usage to Publisher
+   signaling (per-instance dispatch). Then migrate Publisher to a modern
+   signal library (Blinker or psygnal) with true per-instance signals.
+   See [ATTRIBUTE_PATTERN.md — Signal Dispatch](ATTRIBUTE_PATTERN.md#signal-dispatch)
+   for the migration plan.
+
+2. **Automatic cleanup via EVT_WINDOW_DESTROY.** Hook into wx's
+   `EVT_WINDOW_DESTROY` event to call `removeInstance()` automatically when
+   a window is destroyed. This eliminates the need for manual cleanup in
+   every close handler.
+
+3. **Remove all DEAD-OBJ guards.** Once cleanup is automatic, the
+   `try/except RuntimeError` guards become dead code. Remove them.
+
+### Files involved
+
+| Area | Key files |
+|------|-----------|
+| Observer/Publisher | `taskcoachlib/patterns/observer.py` |
+| UICommand lifecycle | `taskcoachlib/gui/uicommand/base_uicommand.py` |
+| Toolbar cleanup | `taskcoachlib/gui/toolbar.py` |
+| Menu cleanup | `taskcoachlib/gui/menu.py` |
+| Editor cleanup | `taskcoachlib/gui/dialog/editor.py` |
+| Viewer cleanup | `taskcoachlib/gui/viewer/base.py` |
+| Signal dispatch design | `docs/ATTRIBUTE_PATTERN.md` |
+
+**Status:** Planned — incremental. Band-aids in place, root cause understood.
 
 ---
 

--- a/launcher.pyw
+++ b/launcher.pyw
@@ -25,6 +25,34 @@ if sys.stderr is None:
 if sys.stdout is None:
     sys.stdout = open(os.devnull, 'w')
 
+# Save a duplicate of stderr's file descriptor before anything can lose it.
+# When Python hits RecursionError the stack is exhausted and even resolving
+# sys.stderr requires a Python frame, so the default excepthook prints
+# "lost sys.stderr" instead of the traceback.  Writing to the saved fd via
+# os.write() is a C-level call that needs no extra stack frames.
+_stderr_fd = os.dup(sys.stderr.fileno()) if sys.stderr and hasattr(sys.stderr, 'fileno') else None
+
+def _robust_excepthook(exc_type, exc_value, exc_tb):
+    """Write tracebacks to the saved stderr fd so they survive stack exhaustion."""
+    try:
+        lines = traceback.format_exception(exc_type, exc_value, exc_tb)
+        text = "".join(lines)
+    except Exception:
+        text = f"{exc_type.__name__}: {exc_value}\n"
+    if _stderr_fd is not None:
+        try:
+            os.write(_stderr_fd, text.encode("utf-8", errors="replace"))
+            return
+        except OSError:
+            pass
+    # Last resort: try sys.stderr normally
+    try:
+        sys.stderr.write(text)
+    except Exception:
+        pass
+
+sys.excepthook = _robust_excepthook
+
 def get_log_path():
     """Get path for startup log file."""
     log_dir = os.environ.get('LOCALAPPDATA', os.environ.get('TEMP', '.'))

--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -1099,19 +1099,22 @@ class DatesPage(ScrolledPage):
             try:
                 pub.unsubscribe(self._onStatusMayHaveChanged,
                                 self.items[0].statusChangedEventType())
-            except Exception:
-                pass
+            except Exception as e:
+                log_step("unsubscribe failed in %s.close: %s" %
+                         (self.__class__.__name__, e), prefix="DEAD-OBJ")
         if len(self.items) == 1:
             try:
                 pub.unsubscribe(self._onDomainPlannedDurationModeChanged,
                                 self.items[0].plannedDurationModeChangedEventType())
-            except Exception:
-                pass
+            except Exception as e:
+                log_step("unsubscribe failed in %s.close: %s" %
+                         (self.__class__.__name__, e), prefix="DEAD-OBJ")
             try:
                 pub.unsubscribe(self.__onTaskDurationDomainChanged,
                                 self.items[0].plannedDurationChangedEventType())
-            except Exception:
-                pass
+            except Exception as e:
+                log_step("unsubscribe failed in %s.close: %s" %
+                         (self.__class__.__name__, e), prefix="DEAD-OBJ")
         super().close()
 
     def __onPlannedStartChanged(self, value):
@@ -1957,8 +1960,9 @@ class DatesPage(ScrolledPage):
         # Unsubscribe from pubsub topics
         try:
             pub.unsubscribe(self.__onPresetsConfigChanged, "settings.feature.task_duration_presets")
-        except Exception:
-            pass
+        except Exception as e:
+            log_step("unsubscribe failed in %s.close: %s" %
+                     (self.__class__.__name__, e), prefix="DEAD-OBJ")
         super().close()
 
 
@@ -2737,7 +2741,8 @@ class PathPage(ScrolledPage):
                 if self._pathPanel.IsShownOnScreen():
                     wx.CallAfter(self._rebuildPathDisplay)
             except RuntimeError:
-                pass  # Window destroyed
+                log_step("_onAnyChange: pathPanel dead %x" % id(self),
+                         prefix="DEAD-OBJ")
 
     def _rebuildPathDisplay(self):
         """Rebuild the path display with all sections."""
@@ -2746,6 +2751,8 @@ class PathPage(ScrolledPage):
         try:
             self._pathPanel.GetName()  # Check if still valid
         except RuntimeError:
+            log_step("_rebuildPathDisplay: pathPanel dead %x" % id(self),
+                     prefix="DEAD-OBJ")
             return
 
         # Unsubscribe existing icon handlers before clearing
@@ -2947,7 +2954,8 @@ class PathPage(ScrolledPage):
                             bitmap.SetBitmap(new_bitmap)
                             bitmap.Refresh()
                 except RuntimeError:
-                    pass  # Widget destroyed
+                    log_step("_onEffectiveIconChanged: icon widget dead %x" %
+                             id(self), prefix="DEAD-OBJ")
 
     def _unsubscribeIconUpdates(self):
         """Clear icon widget tracking (subscription cleaned up on page close)."""
@@ -2994,8 +3002,9 @@ class PathPage(ScrolledPage):
                 if eventType.startswith("pubsub"):
                     try:
                         pub.unsubscribe(self._onAnyChange, eventType)
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        log_step("unsubscribe failed in %s.close: %s" %
+                                 (self.__class__.__name__, e), prefix="DEAD-OBJ")
             patterns.Publisher().removeObserver(self._onAnyChange)
         super().close()
 
@@ -3521,7 +3530,9 @@ class NullableDateTimeWrapper:
                 return None
             return self._datetime_entry.GetValue()
         except RuntimeError:
-            return None  # Widget already deleted (dialog closed)
+            log_step("DateTimeEntry.GetValue: widget dead %x" % id(self),
+                     prefix="DEAD-OBJ")
+            return None
 
     def SetValue(self, value):
         """Set value - None unchecks checkbox, otherwise sets datetime."""
@@ -3534,7 +3545,8 @@ class NullableDateTimeWrapper:
                 self._datetime_entry.Enable(True)
                 self._datetime_entry.SetValue(value)
         except RuntimeError:
-            pass  # Widget already deleted (dialog closed)
+            log_step("DateTimeEntry.SetValue: widget dead %x" % id(self),
+                     prefix="DEAD-OBJ")
 
     def Bind(self, event_type, handler, source=None, id=wx.ID_ANY, id2=wx.ID_ANY):
         """Forward bind to datetime entry."""
@@ -4384,19 +4396,22 @@ class EffortEditBook(Page):
         """Cleanup method called when dialog closes."""
         try:
             pub.unsubscribe(self.__onEffortPresetsConfigChanged, "settings.feature.effort_duration_presets")
-        except Exception:
-            pass
+        except Exception as e:
+            log_step("unsubscribe failed in %s.close_edit_book: %s" %
+                     (self.__class__.__name__, e), prefix="DEAD-OBJ")
         if len(self.items) == 1:
             try:
                 pub.unsubscribe(self.__onEffortDurationDomainChanged,
                                 self.items[0].durationChangedEventType())
-            except Exception:
-                pass
+            except Exception as e:
+                log_step("unsubscribe failed in %s.close_edit_book: %s" %
+                         (self.__class__.__name__, e), prefix="DEAD-OBJ")
             try:
                 pub.unsubscribe(self._onDomainEntryModeChanged,
                                 self.items[0].entryModeChangedEventType())
-            except Exception:
-                pass
+            except Exception as e:
+                log_step("unsubscribe failed in %s.close_edit_book: %s" %
+                         (self.__class__.__name__, e), prefix="DEAD-OBJ")
         # Stop the time spent timer
         self.__stopTimeSpentTimer()
 
@@ -4529,8 +4544,10 @@ class Editor(BalloonTipManager, widgets.Dialog):
         )
 
     def on_close_editor(self, event):
-        event.Skip()
-        # Save dialog position/size before closing
+        # DO NOT call event.Skip() — we call Destroy() explicitly below.
+        # Calling both is an anti-pattern: the default EVT_CLOSE handler
+        # would run after Destroy(), accessing the dead dialog.
+        self.Unbind(wx.EVT_CLOSE)
         self.__dimensions_tracker.save()
         self._interior.close_edit_book()
         patterns.Publisher().removeObserver(self.on_item_removed)
@@ -4542,10 +4559,43 @@ class Editor(BalloonTipManager, widgets.Dialog):
         if self.__timer is not None:
             self.__timer.Stop()
             IdProvider.put(self.__timer.GetId())
+        # Clean up UICommands created in __create_ui_commands()
+        self.__undo_command.unbind(self._interior, wx.ID_UNDO)
+        self.__undo_command.removeInstance()
+        self.__redo_command.unbind(self._interior, wx.ID_REDO)
+        self.__redo_command.removeInstance()
+        self.__new_effort_command.unbind(
+            self._interior, self.__new_effort_id)
+        self.__new_effort_command.removeInstance()
         IdProvider.put(self.__new_effort_id)
         IdProvider.put(self.__next_tab_id)
         IdProvider.put(self.__prev_tab_id)
-        self.Destroy()
+        # Close any child Editor dialogs BEFORE Destroy(). Without
+        # this, Destroy() cascades to children without sending
+        # EVT_CLOSE, so their on_close_editor never runs — leaving
+        # dangling observers, UICommands, and pubsub subscriptions
+        # that cause C++ segfaults.
+        for child in list(self.GetChildren()):
+            if isinstance(child, Editor) and child is not self:
+                child.Close()
+        # Hide first to stop GTK rendering, then destroy on next
+        # idle cycle. Direct Destroy() crashes in C++ deferred
+        # destruction with GTK popup widgets (PopupTransientWindow,
+        # GTKPopupFrame). Separating hide from destroy lets pending
+        # GTK events settle. Same pattern as PYTHON3_MIGRATION_1.md.
+        self.Hide()
+        wx.CallAfter(self._deferred_destroy)
+
+    def _deferred_destroy(self):
+        """Destroy the editor after one event loop iteration.
+        Called via wx.CallAfter from on_close_editor to let GTK
+        process pending events before C++ widget destruction."""
+        try:
+            if self:
+                self.Destroy()
+        except RuntimeError:
+            log_step("_deferred_destroy: already dead %x" % (
+                id(self)), prefix="DEAD-OBJ")
 
     def on_activate(self, event):
         event.Skip()
@@ -4565,9 +4615,12 @@ class Editor(BalloonTipManager, widgets.Dialog):
         # callback executes after window destruction (e.g., closing nested dialogs)
         try:
             if not self or self.IsBeingDeleted():
+                log_step("__close_if_item_is_deleted: dialog already dead/deleting %x" %
+                         id(self), prefix="DEAD-OBJ")
                 return
         except RuntimeError:
-            # wrapped C/C++ object has been deleted
+            log_step("__close_if_item_is_deleted: C++ object deleted %x" %
+                     id(self), prefix="DEAD-OBJ")
             return
         for item in items:
             if (

--- a/taskcoachlib/gui/menu.py
+++ b/taskcoachlib/gui/menu.py
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from taskcoachlib import operating_system
 from taskcoachlib import patterns, persistence, help  # pylint: disable=W0622
+from taskcoachlib.meta.debug import log_step
 from taskcoachlib.domain import task, note, base, category
 from taskcoachlib.i18n import _
 from pubsub import pub
@@ -131,7 +132,7 @@ class DynamicMenu(Menu):
         try:  # Prepare for menu or window to be destroyed
             self.updateMenu()
         except RuntimeError:
-            pass
+            log_step("onUpdateMenu: menu/window dead", prefix="DEAD-OBJ")
 
     def onUpdateMenu_Deprecated(self, event=None):
         """This event handler should be called at the right times so that
@@ -148,7 +149,8 @@ class DynamicMenu(Menu):
         try:  # Prepare for menu or window to be destroyed
             self.updateMenu()
         except RuntimeError:
-            pass  # Menu or window may be destroyed
+            log_step("onUpdateMenu_Deprecated: menu/window dead",
+                     prefix="DEAD-OBJ")
 
     def updateMenu(self):
         """Updating the menu consists of two steps: updating the menu item
@@ -812,7 +814,7 @@ class ActionMenu(Menu):
             viewer=viewerContainer
         ).add_to_menu(
             self, self._window,
-            subMenu=TaskPriorityMenu(mainwindow, tasks, viewerContainer),
+            sub_menu=TaskPriorityMenu(mainwindow, tasks, viewerContainer),
         )
         self.appendUICommands(
             None,
@@ -1063,7 +1065,7 @@ class TaskPopupMenu(Menu):
             viewer=taskViewer
         ).add_to_menu(
             self, self._window,
-            subMenu=TaskPriorityMenu(mainwindow, tasks, taskViewer),
+            sub_menu=TaskPriorityMenu(mainwindow, tasks, taskViewer),
         )
         self.appendUICommands(
             None,

--- a/taskcoachlib/gui/toolbar.py
+++ b/taskcoachlib/gui/toolbar.py
@@ -114,6 +114,7 @@ class ToolBar(_Toolbar, uicommand.UICommandContainerMixin):
             for item in self.__visible_ui_commands:
                 if item.is_command():
                     item.unbind(self, item.id)
+                    item.removeInstance()
 
         idx = 0
         while idx < self.GetToolCount():

--- a/taskcoachlib/gui/uicommand/base_uicommand.py
+++ b/taskcoachlib/gui/uicommand/base_uicommand.py
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import wx
-from taskcoachlib import operating_system
+from taskcoachlib import operating_system, patterns
 from taskcoachlib.gui.icons.icon_library import icon_catalog, LIST_ICON_SIZE
 from taskcoachlib.gui.newid import IdProvider
 from taskcoachlib.meta.debug import log_step
@@ -26,8 +26,8 @@ from taskcoachlib.meta.debug import log_step
 
 """ User interface commands (subclasses of UICommand) are actions that can
     be invoked by the user via the user interface (menu's, toolbar, etc.).
-    See the Taskmaster pattern described here: 
-    http://www.objectmentor.com/resources/articles/taskmast.pdf 
+    See the Taskmaster pattern described here:
+    http://www.objectmentor.com/resources/articles/taskmast.pdf
 """  # pylint: disable=W0105
 
 
@@ -45,15 +45,16 @@ class MenuItem(wx.MenuItem):
         if new_text is not None:
             try:
                 self.SetItemLabel(new_text)
-            except Exception:
-                pass
+            except Exception as e:
+                log_step("MenuItem.update_state: dead menu item: %s" % e,
+                         prefix="DEAD-OBJ")
         if enabled and self.IsCheckable():
             check = self._command.checked()
             if check is not None:
                 self.Check(check)
 
 
-class UICommand(object):
+class UICommand(patterns.Observer):
     """Base user interface command. An UICommand is some action that can be
     associated with menus and/or toolbars. It contains the menutext and
     helptext to be displayed and methods to attach the command to a menu
@@ -120,21 +121,21 @@ class UICommand(object):
             return [(flags, wx.WXK_NUMPAD_ENTER, self.id)]
         return []
 
-    def add_to_menu(self, menu, window, position=None, subMenu=None):
-        menuItem = MenuItem(
+    def add_to_menu(self, menu, window, position=None, sub_menu=None):
+        menu_item = MenuItem(
             self, menu, self.id, self.menu_text, self.help_text, self.kind,
-            subMenu=subMenu
+            subMenu=sub_menu
         )
-        self.menu_items.append(menuItem)
-        self.add_bitmap_to_menu_item(menuItem)
+        self.menu_items.append(menu_item)
+        self.add_bitmap_to_menu_item(menu_item)
         if position is None:
-            menu.Append(menuItem)
+            menu.Append(menu_item)
         else:
-            menu.Insert(position, menuItem)
+            menu.Insert(position, menu_item)
         self.bind(window, self.id)
         return self.id
 
-    def add_bitmap_to_menu_item(self, menuItem):
+    def add_bitmap_to_menu_item(self, menu_item):
         if (
             self.icon_id2
             and self.kind == wx.ITEM_CHECK
@@ -142,7 +143,7 @@ class UICommand(object):
         ):
             bitmap1 = icon_catalog.get_bitmap(self.icon_id, LIST_ICON_SIZE)
             bitmap2 = icon_catalog.get_bitmap(self.icon_id2, LIST_ICON_SIZE)
-            menuItem.SetBitmaps(bitmap1, bitmap2)
+            menu_item.SetBitmaps(bitmap1, bitmap2)
         elif self.kind == wx.ITEM_NORMAL:
             if self.icon_id is None:
                 return  # No icon intended - correct, do nothing
@@ -151,19 +152,21 @@ class UICommand(object):
             if not bitmap.IsOk():
                 # TRAP: icon_id given but invalid - this is an error
                 log_step("ERROR: invalid icon '%s' for menu item '%s'" %
-                         (self.icon_id, menuItem.GetItemLabelText()), prefix="ICON")
+                         (self.icon_id, menu_item.GetItemLabelText()), prefix="ICON")
                 return
 
-            menuItem.SetBitmap(bitmap)
+            menu_item.SetBitmap(bitmap)
 
     def remove_from_menu(self, menu, window):
-        for menuItem in self.menu_items:
-            if menuItem.GetMenu() == menu:
-                self.menu_items.remove(menuItem)
-                menuId = menuItem.GetId()
-                menu.Remove(menuId)
+        menu_id = None
+        for menu_item in self.menu_items:
+            if menu_item.GetMenu() == menu:
+                self.menu_items.remove(menu_item)
+                menu_id = menu_item.GetId()
+                menu.Remove(menu_id)
                 break
-        self.unbind(window, menuId)
+        if menu_id is not None:
+            self.unbind(window, menu_id)
 
     def append_to_toolbar(self, toolbar):
         self.toolbar = toolbar
@@ -182,11 +185,11 @@ class UICommand(object):
         self.bind(toolbar, self.id)
         return self.id
 
-    def bind(self, window, itemId):
-        window.Bind(wx.EVT_MENU, self.on_command_activate, id=itemId)
+    def bind(self, window, item_id):
+        window.Bind(wx.EVT_MENU, self.on_command_activate, id=item_id)
 
-    def unbind(self, window, itemId):
-        window.Unbind(wx.EVT_MENU, id=itemId)
+    def unbind(self, window, item_id):
+        window.Unbind(wx.EVT_MENU, id=item_id)
 
     def on_command_activate(self, event, *args, **kwargs):
         """For controls such as the ListCtrl and the TreeCtrl, activating
@@ -220,23 +223,24 @@ class UICommand(object):
     def update_tool_help(self):
         if not self.toolbar:
             return  # Not attached to a toolbar or it's hidden
-        shortHelp = wx.MenuItem.GetLabelText(self.get_menu_text())
-        if shortHelp != self.toolbar.GetToolShortHelp(self.id):
-            self.toolbar.SetToolShortHelp(self.id, shortHelp)
-        longHelp = self.get_help_text()
-        if longHelp != self.toolbar.GetToolLongHelp(self.id):
-            self.toolbar.SetToolLongHelp(self.id, longHelp)
+        short_help = wx.MenuItem.GetLabelText(self.get_menu_text())
+        if short_help != self.toolbar.GetToolShortHelp(self.id):
+            self.toolbar.SetToolShortHelp(self.id, short_help)
+        long_help = self.get_help_text()
+        if long_help != self.toolbar.GetToolLongHelp(self.id):
+            self.toolbar.SetToolLongHelp(self.id, long_help)
 
     def update_menu_text(self, menu_text):
         self.menu_text = menu_text
         # SetItemLabel works on all platforms in modern wxPython 4.x
         # The old Windows-specific code that deleted/inserted menu items
         # was causing access violations when popup menus were displayed.
-        for menuItem in self.menu_items:
+        for menu_item in self.menu_items:
             try:
-                menuItem.SetItemLabel(menu_text)
-            except Exception:
-                pass  # Ignore errors from deleted menu items
+                menu_item.SetItemLabel(menu_text)
+            except Exception as e:
+                log_step("update_menu_text: dead menu item: %s" % e,
+                         prefix="DEAD-OBJ")
 
     def main_window(self):
         return wx.GetApp().TopWindow

--- a/taskcoachlib/gui/uicommand/settings_uicommand.py
+++ b/taskcoachlib/gui/uicommand/settings_uicommand.py
@@ -44,10 +44,10 @@ class BooleanSettingsCommand(SettingsCommand):  # pylint: disable=W0223
         super().__init__(*args, **kwargs)
 
     def add_to_menu(self, menu, window, position=None):
-        menuId = super().add_to_menu(menu, window, position)
-        menuItem = menu.FindItemById(menuId)
-        menuItem.Check(self.is_setting_checked())
-        return menuId
+        menu_id = super().add_to_menu(menu, window, position)
+        menu_item = menu.FindItemById(menu_id)
+        menu_item.Check(self.is_setting_checked())
+        return menu_id
 
     def checked(self):
         return self.is_setting_checked()

--- a/taskcoachlib/gui/uicommand/uicommand.py
+++ b/taskcoachlib/gui/uicommand/uicommand.py
@@ -52,7 +52,7 @@ from taskcoachlib.thirdparty.wxScheduler import (
 )
 from taskcoachlib.gui.icons.icon_library import icon_catalog
 from taskcoachlib.tools import anonymize, openfile
-from taskcoachlib.meta.debug import log_step
+
 import wx, re, operator
 from . import base_uicommand
 from . import mixin_uicommand
@@ -1263,7 +1263,7 @@ class ResetFilter(ViewerCommand):
 
     def append_to_toolbar(self, *args, **kwargs):
         super().append_to_toolbar(*args, **kwargs)
-        patterns.Publisher().registerObserver(
+        self.registerObserver(
             self._on_filter_change,
             eventType=base.filter.Filter.filter_change_event_type(),
         )
@@ -1274,7 +1274,6 @@ class ResetFilter(ViewerCommand):
             self.toolbar.Refresh(False)
         except RuntimeError:
             pass
-
 
     def do_command(self, event):
         self.viewer.reset_filter()
@@ -1635,7 +1634,7 @@ class ViewerHideTasks(ViewerCommand, settings_uicommand.UICheckCommand):
     def append_to_toolbar(self, *args, **kwargs):
         super().append_to_toolbar(*args, **kwargs)
         self.toolbar.ToggleTool(self.id, self.checked())
-        patterns.Publisher().registerObserver(
+        self.registerObserver(
             self._on_filter_change,
             eventType=base.filter.Filter.filter_change_event_type(),
         )
@@ -1643,7 +1642,6 @@ class ViewerHideTasks(ViewerCommand, settings_uicommand.UICheckCommand):
     def _on_filter_change(self, event):
         self.toolbar.ToggleTool(self.id, self.checked())
         self.toolbar.Refresh(False)
-
 
     def unique_name(self):
         return super().unique_name() + "_" + str(self.__taskStatus)
@@ -1670,7 +1668,6 @@ class ViewerHideCompositeTasks(
             *args,
             **kwargs
         )
-
 
     def is_setting_checked(self):
         return self.viewer.is_hiding_composite_tasks()
@@ -2845,6 +2842,10 @@ class EffortStop(EffortListCommand, TaskListCommand, ViewerCommand):
             )
         self.__current_icon_id = None
 
+    def removeInstance(self):
+        self._EffortStop__tracker.removeInstance()
+        super().removeInstance()
+
     def __onEffortsChanged(self, efforts):
         self.updateUI()
 
@@ -2879,7 +2880,6 @@ class EffortStop(EffortListCommand, TaskListCommand, ViewerCommand):
         # untracked efforts this command will resume them. Otherwise this
         # command is disabled.
         return self.anyTrackedEfforts() or self.anyStoppedEfforts()
-
 
     def updateUI(self):
         if wx.GetApp().quitting:
@@ -3969,11 +3969,11 @@ class ViewerPieChartAngle(ViewerCommand, settings_uicommand.SettingsCommand):
         self.sliderCtrl.Bind(wx.EVT_SLIDER, self.onSlider)
         toolbar.AddControl(self.sliderCtrl)
 
-    def unbind(self, window, itemId):
+    def unbind(self, window, item_id):
         if self.sliderCtrl is not None:
             self.sliderCtrl.Unbind(wx.EVT_SLIDER)
             self.sliderCtrl = None
-        super().unbind(window, itemId)
+        super().unbind(window, item_id)
 
     def onSlider(self, event):
         """The user picked a new angle."""
@@ -4047,11 +4047,11 @@ class AlwaysRoundUp(settings_uicommand.UICheckCommand, ViewerCommand):
         self.checkboxCtrl.Bind(wx.EVT_CHECKBOX, self.onCheck)
         toolbar.AddControl(self.checkboxCtrl)
 
-    def unbind(self, window, itemId):
+    def unbind(self, window, item_id):
         if self.checkboxCtrl is not None:
             self.checkboxCtrl.Unbind(wx.EVT_CHECKBOX)
             self.checkboxCtrl = None
-        super().unbind(window, itemId)
+        super().unbind(window, item_id)
 
     def is_setting_checked(self):
         return self.settings.getboolean(
@@ -4100,11 +4100,11 @@ class ConsolidateEffortsPerTask(
         self.checkboxCtrl.Bind(wx.EVT_CHECKBOX, self.onCheck)
         toolbar.AddControl(self.checkboxCtrl)
 
-    def unbind(self, window, itemId):
+    def unbind(self, window, item_id):
         if self.checkboxCtrl is not None:
             self.checkboxCtrl.Unbind(wx.EVT_CHECKBOX)
             self.checkboxCtrl = None
-        super().unbind(window, itemId)
+        super().unbind(window, item_id)
 
     def is_setting_checked(self):
         return self.settings.getboolean(

--- a/taskcoachlib/gui/viewer/base.py
+++ b/taskcoachlib/gui/viewer/base.py
@@ -28,6 +28,7 @@ from taskcoachlib.gui.icons import icon_library
 from taskcoachlib.gui.icons import image_list_cache
 from wx.lib.agw import hypertreelist
 from pubsub import pub
+from taskcoachlib.meta.debug import log_step
 from . import mixin
 
 
@@ -201,17 +202,16 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
             else:
                 observers.append(observable)
         for observer in observers:
-            try:
+            if hasattr(observer, 'removeInstance'):
                 observer.removeInstance()
-            except AttributeError:
-                pass  # Ignore observables that are not an observer themselves
 
         for popupMenu in self._popupMenus:
             try:
                 popupMenu.clearMenu()
                 popupMenu.Destroy()
             except RuntimeError:
-                pass
+                log_step("detach: popup menu already dead %x" %
+                         id(popupMenu), prefix="DEAD-OBJ")
 
         pub.unsubscribe(self.onBeginIO, "taskfile.aboutToRead")
         pub.unsubscribe(self.onBeginIO, "taskfile.aboutToClear")
@@ -704,9 +704,16 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
     def editItemDialog(
         self, items, icon_id, columnName="", items_are_new=False
     ):
-        Editor = self.itemEditorClass()
-        return Editor(
-            wx.GetTopLevelParent(self),
+        parent = wx.GetTopLevelParent(self)
+        # If the viewer is inside an Editor dialog (e.g. EffortViewer inside
+        # TaskEditor), parent to main window instead. Otherwise Destroy() on
+        # the parent editor cascades to this editor without EVT_CLOSE, leaving
+        # dangling observers/subscriptions and causing C++ segfaults.
+        if isinstance(parent, wx.Dialog):
+            parent = wx.GetApp().TopWindow
+        EditorClass = self.itemEditorClass()
+        return EditorClass(
+            parent,
             items,
             self.settings,
             self.presentation(),
@@ -816,7 +823,10 @@ class ListViewer(Viewer):  # pylint: disable=W0223
             yield item
 
     def getItemWithIndex(self, index):
-        return self.presentation()[index]
+        try:
+            return self.presentation()[index]
+        except IndexError:
+            return None
 
     def getIndexOfItem(self, item):
         return self.presentation().index(item)

--- a/taskcoachlib/gui/viewer/task.py
+++ b/taskcoachlib/gui/viewer/task.py
@@ -237,8 +237,13 @@ class BaseTaskTreeViewer(BaseTaskViewer):  # pylint: disable=W0223
                 items_are_new=items_are_new,
             )
         else:
+            parent = wx.GetTopLevelParent(self)
+            # Same fix as base.py: if viewer is inside an Editor dialog,
+            # parent to main window to avoid cascade-Destroy segfault.
+            if isinstance(parent, wx.Dialog):
+                parent = wx.GetApp().TopWindow
             return dialog.editor.EffortEditor(
-                wx.GetTopLevelParent(self),
+                parent,
                 items,
                 self.settings,
                 self.taskFile.efforts(),

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,10 +41,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.2"  # Major.Minor.Milestone
-patch = "3"  # Patch number - INCREMENT THIS for each release
+patch = "4"  # Patch number - INCREMENT THIS for each release
 version_full = f"{version}.{patch}"  # Full version: 2.0.2.1
 
-release_day = "23"  # Day of the release (1-31)
+release_day = "26"  # Day of the release (1-31)
 release_month = "February"  # Month of the release
 release_year = "2026"  # Year of the release
 


### PR DESCRIPTION
Editor segfault fixes (3 crash causes):
- UICommand inherits Observer for automatic cleanup on removeInstance()
- toolbar.Clear() calls removeInstance() on each UICommand
- EffortStop.removeInstance() cleans up its internal tracker
- Editors opened from within editors now parent to main window, preventing cascade-Destroy without EVT_CLOSE
- Editor close uses Hide() + wx.CallAfter(Destroy) to avoid GTK popup widget crashes during C++ deferred destruction
- Remove event.Skip() + Destroy() anti-pattern in on_close_editor
- Close child Editor dialogs before Destroy() for proper cleanup
- Add DEAD-OBJ error logging to all silent exception guards

PEP 8 renames across uicommand system:
- menuItem→menu_item, menuId→menu_id, subMenu→sub_menu
- itemId→item_id, shortHelp→short_help, longHelp→long_help
- Applied consistently in base_uicommand, uicommand, settings_uicommand, menu

Icon system cleanup:
- Remove obsolete ICON_MAPPING.json (replaced by icon_catalog)
- Consolidate icon documentation into ICON_LIBRARY.md
- Clean up TODO.md with signaling system cleanup item 

Documentation polish:
- Add TOC and anchor links to install docs (macOS, Windows)
- Cross-link Security Warning sections
- Update version references in all READMEs


Crash when starting effort on a fresh subtask #395