### PR TITLE
Update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Full history for version info
 
@@ -365,7 +365,7 @@ jobs:
           echo "All tests passed!"
 
       - name: Upload AppImage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: TaskCoach-AppImage-${{ steps.version.outputs.version }}
           path: TaskCoach-*.AppImage

--- a/.github/workflows/build-arch.yml
+++ b/.github/workflows/build-arch.yml
@@ -45,7 +45,7 @@ jobs:
           echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -164,7 +164,7 @@ jobs:
           ls -la artifacts/
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: taskcoach-${{ steps.version.outputs.version }}-arch-linux
           path: artifacts/

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -62,7 +62,7 @@ jobs:
           apt-get install -y git ca-certificates
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -178,7 +178,7 @@ jobs:
           ls -la artifacts/
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: taskcoach-${{ steps.version.outputs.version }}-${{ matrix.os }}-${{ matrix.osver }}-${{ matrix.codename }}
           path: artifacts/

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -314,7 +314,7 @@ jobs:
           ls -la *.dmg
 
       - name: Upload DMG artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: TaskCoach-macos-${{ matrix.suffix }}-${{ steps.version.outputs.version }}
           path: TaskCoach-*.dmg

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -46,7 +46,7 @@ jobs:
           dnf install -y git rpm-build rpmdevtools dnf-plugins-core
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -151,7 +151,7 @@ jobs:
           ls -la artifacts/
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: taskcoach-${{ steps.version.outputs.version }}-${{ matrix.os }}-${{ matrix.osver }}
           path: artifacts/

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -375,7 +375,7 @@ jobs:
           ls -la build/TaskCoach/ | head -20
 
       - name: Upload installer artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: TaskCoach-windows-${{ matrix.suffix }}-installer-${{ steps.version.outputs.version }}
           path: dist/TaskCoach-*.exe
@@ -392,7 +392,7 @@ jobs:
           ls -la *.zip
 
       - name: Upload portable artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: TaskCoach-windows-${{ matrix.suffix }}-portable-${{ steps.version.outputs.version }}
           path: TaskCoach-*-portable.zip


### PR DESCRIPTION
- actions/checkout v4 -> v5
- actions/upload-artifact v4 -> v6

Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 2, 2026.