### PR TITLE
Fix AUI repaint cascade, refcount input filter, log silent exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.6-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.6-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.6_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.6_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.6_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.6-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.7-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.7-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.7_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.7_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.7_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.7-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.6-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.6-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.6_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.6_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.2.6-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.2.6-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.7-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.7-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.7_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.7_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.2.7-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.2.7-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.6_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.2.6_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.7_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.2.7_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.6-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.2.6-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.7-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.2.7-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.6-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.2.6-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.7-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.2.7-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.6-x86_64.AppImage
-chmod +x TaskCoach-2.0.2.6-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.7-x86_64.AppImage
+chmod +x TaskCoach-2.0.2.7-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.2.6-x86_64.AppImage
+./TaskCoach-2.0.2.7-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/docs/LIST_MANAGEMENT.md
+++ b/docs/LIST_MANAGEMENT.md
@@ -721,62 +721,63 @@ position after menu dismiss).
 
 ### Current Solution (3 layers)
 
-The primary goal is to **limit the tree widget's own repaints** during
-refresh/filter/rebuild operations, because the tree's `OnPaint` is
-where the heavy drawing work happens.  Each cascade paint redraws all
-visible tree items — with 100+ cascade paints, this is the dominant
-cost.  By debouncing at the widget level, the cascade is broken at its
-source regardless of what the AUI frame does.
+**1. Paint suppression on TreeListCtrl** (`treectrl.py`):
+Replaces the tree widget's `OnPaint` handler.  **Only active during
+refresh** (`__refreshing=True`) — normal paints (hover, scroll, mouse
+interaction) are never affected.  During refresh, **ALL** paints are
+suppressed with an empty `wx.PaintDC` (validates the GDK region to
+prevent infinite expose loops, but draws nothing).  This completely
+breaks the AUI cascade at its source — each cascade paint of 291 items
+takes ~280ms, and without suppression 5+ cascade paints cause a
+1.4+ second freeze.  A single clean `Refresh()` is triggered when
+`__refreshing` clears, rendering the final state with correct item
+positions.
 
-**1. Paint debounce on TreeListCtrl** (`treectrl.py`):
-Replaces the tree widget's `OnPaint` handler with a debounced version.
-**Only active during refresh** (`__refreshing=True`) — normal paints
-(hover, scroll, mouse interaction) are never affected.  The first
-paint goes through immediately, then subsequent cascade paints are
-suppressed for 100ms intervals.  Suppressed paints create a
-`wx.PaintDC` to validate the GDK region (preventing infinite expose
-loops) but don't draw.  A deferred `wx.CallLater` `Refresh()`
-guarantees the final state is always rendered after the cascade
-settles.
+**Why suppress ALL paints, not throttle?**  The cascade is
+self-sustaining: AUI paint → GDK damage on children → child repaint →
+AUI repaint → repeat.  Each tree paint takes ~280ms for a 291-item
+list, so a 100ms throttle lets every cascade paint through (they're
+always >100ms apart).  Only total suppression breaks the cycle.
 
