### PR TITLE
Fix recurring task cascade abort, resize crashes, SelectAll, PEP 8 locals

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.4-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.4-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.4_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.4_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.4_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.4-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.5-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.5-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.5_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.5_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.5_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.5-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.4-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.4-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.4_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.4_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.2.4-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.2.4-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.5-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.5-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.5_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.5_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.2.5-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.2.5-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.4_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.2.4_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.5_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.2.5_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.4-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.2.4-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.5-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.2.5-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.4-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.2.4-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.5-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.2.5-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.4-x86_64.AppImage
-chmod +x TaskCoach-2.0.2.4-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.5-x86_64.AppImage
+chmod +x TaskCoach-2.0.2.5-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.2.4-x86_64.AppImage
+./TaskCoach-2.0.2.5-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/README_INSTALL_MACOS.md
+++ b/README_INSTALL_MACOS.md
@@ -17,7 +17,7 @@ Download the DMG for your Mac from the [latest release](https://github.com/taskc
 - **Apple Silicon** (M1/M2/M3/M4): `TaskCoach-<version>-macos-arm64.dmg`
 - **Intel**: `TaskCoach-<version>-macos-intel.dmg`
 
-Where `<version>` is the release version (e.g., `2.0.2.4`).
+Where `<version>` is the release version (e.g., `2.0.2.5`).
 
 Not sure which Mac you have? Click the Apple menu → "About This Mac". Look for "Chip" (Apple Silicon) or "Processor" (Intel).
 

--- a/README_INSTALL_WINDOWS.md
+++ b/README_INSTALL_WINDOWS.md
@@ -19,7 +19,7 @@ Download the installer from the [latest release](https://github.com/taskcoach/ta
 - **Installer**: `TaskCoach-<version>-windows-x64-setup.exe` - Standard installation
 - **Portable**: `TaskCoach-<version>-windows-x64-portable.zip` - No installation required
 
-Where `<version>` is the release version (e.g., `2.0.2.4`).
+Where `<version>` is the release version (e.g., `2.0.2.5`).
 
 ## <a id="security-warning"></a>Security Warning
 

--- a/taskcoachlib/domain/base/filter.py
+++ b/taskcoachlib/domain/base/filter.py
@@ -54,7 +54,9 @@ class Filter(patterns.SetDecorator):
         try:
             self.observable().set_tree_mode(tree_mode)
         except AttributeError:
-            pass
+            from taskcoachlib.meta.debug import log_step
+            log_step("set_tree_mode: observable has no set_tree_mode",
+                     prefix="FILTER")
         self.reset()
 
     def tree_mode(self):
@@ -77,8 +79,8 @@ class Filter(patterns.SetDecorator):
             return
 
         # Get items that directly match this filter's criteria
-        directMatches = set(self.filter_items(self.observable()))
-        filteredItems = directMatches.copy()
+        direct_matches = set(self.filter_items(self.observable()))
+        filtered_items = direct_matches.copy()
 
         # Reset and rebuild filter_forced tracking
         self.__filterForced = set()
@@ -86,17 +88,17 @@ class Filter(patterns.SetDecorator):
             # In tree mode, include ancestors of matching items to maintain
             # tree structure. Track these as "filter_forced" since they don't
             # match criteria themselves - they're only included for hierarchy.
-            for item in directMatches:
+            for item in direct_matches:
                 for ancestor in item.ancestors():
-                    if ancestor not in directMatches:
+                    if ancestor not in direct_matches:
                         self.__filterForced.add(ancestor)
-                        filteredItems.add(ancestor)
+                        filtered_items.add(ancestor)
 
         self.removeItemsFromSelf(
-            [item for item in self if item not in filteredItems], event=event
+            [item for item in self if item not in filtered_items], event=event
         )
         self.extendSelf(
-            [item for item in filteredItems if item not in self], event=event
+            [item for item in filtered_items if item not in self], event=event
         )
         patterns.Event(self.filter_change_event_type(), self).send()
 
@@ -127,7 +129,9 @@ class Filter(patterns.SetDecorator):
             if hasattr(inner, 'getAccumulatedFilterForced'):
                 accumulated |= inner.getAccumulatedFilterForced()
         except AttributeError:
-            pass
+            from taskcoachlib.meta.debug import log_step
+            log_step("getAccumulatedFilterForced: AttributeError on observable",
+                     prefix="FILTER")
         return accumulated
 
     def filter_items(self, items):

--- a/taskcoachlib/domain/date/recurrence.py
+++ b/taskcoachlib/domain/date/recurrence.py
@@ -105,8 +105,8 @@ class Recurrence(object):
             first_iso = iso_weekdays[0]
             days_ahead = 7 - current_iso + first_iso
             return dateTime + timedelta.TimeDelta(days=days_ahead)
-        nrOfDays = dict(daily=1, weekly=7)[self.unit]
-        return dateTime + timedelta.TimeDelta(days=nrOfDays)
+        nr_of_days = dict(daily=1, weekly=7)[self.unit]
+        return dateTime + timedelta.TimeDelta(days=nr_of_days)
 
     def _addMonth(self, dateTime):
         year, month, day = dateTime.year, dateTime.month, dateTime.day
@@ -123,11 +123,11 @@ class Recurrence(object):
             month += 1
         if self.sameWeekday:
             weekday = dateTime.weekday()
-            weekNr = min(
+            week_nr = min(
                 3, (day - 1) / 7
             )  # In what week of the month falls aDate, allowable range 0-3
             day = (
-                weekNr * 7 + 1
+                week_nr * 7 + 1
             )  # The earliest possible day that is on the same weekday as aDate
             result = date.DateTime(year, month, day, *details)
             while result.weekday() != weekday:
@@ -150,21 +150,21 @@ class Recurrence(object):
             days = 366
         else:
             days = 365
-        newDateTime = dateTime + timedelta.TimeDelta(days=days)
+        new_dt = dateTime + timedelta.TimeDelta(days=days)
         if self.sameWeekday:
-            # Find the nearest date in newDate's year that is on the right
+            # Find the nearest date in new_dt's year that is on the right
             # weekday:
-            weekday, year = dateTime.weekday(), newDateTime.year
-            newEarlierDateTime = newLaterDateTime = newDateTime
-            while newEarlierDateTime.weekday() != weekday:
-                newEarlierDateTime = newEarlierDateTime - timedelta.ONE_DAY
-            while newLaterDateTime.weekday() != weekday:
-                newLaterDateTime = newLaterDateTime + timedelta.ONE_DAY
-            if newEarlierDateTime.year != year:
-                newDateTime = newLaterDateTime
+            weekday, year = dateTime.weekday(), new_dt.year
+            new_earlier = new_later = new_dt
+            while new_earlier.weekday() != weekday:
+                new_earlier = new_earlier - timedelta.ONE_DAY
+            while new_later.weekday() != weekday:
+                new_later = new_later + timedelta.ONE_DAY
+            if new_earlier.year != year:
+                new_dt = new_later
             else:
-                newDateTime = newEarlierDateTime
-        return newDateTime
+                new_dt = new_earlier
+        return new_dt
 
     def copy(self):
         return self.__class__(
@@ -172,6 +172,7 @@ class Recurrence(object):
             self.amount,
             self.sameWeekday,
             self.max,
+            count=self.count,
             stop_datetime=self.stop_datetime,
             recurBasedOnCompletion=self.recurBasedOnCompletion,
             weekdays=list(self.weekdays),
@@ -184,11 +185,15 @@ class Recurrence(object):
                 and self.amount == other.amount
                 and self.sameWeekday == other.sameWeekday
                 and self.max == other.max
+                and self.count == other.count
                 and self.stop_datetime == other.stop_datetime
                 and self.recurBasedOnCompletion == other.recurBasedOnCompletion
                 and self.weekdays == other.weekdays
             )
         except AttributeError:
+            from taskcoachlib.meta.debug import log_step
+            log_step("__eq__ AttributeError: self=%r other=%r" % (
+                self, other), prefix="RECUR")
             return False
 
     def __lt__(self, other):
@@ -200,6 +205,9 @@ class Recurrence(object):
                 and self.amount < other.amount
             )
         except AttributeError:
+            from taskcoachlib.meta.debug import log_step
+            log_step("__lt__ AttributeError: self=%r other=%r" % (
+                self, other), prefix="RECUR")
             return True
 
     def __bool__(self):

--- a/taskcoachlib/domain/task/task.py
+++ b/taskcoachlib/domain/task/task.py
@@ -1220,7 +1220,9 @@ class Task(
         try:
             from taskcoachlib.config import settings2
             return section + "_dark" if settings2.window.theme_is_dark else section
-        except Exception:
+        except Exception as e:
+            from taskcoachlib.meta.debug import log_step
+            log_step("_themedSection(%s): %s" % (section, e), prefix="THEME")
             return section
 
     @classmethod
@@ -1710,59 +1712,65 @@ class Task(
 
     @patterns.eventSource
     def recur(self, completionDateTime=None, event=None):
+        from taskcoachlib.meta.debug import log_step
         completionDateTime = completionDateTime or date.Now()
         self.setCompletionDateTime(self.maxDateTime)
         recur = self.recurrence(recursive=True, upwards=True)
 
-        currentDueDateTime = self.dueDateTime()
-        currentPlannedStartDateTime = self.plannedStartDateTime()
+        if not recur.unit:
+            log_step("recur() on %r: resolved recurrence has no unit"
+                     % self.subject(), prefix="RECUR")
 
-        if currentDueDateTime != date.DateTime():
-            basisForRecurrence = (
+        current_due = self.dueDateTime()
+        current_planned_start = self.plannedStartDateTime()
+
+        if current_due != date.DateTime():
+            basis = (
                 completionDateTime
                 if recur.recurBasedOnCompletion
-                else currentDueDateTime
+                else current_due
             )
-            nextDueDateTime = recur(basisForRecurrence, next=False)
-            nextDueDateTime = nextDueDateTime.replace(
-                hour=currentDueDateTime.hour,
-                minute=currentDueDateTime.minute,
-                second=currentDueDateTime.second,
-                microsecond=currentDueDateTime.microsecond,
+            next_due = recur(basis, next=False)
+            next_due = next_due.replace(
+                hour=current_due.hour,
+                minute=current_due.minute,
+                second=current_due.second,
+                microsecond=current_due.microsecond,
             )
-            self.setDueDateTime(nextDueDateTime)
+            if next_due == current_due:
+                log_step("recur() on %r: date did not advance (%s)"
+                         % (self.subject(), current_due), prefix="RECUR")
+            self.setDueDateTime(next_due)
 
-        if currentPlannedStartDateTime != date.DateTime():
+        if current_planned_start != date.DateTime():
             if date.DateTime() not in (
-                currentPlannedStartDateTime,
-                currentDueDateTime,
+                current_planned_start,
+                current_due,
             ):
-                taskDuration = currentDueDateTime - currentPlannedStartDateTime
-                nextPlannedStartDateTime = nextDueDateTime - taskDuration
+                task_duration = current_due - current_planned_start
+                next_planned_start = next_due - task_duration
             else:
-                basisForRecurrence = (
+                basis = (
                     completionDateTime
                     if recur.recurBasedOnCompletion
-                    else currentPlannedStartDateTime
+                    else current_planned_start
                 )
-                nextPlannedStartDateTime = recur(
-                    basisForRecurrence, next=False
-                )
-            nextPlannedStartDateTime = nextPlannedStartDateTime.replace(
-                hour=currentPlannedStartDateTime.hour,
-                minute=currentPlannedStartDateTime.minute,
-                second=currentPlannedStartDateTime.second,
-                microsecond=currentPlannedStartDateTime.microsecond,
+                next_planned_start = recur(basis, next=False)
+            next_planned_start = next_planned_start.replace(
+                hour=current_planned_start.hour,
+                minute=current_planned_start.minute,
+                second=current_planned_start.second,
+                microsecond=current_planned_start.microsecond,
             )
-            self.setPlannedStartDateTime(nextPlannedStartDateTime)
+            self.setPlannedStartDateTime(next_planned_start)
 
         self.setActualStartDateTime(date.DateTime())
         self.setPercentageComplete(0)
         if self.reminder(includeSnooze=False):
-            nextReminder = recur(
+            next_reminder = recur(
                 self.reminder(includeSnooze=False), next=False
             )
-            self.setReminder(nextReminder)
+            self.setReminder(next_reminder)
         for child in self.children():
             if not child.recurrence():
                 child.recur(completionDateTime, event=event)

--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -133,14 +133,15 @@ class Page(patterns.Observer, widgets.BookPage):
         can start typing over it immediately."""
         the_entry.SetFocus()
         try:
-            if operating_system.isWindows() and isinstance(
-                the_entry, wx.TextCtrl
+            if operating_system.isWindows() and hasattr(
+                the_entry, "SetInsertionPoint"
             ):
-                # Scroll to left...
+                # Scroll to left before selecting
                 the_entry.SetInsertionPoint(0)
             the_entry.SetSelection(-1, -1)  # Select all text
-        except (AttributeError, TypeError):
-            pass  # Not a TextCtrl
+        except (AttributeError, TypeError) as e:
+            log_step("SetSelection failed on %s: %s" %
+                     (type(the_entry).__name__, e), prefix="EDITOR")
 
     def close(self):
         self.removeInstance()
@@ -180,14 +181,15 @@ class ScrolledPage(patterns.Observer, widgets.ScrolledBookPage):
         can start typing over it immediately."""
         the_entry.SetFocus()
         try:
-            if operating_system.isWindows() and isinstance(
-                the_entry, wx.TextCtrl
+            if operating_system.isWindows() and hasattr(
+                the_entry, "SetInsertionPoint"
             ):
-                # Scroll to left...
+                # Scroll to left before selecting
                 the_entry.SetInsertionPoint(0)
             the_entry.SetSelection(-1, -1)  # Select all text
-        except (AttributeError, TypeError):
-            pass  # Not a TextCtrl
+        except (AttributeError, TypeError) as e:
+            log_step("SetSelection failed on %s: %s" %
+                     (type(the_entry).__name__, e), prefix="EDITOR")
 
     def close(self):
         self.removeInstance()

--- a/taskcoachlib/gui/menu.py
+++ b/taskcoachlib/gui/menu.py
@@ -131,7 +131,7 @@ class DynamicMenu(Menu):
         the menu has a chance to update itself."""
         try:  # Prepare for menu or window to be destroyed
             self.updateMenu()
-        except RuntimeError:
+        except (RuntimeError, wx.wxAssertionError):
             log_step("onUpdateMenu: menu/window dead", prefix="DEAD-OBJ")
 
     def onUpdateMenu_Deprecated(self, event=None):
@@ -144,11 +144,9 @@ class DynamicMenu(Menu):
             if event.GetMenu() != self._parentMenu:
                 return
 
-        # FIXME: No RuntimeError similar classes in wxPython4, so
-        # you must carefully check if the window already destroyed.
         try:  # Prepare for menu or window to be destroyed
             self.updateMenu()
-        except RuntimeError:
+        except (RuntimeError, wx.wxAssertionError):
             log_step("onUpdateMenu_Deprecated: menu/window dead",
                      prefix="DEAD-OBJ")
 
@@ -961,29 +959,10 @@ class StartEffortForTaskMenu(DynamicMenu):
         super().__init__(taskBarIcon, parentMenu, labelInParentMenu)
 
     def registerForMenuUpdate(self):
-        for eventType in (
-            self.tasks.addItemEventType(),
-            self.tasks.removeItemEventType(),
-        ):
-            patterns.Publisher().registerObserver(
-                self.onUpdateMenu_Deprecated,
-                eventType=eventType,
-                eventSource=self.tasks,
-            )
-        for eventType in (
-            task.Task.subjectChangedEventType(),
-            task.Task.trackingChangedEventType(),
-            task.Task.plannedStartDateTimeChangedEventType(),
-            task.Task.dueDateTimeChangedEventType(),
-            task.Task.actualStartDateTimeChangedEventType(),
-            task.Task.completionDateTimeChangedEventType(),
-        ):
-            if eventType.startswith("pubsub"):
-                pub.subscribe(self.onUpdateMenu, eventType)
-            else:
-                patterns.Publisher().registerObserver(
-                    self.onUpdateMenu_Deprecated, eventType
-                )
+        # No-op: menu is rebuilt on-demand in popupTaskBarMenu() instead of
+        # subscribing to every domain event.  The old approach exhausted wx
+        # menu-item IDs during recur() cascades (wxAssertionError 0x7fff).
+        pass
 
     def updateMenuItems(self):
         self.clearMenu()

--- a/taskcoachlib/gui/taskbaricon.py
+++ b/taskcoachlib/gui/taskbaricon.py
@@ -195,6 +195,7 @@ class TaskBarIcon(patterns.Observer, wx.adv.TaskBarIcon):
     def popupTaskBarMenu(self, event):  # pylint: disable=W0613
         log_step("RIGHT-CLICK on taskbar icon, showing popup menu", prefix="TRAY")
         log_step("popupmenu object:", self.popupmenu, prefix="TRAY")
+        self.popupmenu.updateMenu()
         self.PopupMenu(self.popupmenu)
         log_step("PopupMenu() returned", prefix="TRAY")
 

--- a/taskcoachlib/gui/viewer/base.py
+++ b/taskcoachlib/gui/viewer/base.py
@@ -316,8 +316,9 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
     def SetFocus(self, *args, **kwargs):
         try:
             self.widget.SetFocus(*args, **kwargs)
-        except RuntimeError:
-            pass
+        except RuntimeError as e:
+            log_step("SetFocus on dead widget %s: %s" %
+                     (self.__class__.__name__, e), prefix="DEAD-OBJ")
 
     def createSorter(self, collection):
         """This method can be overridden to decorate the presentation with a
@@ -408,10 +409,9 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
             # Fire status event - StatusBar has its own 500ms debounce
             # No need to query selection here; status bar queries fresh when displaying
             wx.CallAfter(self.sendViewerStatusEvent)
-        except RuntimeError:
-            # RuntimeError: wrapped C/C++ object of type EffortViewer has been deleted
-            # FIXME: It's a bug?
-            pass
+        except RuntimeError as e:
+            log_step("onSelect on dead viewer %s: %s" %
+                     (self.__class__.__name__, e), prefix="DEAD-OBJ")
 
     def updateSelection(self, sendViewerStatusEvent=True):
         """Legacy method - kept for subclass compatibility.
@@ -1094,24 +1094,24 @@ class ViewerWithColumns(Viewer):  # pylint: disable=W0223
         )
         return column.name() not in unhideableColumns
 
-    def getColumnWidth(self, columnName):
-        columnWidths = self.settings.getdict(
+    def getColumnWidth(self, column_name):
+        column_widths = self.settings.getdict(
             self.settingsSection(), "columnwidths"
         )
-        defaultWidth = (
+        default_width = (
             28
-            if columnName == "ordering"
+            if column_name == "ordering"
             else hypertreelist._DEFAULT_COL_WIDTH
         )  # pylint: disable=W0212
-        return columnWidths.get(columnName, defaultWidth)
+        return int(column_widths.get(column_name, default_width))
 
     def onResizeColumn(self, column, width):
-        columnWidths = self.settings.getdict(
+        column_widths = self.settings.getdict(
             self.settingsSection(), "columnwidths"
         )
-        columnWidths[column.name()] = width
+        column_widths[column.name()] = int(width)
         self.settings.setdict(
-            self.settingsSection(), "columnwidths", columnWidths
+            self.settingsSection(), "columnwidths", column_widths
         )
 
     def validateDrag(self, dropItem, dragItems, columnIndex):

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,11 +41,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.2"  # Major.Minor.Milestone
-patch = "4"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.2.1
+patch = "5"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.2.5
 
-release_day = "26"  # Day of the release (1-31)
-release_month = "February"  # Month of the release
+release_day = "2"  # Day of the release (1-31)
+release_month = "March"  # Month of the release
 release_year = "2026"  # Year of the release
 
 # =============================================================================

--- a/taskcoachlib/patterns/observer.py
+++ b/taskcoachlib/patterns/observer.py
@@ -88,15 +88,15 @@ class Event(object):
         the type as keyword argument. If no type is specified, the source
         and values are added for a random type, i.e. only omit the type if
         the event has only one type."""
-        eventType = kwargs.pop("type", self.type())
-        currentValues = set(
-            self.__sourcesAndValuesByType.setdefault(eventType, {}).setdefault(
+        event_type = kwargs.pop("type", self.type())
+        current_values = set(
+            self.__sourcesAndValuesByType.setdefault(event_type, {}).setdefault(
                 source, tuple()
             )
         )
-        currentValues |= set(values)
-        self.__sourcesAndValuesByType.setdefault(eventType, {})[source] = (
-            tuple(currentValues)
+        current_values |= set(values)
+        self.__sourcesAndValuesByType.setdefault(event_type, {})[source] = (
+            tuple(current_values)
         )
 
     def type(self):
@@ -145,20 +145,20 @@ class Event(object):
     def subEvent(self, *typesAndSources):
         """Create a new event that contains a subset of the data of this
         event."""
-        subEvent = self.__class__()
+        sub_event = self.__class__()
         for type, source in typesAndSources:
-            sourcesToAdd = self.sources(type)
+            sources_to_add = self.sources(type)
             if source is not None:
                 # Make sure source is actually in self.sources(type):
-                sourcesToAdd &= set([source])
+                sources_to_add &= set([source])
             kwargs = dict(
                 type=type
             )  # Python doesn't allow type=type after *values
-            for eachSource in sourcesToAdd:
-                subEvent.addSource(
-                    eachSource, *self.values(eachSource, type), **kwargs
+            for each_source in sources_to_add:
+                sub_event.addSource(
+                    each_source, *self.values(each_source, type), **kwargs
                 )  # pylint: disable=W0142
-        return subEvent
+        return sub_event
 
     def send(self):
         """Send this event to observers of the type(s) of this event."""
@@ -338,24 +338,24 @@ class Publisher(object, metaclass=singleton.Singleton):
         types = event.types()
         # Include observers not registered for a specific event source:
         sources = event.sources() | set([None])
-        eventTypesAndSources = [
+        types_and_sources = [
             (type, source) for source in sources for type in types
         ]
-        for eventTypeAndSource in eventTypesAndSources:
-            for observer in self.__observers.get(eventTypeAndSource, set()):
-                observers.setdefault(observer, set()).add(eventTypeAndSource)
+        for type_and_source in types_and_sources:
+            for observer in self.__observers.get(type_and_source, set()):
+                observers.setdefault(observer, set()).add(type_and_source)
         import wx
-        if wx.GetApp() and wx.GetApp().quitting:
+        if wx.GetApp() and getattr(wx.GetApp(), 'quitting', False):
             return
-        for observer, eventTypesAndSources in observers.items():
-            subEvent = event.subEvent(*eventTypesAndSources)
-            if subEvent.types():
+        for observer, types_and_sources in observers.items():
+            sub_event = event.subEvent(*types_and_sources)
+            if sub_event.types():
                 try:
-                    observer(subEvent)
-                except RuntimeError:
+                    observer(sub_event)
+                except Exception:
                     from taskcoachlib.meta.debug import log_step
-                    log_step("Observer RuntimeError: %s on %s" % (
-                        observer, subEvent.types()), prefix="OBSERVER")
+                    log_step("Observer exception: %s on %s" % (
+                        observer, sub_event.types()), prefix="OBSERVER")
 
     @unwrapObservers
     def observers(self, eventType=None):

--- a/taskcoachlib/widgets/autowidth.py
+++ b/taskcoachlib/widgets/autowidth.py
@@ -202,7 +202,7 @@ class AutoColumnWidthMixin(object):
     ResizeColumn = property(GetResizeColumn, SetResizeColumn)
 
     def GetAvailableWidth(self):
-        available_width = self.GetClientSize().width
+        available_width = int(self.GetClientSize().width)
         if (
             self.__is_scrollbar_visible()
             and self.__is_scrollbar_included_in_client_size()
@@ -219,7 +219,7 @@ class AutoColumnWidthMixin(object):
             if column_index == self.ResizeColumn:
                 necessary_width += self.ResizeColumnMinWidth
             else:
-                necessary_width += self.GetColumnWidth(column_index)
+                necessary_width += int(self.GetColumnWidth(column_index))
         return necessary_width
 
     NecessaryWidth = property(GetNecessaryWidth)

--- a/taskcoachlib/widgets/textctrl.py
+++ b/taskcoachlib/widgets/textctrl.py
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from taskcoachlib import i18n, operating_system
+from taskcoachlib.meta.debug import log_step
 import ast
 import wx
 import wx.stc as stc
@@ -66,7 +67,9 @@ class SpellCheckMixin:
             return []
         try:
             return enchant.list_languages()
-        except Exception:
+        except Exception as e:
+            log_step("enchant.list_languages() failed: %s" % e,
+                     prefix="SPELL")
             return []
 
 
@@ -265,8 +268,9 @@ class _StyledTextCtrl(stc.StyledTextCtrl):
     def _onDestroy(self, event):
         try:
             pub.unsubscribe(self._onSquiggleColourChanged, 'spellcheck.colours.changed')
-        except Exception:
-            pass
+        except Exception as e:
+            log_step("unsubscribe squiggle colour failed: %s" % e,
+                     prefix="SPELL")
         event.Skip()
 
     def _onKeyDown(self, event):
@@ -350,7 +354,9 @@ class _StyledTextCtrl(stc.StyledTextCtrl):
             section = "spellcheck_dark" if settings2.window.theme_is_dark else "spellcheck_light"
             color_tuple = self._settings.getvalue(section, "squiggle_color")
             return wx.Colour(*color_tuple)
-        except Exception:
+        except Exception as e:
+            log_step("squiggle colour load failed, using RED: %s" % e,
+                     prefix="SPELL")
             return wx.RED
 
     def _setupIndicators(self):
@@ -380,7 +386,9 @@ class _StyledTextCtrl(stc.StyledTextCtrl):
             try:
                 self._spellCheckEnabled = self._settings.getboolean('spellcheck', 'enabled')
                 self._spellCheckLanguage = self._settings.get('spellcheck', 'language') or None
-            except Exception:
+            except Exception as e:
+                log_step("spellcheck settings load failed, using defaults: %s"
+                         % e, prefix="SPELL")
                 self._spellCheckEnabled = True
                 self._spellCheckLanguage = None
         else:
@@ -611,8 +619,9 @@ class _StyledTextCtrl(stc.StyledTextCtrl):
             try:
                 spell_dict.add(word)
                 wx.CallAfter(self._performHighlighting)
-            except Exception:
-                pass
+            except Exception as e:
+                log_step("add word to dictionary failed: %s" % e,
+                         prefix="SPELL")
 
     # Compatibility methods to match wx.TextCtrl interface
     def GetValue(self):
@@ -689,8 +698,9 @@ class MultiLineTextCtrl(wx.Panel):
                 if padding.left > 0:
                     cls._nativePadding = padding.left
                     return cls._nativePadding
-            except Exception:
-                pass
+            except Exception as e:
+                log_step("GTK padding probe failed: %s" % e,
+                         prefix="TEXTCTRL")
 
         # Fallback: try wxPython GetMargins (works on Windows)
         try:
@@ -700,8 +710,9 @@ class MultiLineTextCtrl(wx.Panel):
             if margins.x > 0:
                 cls._nativePadding = margins.x
                 return cls._nativePadding
-        except Exception:
-            pass
+        except Exception as e:
+            log_step("wxPython GetMargins probe failed: %s" % e,
+                     prefix="TEXTCTRL")
 
         # Last fallback
         cls._nativePadding = 6
@@ -834,6 +845,15 @@ class MultiLineTextCtrl(wx.Panel):
                 return self._textCtrl.Bind(stc.EVT_STC_CHANGE, handler, *args, **kwargs)
             return self._textCtrl.Bind(event, handler, *args, **kwargs)
         return super().Bind(event, handler, *args, **kwargs)
+
+    def SetSelection(self, from_pos, to_pos):
+        # wx.TextCtrl convention: (-1, -1) means "select all"
+        if from_pos == -1 and to_pos == -1:
+            return self._textCtrl.SelectAll()
+        return self._textCtrl.SetSelection(from_pos, to_pos)
+
+    def SelectAll(self):
+        return self._textCtrl.SelectAll()
 
     def setSpellCheckEnabled(self, enabled):
         return self._textCtrl.setSpellCheckEnabled(enabled)


### PR DESCRIPTION
Recurring tasks: decouple StartEffortForTaskMenu from pubsub events to prevent wxAssertionError (menu-item ID exhaustion) during recur() cascades. Menu now rebuilds on-demand via popupTaskBarMenu() instead of on every domain event. Widen exception catches in onUpdateMenu() and notifyObservers() so menu/observer errors never abort domain operations. Fix Recurrence.copy()/eq() to preserve count field.

Resize crashes: cast column widths to int() in autowidth.py and viewer/base.py to prevent TypeError from float values.

Editor fixes: add SetSelection()/SelectAll() to MultiLineTextCtrl, fix GTK padding probe, add logging to silent exception handlers.

Version bump to 2.0.2.5.

PEP 8: rename camelCase local variables to snake_case in recurrence.py, filter.py, and observer.py (locals only, no API changes).