### PR TITLE
Narrow EventFilter to motion events only, pass clicks and keyboard

### DIFF
--- a/docs/LIST_MANAGEMENT.md
+++ b/docs/LIST_MANAGEMENT.md
@@ -750,14 +750,17 @@ clean paint with correct item positions (after `CalculatePositions()`).
 `RefreshAllItems` calls can overlap.  It only drives paint suppression
 and selection event suppression.
 
-**3. EventFilter input blocking** (`frame.py`):
+**3. EventFilter motion blocking** (`frame.py`):
 `_RebuildInputFilter` is a `wx.EventFilter` that silently eats mouse
-and keyboard events at the wx level.  No visual effect (no gray, no
-flicker).  Each `RefreshAllItems` call increments a refcount via
-`acquire()`; each `_on_refresh_idle` decrements via `release()`.  When
-the last widget completes, a 1-second deferred release timer starts to
-cover the post-rebuild settling period.  If a new rebuild starts during
-the settling, the timer is cancelled and the filter stays active.
+**motion** events (MOTION, ENTER_WINDOW, LEAVE_WINDOW) at the wx level.
+Clicks, keyboard, and scroll events pass through normally so the app
+stays responsive.  Only motion events are suppressed because they drive
+the AUI cascade (OnMotion -> hover state change -> repaint -> repeat).
+Each `RefreshAllItems` call increments a refcount via `acquire()`; each
+`_on_refresh_idle` decrements via `release()`.  When the last widget
+completes, a 1-second deferred release timer starts to cover the
+post-rebuild settling period.  If a new rebuild starts during the
+settling, the timer is cancelled and the filter stays active.
 
 ### How the layers work together
 
@@ -773,7 +776,7 @@ RefreshAllItems()
     │   ├── __refreshing = False  (paint suppression deactivates)
     │   ├── _input_filter.release()  (refcount--, deferred release if 0)
     │   └── Refresh() → ONE clean paint with correct positions
-    └── 1s later: filter deactivates (mouse/keyboard resume)
+    └── 1s later: filter deactivates (motion events resume)
 ```
 
 Total elapsed: rebuild ~80ms + CalculatePositions + one paint ~280ms.
@@ -794,7 +797,8 @@ Cascade eliminated (down from 1.4+ seconds with 5+ cascade paints).
 | 9 | Remove `__refreshing` re-entry guard entirely | Empty lists on startup — legitimate refresh calls during 703ms idle wait were no longer blocked, but without `__refreshing` flag the paint debounce and selection suppression also stopped working |
 | 10 | Paint throttle 1-per-100ms during `__refreshing` | Each cascade paint takes ~280ms (291 items), so paints are always >100ms apart — throttle never triggers. Cascade runs unimpeded. Only total suppression (zero paints during refresh) breaks the cycle |
 | 11 | Per-widget EventFilter release (each `_on_refresh_idle` sets `active=False`) | First widget to finish clears the filter while other widgets still need it. Global singleton filter requires refcount + deferred release |
-| 12 | `__refreshing` as re-entry guard for `RefreshAllItems` | Blocks legitimate refresh calls for 703ms during idle wait, causing empty lists on startup. Removed re-entry guard — `__refreshing` now only drives paint suppression and selection suppression |
+| 12 | `__refreshing` as re-entry guard for `RefreshAllItems` | Blocks legitimate refresh calls for 703ms during idle wait, causing empty lists on startup. Removed re-entry guard - `__refreshing` now only drives paint suppression and selection suppression |
+| 13 | EventFilter eating ALL input (clicks, keyboard, scroll, motion) | Clicks and keyboard events lost during rebuild + 1s settling period makes the app feel unresponsive. Only motion events drive the AUI cascade; clicks and keyboard do not. Narrowed filter to motion events only |
 
 ### Resolved Questions
 

--- a/taskcoachlib/widgets/frame.py
+++ b/taskcoachlib/widgets/frame.py
@@ -21,24 +21,24 @@ import wx.lib.agw.aui as aui
 from taskcoachlib import operating_system
 
 
-# --- Rebuild guard: block input during list/tree rebuilds ---
+# --- Rebuild guard: block motion events during list/tree rebuilds ---
 
-# Mouse and keyboard event types to eat during rebuild
-_INPUT_EVENTS = {
-    wx.wxEVT_LEFT_DOWN, wx.wxEVT_LEFT_UP, wx.wxEVT_LEFT_DCLICK,
-    wx.wxEVT_RIGHT_DOWN, wx.wxEVT_RIGHT_UP, wx.wxEVT_RIGHT_DCLICK,
-    wx.wxEVT_MIDDLE_DOWN, wx.wxEVT_MIDDLE_UP, wx.wxEVT_MIDDLE_DCLICK,
-    wx.wxEVT_MOTION, wx.wxEVT_MOUSEWHEEL,
+# Motion event types to eat during rebuild.  Only motion events are
+# suppressed - clicks, keyboard, and scroll are passed through so
+# the app remains responsive.  Motion events drive the AUI cascade
+# (OnMotion -> hover -> repaint -> repeat) and must be suppressed.
+_MOTION_EVENTS = {
+    wx.wxEVT_MOTION,
     wx.wxEVT_ENTER_WINDOW, wx.wxEVT_LEAVE_WINDOW,
-    wx.wxEVT_KEY_DOWN, wx.wxEVT_KEY_UP, wx.wxEVT_CHAR, wx.wxEVT_CHAR_HOOK,
 }
 
 
 class _RebuildInputFilter(wx.EventFilter):
-    """Silently eat mouse and keyboard events during rebuild.
+    """Silently eat mouse motion events during rebuild.
 
-    No visual effect — no gray, no disable flicker.  Just drops
-    input events so mouse movement can't drive the AUI cascade.
+    No visual effect - no gray, no disable flicker.  Just drops
+    motion events so mouse movement can't drive the AUI cascade.
+    Clicks, keyboard, and scroll events pass through normally.
     """
     active = False
     _refcount = 0
@@ -47,8 +47,7 @@ class _RebuildInputFilter(wx.EventFilter):
     def FilterEvent(self, event):
         if not self.active:
             return self.Event_Skip
-        etype = event.GetEventType()
-        if etype in _INPUT_EVENTS:
+        if event.GetEventType() in _MOTION_EVENTS:
             return self.Event_Processed
         return self.Event_Skip
 


### PR DESCRIPTION
The input filter was eating all mouse, keyboard, and scroll events during rebuild + 1s settling period, making the app feel unresponsive (lost clicks, lost keystrokes).  Only motion events drive the AUI cascade (OnMotion -> hover -> repaint -> repeat).  Clicks, keyboard, and scroll do not contribute to the cascade and should pass through.

Narrowed _MOTION_EVENTS to wxEVT_MOTION, wxEVT_ENTER_WINDOW, wxEVT_LEAVE_WINDOW only.  Updated LIST_MANAGEMENT.md with the abandoned approach (#13) and revised architecture description.