-**2. `__refreshing` debounce flag** (`treectrl.py`):
-`RefreshAllItems()` sets `__refreshing=True` before rebuild and skips
-re-entry if already refreshing (cascade-triggered calls).  An
-`EVT_IDLE` handler monitors the widget's `_dirty` flag; when
-`_dirty=False` (layout complete), it clears `__refreshing` and
-triggers one final `Refresh()` for a clean paint with correct item
-positions (after `CalculatePositions()`).
+**2. `__refreshing` lifecycle flag** (`treectrl.py`):
+`RefreshAllItems()` sets `__refreshing=True` before rebuild.  An
+`EVT_IDLE` handler (`_on_refresh_idle`) monitors the upstream
+`_dirty` flag on the tree's main window; when `_dirty=False` + one
+extra idle cycle (for the paint from `OnInternalIdle`'s `Refresh()`),
+it clears `__refreshing` and triggers one final `Refresh()` for a
+clean paint with correct item positions (after `CalculatePositions()`).
+`__refreshing` is NOT used as a re-entry guard — multiple
+`RefreshAllItems` calls can overlap.  It only drives paint suppression
+and selection event suppression.
 
 **3. EventFilter input blocking** (`frame.py`):
-`rebuild_guard(widget)` context manager activates a `wx.EventFilter`
-that silently eats mouse and keyboard events at the wx level during
-rebuild.  No visual effect (no gray, no flicker).  On exit, binds
-`EVT_IDLE` to monitor the widget's `_dirty` flag.  When `_dirty=False`
-+ one extra idle cycle (for the paint from `OnInternalIdle`'s
-`Refresh()`), re-enables input.  Used in `viewer.refresh()`,
-`showColumn()`, and `CalendarViewer.reconfig()`.
+`_RebuildInputFilter` is a `wx.EventFilter` that silently eats mouse
+and keyboard events at the wx level.  No visual effect (no gray, no
+flicker).  Each `RefreshAllItems` call increments a refcount via
+`acquire()`; each `_on_refresh_idle` decrements via `release()`.  When
+the last widget completes, a 1-second deferred release timer starts to
+cover the post-rebuild settling period.  If a new rebuild starts during
+the settling, the timer is cancelled and the filter stays active.
 
 ### How the layers work together
 
 ```
-viewer.refresh() or showColumn() or CalendarViewer.reconfig()
-  └── rebuild_guard(widget) activates
-      ├── EventFilter: eats mouse/keyboard at wx level
-      └── RefreshAllItems()
-          ├── __refreshing = True  (paint debounce activates)
-          ├── Freeze → build items → Thaw → restore selection
-          ├── Thaw triggers paint → FIRST paint allowed (debounce)
-          ├── AUI cascade paints → SUPPRESSED (100ms debounce)
-          ├── EVT_IDLE fires quickly (cascade killed)
-          │   └── OnInternalIdle → _dirty=False → Refresh()
-          │       └── paint from Refresh() → may be suppressed
-          ├── _on_refresh_idle → __refreshing=False → Refresh()
-          │   └── final clean paint with correct positions
-          │   └── (paint debounce deactivates — normal paints resume)
-          └── rebuild_guard releases → EventFilter deactivated
+RefreshAllItems()
+    ├── _input_filter.acquire()  (refcount++, filter active)
+    ├── __refreshing = True  (paint suppression activates)
+    ├── Freeze → build items → Thaw → restore selection
+    ├── Thaw triggers paint → SUPPRESSED (empty PaintDC)
+    ├── AUI cascade paints → ALL SUPPRESSED (zero drawing work)
+    ├── EVT_IDLE → OnInternalIdle → CalculatePositions → _dirty=False
+    ├── _on_refresh_idle (extra idle cycle for safety)
+    │   ├── __refreshing = False  (paint suppression deactivates)
+    │   ├── _input_filter.release()  (refcount--, deferred release if 0)
+    │   └── Refresh() → ONE clean paint with correct positions
+    └── 1s later: filter deactivates (mouse/keyboard resume)
 ```
 
-Total elapsed: ~50-120ms (down from 880-1290ms).
+Total elapsed: rebuild ~80ms + CalculatePositions + one paint ~280ms.
+Cascade eliminated (down from 1.4+ seconds with 5+ cascade paints).
 
 ### What was tried and abandoned
 
@@ -788,6 +789,12 @@ Total elapsed: ~50-120ms (down from 880-1290ms).
 | 4 | Instance-level `Repaint` override | Not reached (bound method capture) |
 | 5 | Class-level `Repaint` debounce (50ms throttle) | Suppressed ~half, but AUI still cascades |
 | 6 | `wx.WindowDisabler` | Grays out menu bar on GTK3 (calls `gtk_widget_set_sensitive`) |
+| 7 | Always-on paint throttle (1 per 100ms + deferred `Refresh()`) | Ghosting and missing paints everywhere — suppressed paints with empty `PaintDC` leave stale content, deferred `Refresh()` doesn't reliably produce a clean repaint. A guard on repaint does not work because it creates a lot of ghosting/missing-paint problems |
+| 8 | `RefreshAllItems` time-based throttle (skip if <100ms, schedule `CallLater(100, RefreshAllItems)`) | Deferred calls triggered full 80ms rebuilds when only a repaint was needed; cascade of deferred calls from multiple widgets |
+| 9 | Remove `__refreshing` re-entry guard entirely | Empty lists on startup — legitimate refresh calls during 703ms idle wait were no longer blocked, but without `__refreshing` flag the paint debounce and selection suppression also stopped working |
+| 10 | Paint throttle 1-per-100ms during `__refreshing` | Each cascade paint takes ~280ms (291 items), so paints are always >100ms apart — throttle never triggers. Cascade runs unimpeded. Only total suppression (zero paints during refresh) breaks the cycle |
+| 11 | Per-widget EventFilter release (each `_on_refresh_idle` sets `active=False`) | First widget to finish clears the filter while other widgets still need it. Global singleton filter requires refcount + deferred release |
+| 12 | `__refreshing` as re-entry guard for `RefreshAllItems` | Blocks legitimate refresh calls for 703ms during idle wait, causing empty lists on startup. Removed re-entry guard — `__refreshing` now only drives paint suppression and selection suppression |
 
 ### Resolved Questions
 
@@ -808,8 +815,21 @@ Total elapsed: ~50-120ms (down from 880-1290ms).
    without visual effects.
 
 5. **AUI Repaint debounce** — Suppressed some repaints but the cascade
-   still ran through paint events.  Replaced by paint debounce on the
-   tree widget's OnPaint which breaks the cascade at its source.
+   still ran through paint events.  Replaced by total paint suppression
+   on the tree widget's OnPaint which breaks the cascade at its source.
+
+6. **Cascade is self-sustaining without mouse input** — Even with all
+   mouse events eaten by the EventFilter, the cascade continues: AUI
+   paint → GDK damage → child repaint → AUI repaint → repeat.  Each
+   tree paint of 291 items takes ~280ms.  Mouse events make it worse
+   but are not required.  Total paint suppression during `__refreshing`
+   is the only effective fix.
+
+7. **EventFilter cannot catch events during synchronous processing** —
+   During a long paint handler (~280ms), the wx event loop doesn't run,
+   so `FilterEvent` never fires.  Motion events queue in GTK and are
+   only dispatched between paints.  With total paint suppression, the
+   event loop runs freely and the filter catches all motion events.
 
 ### Open Questions
 
@@ -817,35 +837,26 @@ Total elapsed: ~50-120ms (down from 880-1290ms).
    occur with standard `wx.aui.AuiManager` (C++ implementation) or
    is it specific to the pure-Python `agw` version?
 
-2. **GDK-level mouse processing** — The EventFilter eats mouse events
-   at the wx level, but GDK processes them at the native level first.
-   More `motion_eaten` correlates with more paint events, suggesting
-   GDK native processing (possibly enter/leave → prelight state
-   changes → widget redraws) contributes to the cascade.  The paint
-   debounce makes this moot by breaking the cascade regardless.
-
 ### Key Files
 
 | File | Role |
 |------|------|
-| `taskcoachlib/widgets/treectrl.py` | `RefreshAllItems()`, `__refreshing` flag, paint debounce, `_on_refresh_idle` |
-| `taskcoachlib/widgets/frame.py` | `rebuild_guard`, `_RebuildInputFilter` (EventFilter), sash throttle |
-| `taskcoachlib/gui/viewer/base.py` | `refresh()`, `showColumn()` — uses `rebuild_guard` |
-| `taskcoachlib/gui/viewer/task.py` | `CalendarViewer.reconfig()` — uses `rebuild_guard` |
+| `taskcoachlib/widgets/treectrl.py` | `RefreshAllItems()`, `__refreshing` flag, paint suppression, `_on_refresh_idle` |
+| `taskcoachlib/widgets/frame.py` | `_RebuildInputFilter` (EventFilter with refcount + deferred release), sash throttle |
+| `taskcoachlib/gui/viewer/base.py` | `refresh()` — calls `RefreshAllItems` |
 | `taskcoachlib/meta/debug.py` | `log_step()` — timestamped debug logging |
 
 ### Diagnostics
 
-Active diagnostics (all use `log_step` with `REBUILD_GUARD` prefix):
+Active diagnostics:
 
-- **`_RebuildInputFilter`** (`frame.py`) — counts eaten motion, clicks,
-  keys, and paint events during guard
-- **`rebuild_guard`** (`frame.py`) — logs guard activation, EVT_IDLE
-  state (`_dirty` flag), and release with elapsed time and event counts
-- **`RefreshAllItems`** (`treectrl.py`) — logs start, skip (re-entry),
-  items built, and complete (when `__refreshing` cleared)
-- **Paint debounce** (`treectrl.py`) — logs count of suppressed paints
-  when the next allowed paint fires
+- **`_RebuildInputFilter`** (`frame.py`, prefix `INPUT_FILTER`) — logs
+  every motion event (eaten or passed), refcount transitions, deferred
+  release timing
+- **`RefreshAllItems`** (`treectrl.py`, prefix `REBUILD_GUARD`) — logs
+  start, items built, and complete (when `__refreshing` cleared)
+- **Paint suppression** (`treectrl.py`, prefix `REBUILD_GUARD`) — logs
+  total count of suppressed paints when `__refreshing` clears
 
 ---
 
@@ -853,13 +864,13 @@ Active diagnostics (all use `log_step` with `REBUILD_GUARD` prefix):
 
 | File | Purpose |
 |------|---------|
-| `taskcoachlib/gui/viewer/base.py` | Base viewer with `curselection()`, `onSelect()`, `onPresentationChanged()`, `rebuild_guard` usage |
-| `taskcoachlib/gui/viewer/task.py` | `CalendarViewer.reconfig()` — `rebuild_guard` usage |
+| `taskcoachlib/gui/viewer/base.py` | Base viewer with `curselection()`, `onSelect()`, `onPresentationChanged()` |
+| `taskcoachlib/gui/viewer/task.py` | `CalendarViewer.reconfig()` |
 | `taskcoachlib/gui/status.py` | Status bar with 500ms debounce |
 | `taskcoachlib/widgets/treectrl.py` | Tree widget: selection, scroll, hover, `__refreshing` debounce, paint debounce |
 | `taskcoachlib/widgets/listctrl.py` | List widget with selection handling |
 | `taskcoachlib/widgets/iconpicker.py` | Icon picker: virtual ListCtrl (`wx.LC_VIRTUAL`) for fast population |
 | `taskcoachlib/widgets/tooltip.py` | Tooltip mixin with deferred data prep |
-| `taskcoachlib/widgets/frame.py` | AUI frame, `rebuild_guard`, EventFilter input blocking, sash throttle |
+| `taskcoachlib/widgets/frame.py` | AUI frame, `_RebuildInputFilter` (EventFilter), sash throttle |
 | `taskcoachlib/patches/hypertreelist.py` | Patched upstream widget — hover outline, drag highlight |
 

--- a/docs/LOGGING_GUIDE.md
+++ b/docs/LOGGING_GUIDE.md
@@ -178,6 +178,13 @@ hypertreelist imported from: /path/to/.venv/lib/python3.X/site-packages/wx/lib/a
 
 ---
 
+## Coding Rules for Log Messages
+
+- **ASCII only** - never use Unicode em-dash, en-dash, or other non-ASCII
+  punctuation in log messages, comments, or strings.  Use the plain ASCII
+  hyphen-minus (`-`) instead.  Em-dashes cause encoding errors on Windows
+  consoles (e.g. cp932) and are not standard in source code.
+
 ## Log Prefixes
 
 - `[WXPYTHON_PATCH]`: wxPython background coloring patch (import hook and patched module)

--- a/taskcoachlib/application/application.py
+++ b/taskcoachlib/application/application.py
@@ -709,9 +709,9 @@ Break the lock?"""
 
         if i18n.Translator.hasInstance():
             log_step("FATAL ERROR: Translator already created before __init_language(). "
-                     "A module-level _() call ran before language was initialized — "
+                     "A module-level _() call ran before language was initialized - "
                      "the user's language preference was silently ignored. "
-                     "This is a programming error — fix the initialization sequence "
+                     "This is a programming error - fix the initialization sequence "
                      "so nothing calls _() before __init_language().",
                      prefix="i18n")
             sys.exit(1)

--- a/taskcoachlib/gui/icons/icon_library.py
+++ b/taskcoachlib/gui/icons/icon_library.py
@@ -383,7 +383,7 @@ class IconCatalog:
         if icon_id == _FALLBACK_ICON:
             log_step(
                 f"CRITICAL: Fallback icon '{_FALLBACK_ICON}' itself failed. "
-                f"This should never occur — the installation is broken.",
+                f"This should never occur - the installation is broken.",
                 prefix="ICON"
             )
             return None
@@ -391,7 +391,7 @@ class IconCatalog:
         if not fallback:
             log_step(
                 f"CRITICAL: Fallback icon '{_FALLBACK_ICON}' not in catalog. "
-                f"This should never occur — the installation is broken.",
+                f"This should never occur - the installation is broken.",
                 prefix="ICON"
             )
         return fallback
@@ -561,7 +561,7 @@ class IconCatalog:
         if icon.icon_id in self._icons:
             existing = self._icons[icon.icon_id]
             log_step(
-                f"ERROR: Icon ID conflict '{icon.icon_id}' — "
+                f"ERROR: Icon ID conflict '{icon.icon_id}' - "
                 f"theme '{existing.theme}' vs '{icon.theme}'. "
                 f"Keeping first, dropping second.",
                 prefix="ICON"

--- a/taskcoachlib/gui/toolbar.py
+++ b/taskcoachlib/gui/toolbar.py
@@ -84,7 +84,7 @@ class _Toolbar(aui.AuiToolBar):
             size = self.GetToolBitmapSize()
             log_step(
                 f"ERROR: Toolbar received NullBitmap at size {size[0]}x{size[1]}. "
-                f"A toolbar icon is missing this size — import it from the "
+                f"A toolbar icon is missing this size - import it from the "
                 f"distillery and update icons.json sizes. "
                 f"See ICON_LIBRARY.md Step 2.3.",
                 prefix="ICON"

--- a/taskcoachlib/gui/viewer/base.py
+++ b/taskcoachlib/gui/viewer/base.py
@@ -430,9 +430,7 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
 
     def refresh(self):
         if self and not self.__freezeCount:
-            from taskcoachlib.widgets.frame import rebuild_guard
-            with rebuild_guard(self.widget):
-                self.widget.RefreshAllItems(len(self.presentation()))
+            self.widget.RefreshAllItems(len(self.presentation()))
 
     def refreshItems(self, *items):
         if not self.__freezeCount:

--- a/taskcoachlib/gui/viewer/task.py
+++ b/taskcoachlib/gui/viewer/task.py
@@ -1152,9 +1152,7 @@ class CalendarViewer(
         self.settings.set(self.settingsSection(), "viewdate", to_save)
 
     def reconfig(self):
-        from taskcoachlib.widgets.frame import rebuild_guard
-        with rebuild_guard(self.widget):
-            self._do_reconfig()
+        self._do_reconfig()
 
     def _do_reconfig(self):
         self.widget.Freeze()

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,10 +41,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.2"  # Major.Minor.Milestone
-patch = "6"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.2.6
+patch = "7"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.2.7
 
-release_day = "8"  # Day of the release (1-31)
+release_day = "13"  # Day of the release (1-31)
 release_month = "March"  # Month of the release
 release_year = "2026"  # Year of the release
 

--- a/taskcoachlib/meta/debug.py
+++ b/taskcoachlib/meta/debug.py
@@ -40,7 +40,16 @@ def log_step(*args, prefix="DEBUG"):
     ms = int((t - int(t)) * 1000)
     timestamp = time.strftime("%H:%M:%S", time.localtime(t)) + ".%03d" % ms
     msg = " ".join(str(a) for a in args)
-    print("[%s] [%s] %s" % (timestamp, prefix, msg))
+    line = "[%s] [%s] %s" % (timestamp, prefix, msg)
+    try:
+        print(line)
+    except (UnicodeEncodeError, OSError):
+        # Fallback for consoles that can't encode the output (e.g. cp932
+        # on Japanese Windows when stdout is redirected or absent).
+        try:
+            print(line.encode("ascii", errors="replace").decode("ascii"))
+        except Exception:
+            pass
 
 
 def log_call(traceback_depth):

--- a/taskcoachlib/patterns/observer.py
+++ b/taskcoachlib/patterns/observer.py
@@ -385,7 +385,7 @@ class Publisher(object, metaclass=singleton.Singleton):
                     observer(sub_event)
                 except Exception:
                     from taskcoachlib.meta.debug import log_step
-                    log_step("Observer exception: %s on %s — removing" % (
+                    log_step("Observer exception: %s on %s - removing" % (
                         observer, sub_event.types()), prefix="OBSERVER")
                     for key in types_and_sources:
                         failed_entries.append((key, observer))

--- a/taskcoachlib/persistence/xml/reader.py
+++ b/taskcoachlib/persistence/xml/reader.py
@@ -737,13 +737,13 @@ class XMLReader(object):
                 data_node = node.find("data")
                 ext = data_node.attrib.get("extension", "") if data_node is not None else ""
                 log_step(
-                    f"WARNING: Inline attachment '{subject}' — "
+                    f"WARNING: Inline attachment '{subject}' - "
                     f"embedded file data is not supported and will be "
                     f"lost on save. Use a legacy 1.x version to extract "
                     f"and save attachments before migrating",
                     prefix="FILE",
                 )
-                location = f"(embedded {ext} — data not migrated)"
+                location = f"(embedded {ext} - data not migrated)"
 
         return self.__save_modification_datetime(
             attachment.AttachmentFactory(

--- a/taskcoachlib/tools/_numpy_probe.py
+++ b/taskcoachlib/tools/_numpy_probe.py
@@ -6,7 +6,7 @@ troubleshooting from user-submitted logs.
 
 NumPy is pinned to 1.x (>=1.26,<2) in all pip-based builds, which
 avoids the SSE4.2 baseline introduced in NumPy 2.4+. This probe is
-therefore informational only — it does not gate any runtime behavior.
+therefore informational only - it does not gate any runtime behavior.
 
 Historical context: NumPy 2.4+ requires SSE4.2 (x86_64-v2 baseline).
 On older CPUs (e.g. AMD A6-3650 with SSE4a only), importing numpy 2.4+
@@ -36,7 +36,7 @@ def _probe():
         )
         log_step(f"Subprocess returned rc={result.returncode}", prefix=_PREFIX)
         if result.returncode == 0:
-            log_step("Probe OK — numpy is functional", prefix=_PREFIX)
+            log_step("Probe OK - numpy is functional", prefix=_PREFIX)
             return True
         # POSIX: SIGILL gives returncode -4
         # Windows: nonzero returncode
@@ -46,13 +46,13 @@ def _probe():
                  prefix=_PREFIX)
         return False
     except subprocess.TimeoutExpired:
-        log_step("Probe FAILED — subprocess timed out", prefix=_PREFIX)
+        log_step("Probe FAILED - subprocess timed out", prefix=_PREFIX)
         return False
     except FileNotFoundError:
-        log_step("Probe FAILED — Python executable not found", prefix=_PREFIX)
+        log_step("Probe FAILED - Python executable not found", prefix=_PREFIX)
         return False
     except Exception as exc:
-        log_step(f"Probe FAILED — {exc}", prefix=_PREFIX)
+        log_step(f"Probe FAILED - {exc}", prefix=_PREFIX)
         return False
 
 

--- a/taskcoachlib/widgets/frame.py
+++ b/taskcoachlib/widgets/frame.py
@@ -16,8 +16,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from contextlib import contextmanager
-
 import wx
 import wx.lib.agw.aui as aui
 from taskcoachlib import operating_system
@@ -41,150 +39,54 @@ class _RebuildInputFilter(wx.EventFilter):
 
     No visual effect — no gray, no disable flicker.  Just drops
     input events so mouse movement can't drive the AUI cascade.
-    Also counts events for diagnostics.
     """
     active = False
-    count_motion_eaten = 0
-    count_keys_eaten = 0
-    count_clicks_eaten = 0
-    count_paint = 0
+    _refcount = 0
+    _release_timer = None
 
     def FilterEvent(self, event):
+        if not self.active:
+            return self.Event_Skip
         etype = event.GetEventType()
-        if self.active:
-            if etype == wx.wxEVT_MOTION:
-                self.count_motion_eaten += 1
-                return self.Event_Processed
-            if etype in _INPUT_EVENTS:
-                if etype in (wx.wxEVT_KEY_DOWN, wx.wxEVT_KEY_UP,
-                             wx.wxEVT_CHAR, wx.wxEVT_CHAR_HOOK):
-                    self.count_keys_eaten += 1
-                else:
-                    self.count_clicks_eaten += 1
-                return self.Event_Processed
-            if etype == wx.wxEVT_PAINT:
-                self.count_paint += 1
+        if etype in _INPUT_EVENTS:
+            return self.Event_Processed
         return self.Event_Skip
 
-    def reset_counts(self):
-        self.count_motion_eaten = 0
-        self.count_keys_eaten = 0
-        self.count_clicks_eaten = 0
-        self.count_paint = 0
+    def acquire(self):
+        """Called at start of each RefreshAllItems."""
+        if self._release_timer is not None:
+            self._release_timer.Stop()
+            self._release_timer = None
+        self._refcount += 1
+        self.active = True
+
+    def release(self):
+        """Called when a widget's refresh idle completes.
+
+        Decrements refcount.  When all widgets done, schedules a
+        deferred deactivation (1s) to cover the post-rebuild cascade.
+        """
+        self._refcount = max(0, self._refcount - 1)
+        if self._refcount == 0:
+            self._release_timer = wx.CallLater(
+                1000, self._deferred_release,
+            )
+
+    def _deferred_release(self):
+        self._release_timer = None
+        if self._refcount == 0:
+            self.active = False
 
 
 _input_filter = _RebuildInputFilter()
 _filter_installed = False
 
-_rebuild_guard_state = {
-    'idle_bound': False,
-    'widget': None,
-    'acquire_time': 0.0,
-    'post_dirty': False,
-}
 
-
-def _rebuild_guard_on_idle(event):
-    """EVT_IDLE handler — stop blocking input when widget is done.
-
-    Waits one extra idle cycle after _dirty=False because
-    OnInternalIdle sets _dirty=False then calls Refresh() which
-    queues a paint.  The extra cycle lets that paint process before
-    we re-enable input.
-    """
-    import time
-    st = _rebuild_guard_state
-    from taskcoachlib.meta.debug import log_step
-
-    if _input_filter.active:
-        widget = st['widget']
-        elapsed_ms = (time.monotonic() - st['acquire_time']) * 1000
-
-        # Extra cycle after _dirty=False — paint from Refresh() should be done
-        if st['post_dirty']:
-            f = _input_filter
-            log_step('EVT_IDLE — releasing  elapsed=%.0fms  '
-                     'motion_eaten=%d clicks_eaten=%d keys_eaten=%d paint=%d'
-                     % (elapsed_ms, f.count_motion_eaten, f.count_clicks_eaten,
-                        f.count_keys_eaten, f.count_paint),
-                     prefix='REBUILD_GUARD')
-            _input_filter.active = False
-            st['widget'] = None
-            st['post_dirty'] = False
-        else:
-            # Check if the tree widget still has pending layout work
-            dirty = False
-            if widget is not None:
-                main_win = getattr(widget, 'GetMainWindow', lambda: None)()
-                if main_win is not None:
-                    dirty = getattr(main_win, '_dirty', False)
-                    log_step('EVT_IDLE — _dirty=%s  elapsed=%.0fms'
-                             % (dirty, elapsed_ms), prefix='REBUILD_GUARD')
-                else:
-                    log_step('EVT_IDLE — no main_win (calendar?)  elapsed=%.0fms'
-                             % elapsed_ms, prefix='REBUILD_GUARD')
-            else:
-                log_step('EVT_IDLE — no widget  elapsed=%.0fms'
-                         % elapsed_ms, prefix='REBUILD_GUARD')
-
-            if dirty:
-                event.RequestMore()
-                event.Skip()
-                return
-
-            # _dirty=False — wait one more cycle for paint to process
-            log_step('EVT_IDLE — _dirty=False, waiting one more cycle  elapsed=%.0fms'
-                     % elapsed_ms, prefix='REBUILD_GUARD')
-            st['post_dirty'] = True
-            event.RequestMore()
-            event.Skip()
-            return
-
-    if st['idle_bound']:
-        wx.GetApp().Unbind(wx.EVT_IDLE, handler=_rebuild_guard_on_idle)
-        st['idle_bound'] = False
-    event.Skip()
-
-
-@contextmanager
-def rebuild_guard(widget=None):
-    """Block input during rebuild, release when widget is done.
-
-    Activates an EventFilter that silently eats mouse and keyboard
-    events.  On exit, binds EVT_IDLE and checks the widget's _dirty
-    flag.  When _dirty is False + one extra idle cycle (for the paint
-    from OnInternalIdle's Refresh()), re-enables input.
-    No visual effect — no gray, no flicker.
-    """
-    import time
-    st = _rebuild_guard_state
-    from taskcoachlib.meta.debug import log_step
-    if not _input_filter.active:
-        global _filter_installed
-        if not _filter_installed:
-            wx.EvtHandler.AddFilter(_input_filter)
-            _filter_installed = True
-            log_step('EventFilter installed', prefix='REBUILD_GUARD')
-        _input_filter.reset_counts()
-        _input_filter.active = True
-        st['acquire_time'] = time.monotonic()
-        st['widget'] = widget
-        log_step('Input blocked  widget=%s'
-                 % (type(widget).__name__ if widget else 'None'),
-                 prefix='REBUILD_GUARD')
-    try:
-        yield
-    finally:
-        if not st['idle_bound']:
-            wx.GetApp().Bind(wx.EVT_IDLE, _rebuild_guard_on_idle)
-            st['idle_bound'] = True
-            dirty = None
-            if widget is not None:
-                main_win = getattr(widget, 'GetMainWindow', lambda: None)()
-                if main_win is not None:
-                    dirty = getattr(main_win, '_dirty', None)
-            log_step('EVT_IDLE bound — _dirty=%s  waiting for widget done'
-                     % dirty, prefix='REBUILD_GUARD')
+def _ensure_filter_installed():
+    global _filter_installed
+    if not _filter_installed:
+        wx.EvtHandler.AddFilter(_input_filter)
+        _filter_installed = True
 
 
 def _install_sash_resize_optimization(manager):
@@ -198,26 +100,26 @@ def _install_sash_resize_optimization(manager):
     import time
 
     original_on_motion = getattr(manager, 'OnMotion', None)
+    if not original_on_motion:
+        return
 
     # Throttle state
-    state = {
-        'last_update_time': 0,
-        'min_update_interval': 0.033,  # ~30fps max update rate
-    }
+    min_interval = 0.033  # ~30fps max update rate
+    last_update_time = 0
 
     # Throttle updates during sash drag
-    if original_on_motion:
-        def throttled_on_motion(event):
-            action = getattr(manager, '_action', 0)
-            # action 3 = actionResize (sash drag)
-            if action == 3:
-                now = time.time()
-                if now - state['last_update_time'] < state['min_update_interval']:
-                    # Skip this update - don't call Skip() to prevent other handlers
-                    return
-                state['last_update_time'] = now
-            return original_on_motion(event)
-        manager.OnMotion = throttled_on_motion
+    def throttled_on_motion(event):
+        nonlocal last_update_time
+        action = getattr(manager, '_action', 0)
+        # action 3 = actionResize (sash drag)
+        if action == 3:
+            now = time.time()
+            if now - last_update_time < min_interval:
+                return
+            last_update_time = now
+        return original_on_motion(event)
+
+    manager.OnMotion = throttled_on_motion
 
 
 class AuiManagedFrameWithDynamicCenterPane(wx.Frame):

--- a/taskcoachlib/widgets/treectrl.py
+++ b/taskcoachlib/widgets/treectrl.py
@@ -70,7 +70,9 @@ class BaseHyperTreeList(hypertreelist.HyperTreeList):
                     self.scrollToSelectionCentered()
         except RuntimeError:
             # wrapped C/C++ object has been deleted
-            pass
+            from taskcoachlib.meta.debug import log_step
+            log_step('__onSize failed - widget already destroyed',
+                     prefix='DEAD-OBJ')
 
 
 class HyperTreeList(draganddrop.TreeCtrlDragAndDropMixin, BaseHyperTreeList):
@@ -97,7 +99,9 @@ class HyperTreeList(draganddrop.TreeCtrlDragAndDropMixin, BaseHyperTreeList):
                 self.MainWindow.Refresh()
         except RuntimeError:
             # wrapped C/C++ object has been deleted
-            pass
+            from taskcoachlib.meta.debug import log_step
+            log_step('__safeRefresh failed - widget already destroyed',
+                     prefix='DEAD-OBJ')
 
     def GetSelections(self):  # pylint: disable=C0103
         """If the root item is hidden, it should never be selected.
@@ -218,7 +222,8 @@ class TreeListCtrl(
         self.__user_double_clicked = False
         self.__columns_with_images = []
         self.__default_font = wx.NORMAL_FONT
-        self.__refreshing = False  # Flag to suppress selection events during refresh
+        self.__refreshing = False
+        self.__post_dirty = False
         kwargs.setdefault("resizeableColumn", 0)
         super().__init__(
             parent,
@@ -263,60 +268,24 @@ class TreeListCtrl(
         event.Skip()
 
     def _install_paint_debounce(self):
-        """Debounce the tree widget's OnPaint during refresh only.
+        """Suppress ALL cascade paints during refresh.
 
-        Only active while __refreshing is True.  During refresh, the
-        first paint goes through immediately, then subsequent cascade
-        paints are suppressed for 100ms intervals.  A deferred Refresh()
-        ensures the final state is rendered after the cascade settles.
-        Normal paints (hover, scroll, etc.) are never affected.
+        While __refreshing is True, every paint is suppressed with an
+        empty PaintDC (validates the GDK region to prevent infinite
+        expose loops).  When __refreshing clears, normal paints resume
+        and _on_refresh_idle triggers one clean Refresh().
         """
-        import time
         main_win = self.GetMainWindow()
         original_on_paint = main_win.OnPaint
         tree_ctrl = self
-        _state = {
-            'last_paint': 0.0,
-            'suppressed': 0,
-            'deferred': False,
-        }
-
-        def _do_deferred():
-            _state['deferred'] = False
-            try:
-                main_win.Refresh()
-            except RuntimeError:
-                pass  # C++ object deleted
 
         def debounced_on_paint(event):
-            # Only debounce during refresh — normal paints pass through
             if not tree_ctrl.refreshing:
-                _state['last_paint'] = 0.0  # Reset for next refresh
                 original_on_paint(event)
                 return
-            now = time.monotonic()
-            elapsed = now - _state['last_paint']
-            if elapsed < 0.100:
-                # Too soon — validate the region without drawing
-                dc = wx.PaintDC(main_win)
-                del dc
-                _state['suppressed'] += 1
-                # Schedule a deferred repaint so final state is rendered
-                if not _state['deferred']:
-                    _state['deferred'] = True
-                    remaining = max(1, int((0.100 - elapsed) * 1000) + 5)
-                    wx.CallLater(remaining, _do_deferred)
-                return
-            if _state['suppressed'] > 0:
-                from taskcoachlib.meta.debug import log_step
-                log_step('Paint debounce: %d suppressed in %.0fms'
-                         % (_state['suppressed'],
-                            (now - _state['last_paint']) * 1000),
-                         prefix='REBUILD_GUARD')
-                _state['suppressed'] = 0
-            _state['last_paint'] = now
-            _state['deferred'] = False
-            original_on_paint(event)
+            # During refresh: suppress ALL paints
+            dc = wx.PaintDC(main_win)
+            del dc
 
         main_win.Bind(wx.EVT_PAINT, debounced_on_paint)
 
@@ -351,19 +320,17 @@ class TreeListCtrl(
     @property
     def refreshing(self):
         """True while a rebuild is in progress (items being rebuilt or
-        widget still has pending layout work).  Used to debounce
-        cascade-triggered re-entries and suppress selection events."""
+        widget still has pending layout work).  Used by paint debounce
+        and selection suppression — NOT as a re-entry guard."""
         return self.__refreshing
 
     def RefreshAllItems(self, count=0):  # pylint: disable=W0613
-        from taskcoachlib.meta.debug import log_step
-        if self.__refreshing:
-            log_step('RefreshAllItems skipped — already refreshing',
-                     prefix='REBUILD_GUARD')
-            return
+        from taskcoachlib.widgets.frame import (
+            _input_filter, _ensure_filter_installed,
+        )
+        _ensure_filter_installed()
+        _input_filter.acquire()
         self.__refreshing = True
-        log_step('RefreshAllItems started  count=%d' % count,
-                 prefix='REBUILD_GUARD')
         self.Freeze()
         self.StopEditing()
         self.__selection = self.curselection()
@@ -382,39 +349,48 @@ class TreeListCtrl(
         if self.__selection:
             self.select(self.__selection)
         self.scrollToSelection()
-        # Don't call Refresh() here — let OnInternalIdle handle the
-        # single repaint when _dirty is processed.  Calling Refresh()
-        # immediately triggers the GTK3 AUI repaint cascade.
-        #
         # __refreshing stays True until _dirty is processed on idle.
-        # This debounces any cascade-triggered re-entries.
+        # Input filter also stays active until then.
         self._bind_refresh_complete()
-        log_step('RefreshAllItems items built — waiting for idle paint',
-                 prefix='REBUILD_GUARD')
 
     def _bind_refresh_complete(self):
         """Bind EVT_IDLE to detect when the widget has finished painting."""
         wx.GetApp().Bind(wx.EVT_IDLE, self._on_refresh_idle)
 
     def _on_refresh_idle(self, event):
-        """Release __refreshing when the widget is done painting."""
-        from taskcoachlib.meta.debug import log_step
+        """Release __refreshing and input filter when done painting.
+
+        Waits one extra idle cycle after _dirty=False because
+        OnInternalIdle sets _dirty=False then calls Refresh() which
+        queues a paint.  The extra cycle lets that paint process
+        (and motion events get filtered) before we re-enable input.
+        """
+        from taskcoachlib.widgets.frame import _input_filter
         main_win = self.GetMainWindow()
         dirty = getattr(main_win, '_dirty', False)
         if dirty:
             event.RequestMore()
             event.Skip()
             return
-        # Widget layout is done — clear refreshing flag
+        # _dirty=False — check if we already waited the extra cycle
+        if not self.__post_dirty:
+            self.__post_dirty = True
+            event.RequestMore()
+            event.Skip()
+            return
+        # Extra cycle done — this widget is done
         self.__refreshing = False
+        self.__post_dirty = False
+        _input_filter.release()
         wx.GetApp().Unbind(wx.EVT_IDLE, handler=self._on_refresh_idle)
-        log_step('RefreshAllItems complete — __refreshing cleared',
-                 prefix='REBUILD_GUARD')
-        # Trigger one clean repaint now that positions are calculated
+        # One clean paint now that positions are calculated
         try:
-            self.GetMainWindow().Refresh()
+            main_win.Refresh()
         except RuntimeError:
-            pass
+            # wrapped C/C++ object has been deleted
+            from taskcoachlib.meta.debug import log_step
+            log_step('Refresh() failed - widget already destroyed',
+                     prefix='DEAD-OBJ')
         event.Skip()
 
     def scrollToSelection(self):
@@ -587,7 +563,9 @@ class TreeListCtrl(
                 self.selectCommand()
         except RuntimeError:
             # wrapped C/C++ object has been deleted
-            pass
+            from taskcoachlib.meta.debug import log_step
+            log_step('selectCommand() failed - widget already destroyed',
+                     prefix='DEAD-OBJ')
 
     def onKeyDown(self, event):
         if event.GetKeyCode() == wx.WXK_RETURN:
@@ -620,7 +598,9 @@ class TreeListCtrl(
                     self._expandDropTarget(drop_item)
         except RuntimeError:
             # wrapped C/C++ object has been deleted
-            pass
+            from taskcoachlib.meta.debug import log_step
+            log_step('dragAndDropCommand failed - widget already destroyed',
+                     prefix='DEAD-OBJ')
 
     def _expandDropTarget(self, drop_item):
         """Expand the drop target item so the dropped children are visible."""


### PR DESCRIPTION
Replace the rebuild_guard context manager with a self-contained 3-layer architecture in treectrl/frame:

1. Paint suppression: suppress ALL tree paints during refresh with empty PaintDC (breaks the self-sustaining AUI cascade where each 280ms tree paint triggers GDK damage → child repaint → repeat). One clean Refresh() fires when __refreshing clears.

2. Per-widget idle lifecycle: each RefreshAllItems binds its own EVT_IDLE handler that monitors _dirty + one extra cycle, then clears __refreshing and releases the input filter.

3. Refcounted EventFilter: each widget acquire()s on rebuild start and release()s on idle completion.  Last widget triggers a 1s deferred deactivation to cover the post-rebuild settling period.

Also:
- Remove rebuild_guard from viewer.refresh() and CalendarViewer.reconfig()
- Remove dead code: rebuild_guard, _rebuild_guard_state, idle handler, contextmanager import from frame.py
- Log all silent 'except RuntimeError: pass' via DEAD-OBJ prefix
- Harden log_step() for Windows consoles (UnicodeEncodeError)
- Replace em-dash with ASCII dash in log messages for portability
- Use nonlocal instead of dict hack in sash throttle closure
- Update LIST_MANAGEMENT.md with current architecture and 12 failed approaches

Error on startup with new installation on Windows #406