### PR TITLE
Fix sort oscillation, skip redundant tree rebuilds, PEP 8 renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.7-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.7-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.7_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.7_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.7_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.7-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.8-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.8-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.8_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.8_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.8_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.8-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.7-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.7-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.7_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.7_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.2.7-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.2.7-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.8-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.8-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.8_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.8_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.2.8-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.2.8-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.7_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.2.7_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.8_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.2.8_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.7-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.2.7-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.8-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.2.8-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.7-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.2.7-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.8-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.2.8-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.7-x86_64.AppImage
-chmod +x TaskCoach-2.0.2.7-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.8-x86_64.AppImage
+chmod +x TaskCoach-2.0.2.8-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.2.7-x86_64.AppImage
+./TaskCoach-2.0.2.8-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/docs/LIST_MANAGEMENT.md
+++ b/docs/LIST_MANAGEMENT.md
@@ -750,14 +750,17 @@ clean paint with correct item positions (after `CalculatePositions()`).
 `RefreshAllItems` calls can overlap.  It only drives paint suppression
 and selection event suppression.
 
-**3. EventFilter input blocking** (`frame.py`):
+**3. EventFilter motion blocking** (`frame.py`):
 `_RebuildInputFilter` is a `wx.EventFilter` that silently eats mouse
-and keyboard events at the wx level.  No visual effect (no gray, no
-flicker).  Each `RefreshAllItems` call increments a refcount via
-`acquire()`; each `_on_refresh_idle` decrements via `release()`.  When
-the last widget completes, a 1-second deferred release timer starts to
-cover the post-rebuild settling period.  If a new rebuild starts during
-the settling, the timer is cancelled and the filter stays active.
+**motion** events (MOTION, ENTER_WINDOW, LEAVE_WINDOW) at the wx level.
+Clicks, keyboard, and scroll events pass through normally so the app
+stays responsive.  Only motion events are suppressed because they drive
+the AUI cascade (OnMotion -> hover state change -> repaint -> repeat).
+Each `RefreshAllItems` call increments a refcount via `acquire()`; each
+`_on_refresh_idle` decrements via `release()`.  When the last widget
+completes, a 1-second deferred release timer starts to cover the
+post-rebuild settling period.  If a new rebuild starts during the
+settling, the timer is cancelled and the filter stays active.
 
 ### How the layers work together
 
@@ -773,7 +776,7 @@ RefreshAllItems()
     │   ├── __refreshing = False  (paint suppression deactivates)
     │   ├── _input_filter.release()  (refcount--, deferred release if 0)
     │   └── Refresh() → ONE clean paint with correct positions
-    └── 1s later: filter deactivates (mouse/keyboard resume)
+    └── 1s later: filter deactivates (motion events resume)
 ```
 
 Total elapsed: rebuild ~80ms + CalculatePositions + one paint ~280ms.
@@ -794,7 +797,8 @@ Cascade eliminated (down from 1.4+ seconds with 5+ cascade paints).
 | 9 | Remove `__refreshing` re-entry guard entirely | Empty lists on startup — legitimate refresh calls during 703ms idle wait were no longer blocked, but without `__refreshing` flag the paint debounce and selection suppression also stopped working |
 | 10 | Paint throttle 1-per-100ms during `__refreshing` | Each cascade paint takes ~280ms (291 items), so paints are always >100ms apart — throttle never triggers. Cascade runs unimpeded. Only total suppression (zero paints during refresh) breaks the cycle |
 | 11 | Per-widget EventFilter release (each `_on_refresh_idle` sets `active=False`) | First widget to finish clears the filter while other widgets still need it. Global singleton filter requires refcount + deferred release |
-| 12 | `__refreshing` as re-entry guard for `RefreshAllItems` | Blocks legitimate refresh calls for 703ms during idle wait, causing empty lists on startup. Removed re-entry guard — `__refreshing` now only drives paint suppression and selection suppression |
+| 12 | `__refreshing` as re-entry guard for `RefreshAllItems` | Blocks legitimate refresh calls for 703ms during idle wait, causing empty lists on startup. Removed re-entry guard - `__refreshing` now only drives paint suppression and selection suppression |
+| 13 | EventFilter eating ALL input (clicks, keyboard, scroll, motion) | Clicks and keyboard events lost during rebuild + 1s settling period makes the app feel unresponsive. Only motion events drive the AUI cascade; clicks and keyboard do not. Narrowed filter to motion events only |
 
 ### Resolved Questions
 
@@ -836,6 +840,34 @@ Cascade eliminated (down from 1.4+ seconds with 5+ cascade paints).
 1. **Is the cascade specific to `agw.aui`?**  Would the cascade also
    occur with standard `wx.aui.AuiManager` (C++ implementation) or
    is it specific to the pure-Python `agw` version?
+
+2. **Full rebuild on every editor field change** - Editing any field
+   in the task or category editor (even subject, notes, colors) triggers
+   a full `RefreshAllItems` rebuild of every tree view.  The tree is not
+   virtual - each rebuild deletes all nodes and recreates them (text,
+   colors, fonts, images for every item and column).  For 291 items
+   with 8 columns this is ~2300 text lookups + 291 color/font
+   computations + a 280ms paint.
+
+   The tree already has per-item `RefreshItems()` that updates just the
+   changed rows in place (text, colors, font, repaint line).  The
+   filter's `reset()` and sorter's `reset()` both check whether the
+   result actually changed before firing events.  But something in the
+   event chain still triggers a full rebuild on every edit.  Need caller
+   tracing to identify the exact path.
+
+   User request: "Why every time that I change a value in the edit task
+   window, all lists in my views flicker, seems like they are being
+   fully rebuilt" and "same thing for each time I edit values of a
+   category" and "Any fields, even a task or category subject."
+
+   Ideal fix: attribute changes that don't affect sort order or filter
+   membership should use per-item `RefreshItems()` only, never a full
+   `RefreshAllItems()` rebuild.  The list control (`wx.LC_VIRTUAL`) is
+   already virtual and cheap to refresh.  The tree control
+   (`HyperTreeList`) is not virtual and cannot reorder nodes in place -
+   it has no `MoveItem()` API - so sort order changes do require a full
+   rebuild, but non-sort attribute changes should not.
 
 ### Key Files
 

--- a/taskcoachlib/domain/base/sorter.py
+++ b/taskcoachlib/domain/base/sorter.py
@@ -27,8 +27,8 @@ class Sorter(patterns.ListDecorator):
         self._sortKeys = kwargs.pop("sortBy", ["subject"])
         self._sortCaseSensitive = kwargs.pop("sortCaseSensitive", True)
         super().__init__(*args, **kwargs)
-        for sortKey in self._sortKeys:
-            self._registerObserverForAttribute(sortKey.lstrip("-"))
+        for sort_key in self._sortKeys:
+            self._registerObserverForAttribute(sort_key.lstrip("-"))
         self.reset()
 
     def thaw(self):
@@ -38,11 +38,11 @@ class Sorter(patterns.ListDecorator):
 
     def detach(self):
         super().detach()
-        for sortKey in self._sortKeys:
-            self._removeObserverForAttribute(sortKey.lstrip("-"))
+        for sort_key in self._sortKeys:
+            self._removeObserverForAttribute(sort_key.lstrip("-"))
 
     @classmethod
-    def sortEventType(cls):
+    def sort_event_type(cls):
         return "pubsub.%s.sorted" % cls.__name__
 
     @patterns.eventSource
@@ -50,97 +50,108 @@ class Sorter(patterns.ListDecorator):
         super().extendSelf(items, event)
         self.reset()
 
-    def isAscending(self):
+    def is_ascending(self):
         if self._sortKeys:
             return not self._sortKeys[0].startswith("-")
         return True
 
-    def sortKeys(self):
+    def sort_keys(self):
         return self._sortKeys
 
     # We don't implement removeItemsFromSelf() because there is no need
     # to resort when items are removed since after removing items the
     # remaining items are still in the right order.
 
-    def sortBy(self, sortKey):
-        if self._sortKeys and self._sortKeys[0] == sortKey:
-            if sortKey == "ordering":
+    def sort_by(self, sort_key):
+        if self._sortKeys and self._sortKeys[0] == sort_key:
+            if sort_key == "ordering":
                 return
-            self._sortKeys[0] = "-" + sortKey
-        elif self._sortKeys and self._sortKeys[0] == "-" + sortKey:
-            self._sortKeys[0] = sortKey
-        elif self._sortKeys and sortKey in self._sortKeys:
-            self._sortKeys.remove(sortKey)
-            self._sortKeys.insert(0, sortKey)
-        elif self._sortKeys and ("-" + sortKey) in self._sortKeys:
-            self._sortKeys.remove("-" + sortKey)
-            self._sortKeys.insert(0, sortKey)
+            self._sortKeys[0] = "-" + sort_key
+        elif self._sortKeys and self._sortKeys[0] == "-" + sort_key:
+            self._sortKeys[0] = sort_key
+        elif self._sortKeys and sort_key in self._sortKeys:
+            self._sortKeys.remove(sort_key)
+            self._sortKeys.insert(0, sort_key)
+        elif self._sortKeys and ("-" + sort_key) in self._sortKeys:
+            self._sortKeys.remove("-" + sort_key)
+            self._sortKeys.insert(0, sort_key)
         else:
-            self._sortKeys.insert(0, sortKey)
-            self._registerObserverForAttribute(sortKey)
+            self._sortKeys.insert(0, sort_key)
+            self._registerObserverForAttribute(sort_key)
 
         self.reset()
 
-    def sortCaseSensitive(self, sortCaseSensitive):
-        self._sortCaseSensitive = sortCaseSensitive
+    def sort_case_sensitive(self, sort_case_sensitive):
+        self._sortCaseSensitive = sort_case_sensitive
         self.reset()
 
-    def sortAscending(self, ascending=True):
+    def sort_ascending(self, ascending=True):
         if self._sortKeys:
             if (ascending and self._sortKeys[0].startswith("-")) or (
                 not ascending and not self._sortKeys[0].startswith("-")
             ):
-                self.sortBy(self._sortKeys[0].lstrip("-"))
+                self.sort_by(self._sortKeys[0].lstrip("-"))
 
-    def reset(self, forceEvent=False):
+    def reset(self, force_event=False):
         """reset does the actual sorting. If the order of the list changes,
         observers are notified by means of the list-sorted event."""
         if self.isFrozen():
             return
 
-        oldSelf = self[:]
+        old_self = self[:]
         # XXXTODO: create only one function with all keys ? Reversing may
         # be problematic.
-        for sortKey in reversed(self._sortKeys):
+        # UUID tiebreaker first (least significant) - guarantees
+        # deterministic ordering for items with equal sort keys.
+        self.sort(key=lambda item: item.id())
+        for sort_key in reversed(self._sortKeys):
             self.sort(
-                key=self.createSortKeyFunction(sortKey.lstrip("-")),
-                reverse=sortKey.startswith("-"),
+                key=self.create_sort_key_function(sort_key.lstrip("-")),
+                reverse=sort_key.startswith("-"),
             )
-        if forceEvent or self != oldSelf:
-            pub.sendMessage(self.sortEventType(), sender=self)
+        if force_event or self != old_self:
+            pub.sendMessage(self.sort_event_type(), sender=self)
 
-    def createSortKeyFunction(self, sortKey):
-        """createSortKeyFunction returns a function that is passed to the
+    def create_sort_key_function(self, sort_key):
+        """create_sort_key_function returns a function that is passed to the
         builtin list.sort method to extract the sort key from each element
         in the list. We expect the domain object class to provide a
         <sortKey>SortFunction(sortCaseSensitive) method that returns the
         sortKeyFunction for the sortKey."""
-        return self._getSortKeyFunction(sortKey)(
+        return self._getSortKeyFunction(sort_key)(
             sortCaseSensitive=self._sortCaseSensitive
         )
 
-    def _getSortKeyFunction(self, sortKey):
+    def _getSortKeyFunction(self, sort_key):
         try:
-            return getattr(self.DomainObjectClass, "%sSortFunction" % sortKey)
+            return getattr(self.DomainObjectClass,
+                           "%sSortFunction" % sort_key)
         except AttributeError:
+            from taskcoachlib.meta.debug import log_step
+            log_step('%sSortFunction not found on %s - falling back '
+                     'to subject'
+                     % (sort_key, self.DomainObjectClass.__name__),
+                     prefix='SORTER')
             return self._getSortKeyFunction("subject")
 
     def _registerObserverForAttribute(self, attribute):
-        for eventType in self._getSortEventTypes(attribute):
-            if eventType.startswith("pubsub"):
-                pub.subscribe(self.onAttributeChanged, eventType)
+        for event_type in self._getSortEventTypes(attribute):
+            if event_type.startswith("pubsub"):
+                pub.subscribe(self.onAttributeChanged, event_type)
             else:
                 patterns.Publisher().registerObserver(
-                    self.onAttributeChanged_Deprecated, eventType=eventType
+                    self.onAttributeChanged_Deprecated,
+                    eventType=event_type,
                 )
 
     def _removeObserverForAttribute(self, attribute):
-        for eventType in self._getSortEventTypes(attribute):
-            if eventType.startswith("pubsub"):
-                pub.unsubscribe(self.onAttributeChanged, eventType)
+        for event_type in self._getSortEventTypes(attribute):
+            if event_type.startswith("pubsub"):
+                pub.unsubscribe(self.onAttributeChanged, event_type)
             else:
                 patterns.Publisher().removeObserver(
-                    self.onAttributeChanged_Deprecated, eventType=eventType
+                    self.onAttributeChanged_Deprecated,
+                    eventType=event_type,
                 )
 
     def onAttributeChanged(self, newValue, sender):  # pylint: disable=W0613
@@ -166,8 +177,8 @@ class TreeSorter(Sorter):
     def tree_mode(self):
         return True
 
-    def createSortKeyFunction(self, key):
-        """createSortKeyFunction returns a function that is passed to the
+    def create_sort_key_function(self, key):
+        """create_sort_key_function returns a function that is passed to the
         builtin list.sort method to extract the sort key from each element
         in the list. We expect the domain object class to provide a
         <sortKey>SortFunction(sortCaseSensitive, tree_mode) method that
@@ -186,15 +197,15 @@ class TreeSorter(Sorter):
         return super().extendSelf(items, event=event)
 
     @patterns.eventSource
-    def removeItemsFromSelf(self, itemsToRemove, event=None):
+    def removeItemsFromSelf(self, items_to_remove, event=None):
         self.__invalidateRootItemCache()
         # FIXME: Why is it necessary to remove all children explicitly?
-        itemsToRemove = set(itemsToRemove)
+        items_to_remove = set(items_to_remove)
         if self.tree_mode():
-            for item in itemsToRemove.copy():
-                itemsToRemove.update(item.children(recursive=True))
-        itemsToRemove = [item for item in itemsToRemove if item in self]
-        return super().removeItemsFromSelf(itemsToRemove, event=event)
+            for item in items_to_remove.copy():
+                items_to_remove.update(item.children(recursive=True))
+        items_to_remove = [item for item in items_to_remove if item in self]
+        return super().removeItemsFromSelf(items_to_remove, event=event)
 
     def rootItems(self):
         """Return the root items, i.e. items without a parent."""

--- a/taskcoachlib/domain/task/sorter.py
+++ b/taskcoachlib/domain/task/sorter.py
@@ -33,18 +33,18 @@ class Sorter(base.TreeSorter):
 
     def __init__(self, *args, **kwargs):
         self.__tree_mode = kwargs.pop("tree_mode", False)
-        self.__sortByTaskStatusFirst = kwargs.pop(
+        self.__sort_by_task_status_first = kwargs.pop(
             "sortByTaskStatusFirst", True
         )
         super().__init__(*args, **kwargs)
-        for eventType in (
+        for event_type in (
             task.Task.prerequisitesChangedEventType(),
             task.Task.dueDateTimeChangedEventType(),
             task.Task.plannedStartDateTimeChangedEventType(),
             task.Task.actualStartDateTimeChangedEventType(),
             task.Task.completionDateTimeChangedEventType(),
         ):
-            pub.subscribe(self.onAttributeChanged, eventType)
+            pub.subscribe(self.onAttributeChanged, event_type)
         pub.subscribe(self._onStatusSortPriorityChanged,
                       "settings.statussortpriority.changed")
 
@@ -61,25 +61,25 @@ class Sorter(base.TreeSorter):
             from taskcoachlib.meta.debug import log_step
             log_step("set_tree_mode: Sorter observable is %s, expected Filter"
                      % type(observable).__name__, prefix="FILTER")
-        self.reset(forceEvent=True)
+        self.reset(force_event=True)
 
     def tree_mode(self):
         return self.__tree_mode
 
-    def sortByTaskStatusFirst(self, sortByTaskStatusFirst):
-        self.__sortByTaskStatusFirst = sortByTaskStatusFirst
+    def sort_by_task_status_first(self, sort_by_status_first):
+        self.__sort_by_task_status_first = sort_by_status_first
         # We don't need to invoke self.reset() here since when this property is
         # changed, the sort order also changes which in turn will cause
         # self.reset() to be called.
 
-    def createSortKeyFunction(self, sortKey):
-        statusSortKey = self.__createStatusSortKey()
-        regularSortKey = super().createSortKeyFunction(sortKey)
-        return lambda task: statusSortKey(task) + [regularSortKey(task)]
+    def create_sort_key_function(self, sort_key):
+        status_sort_key = self.__create_status_sort_key()
+        regular_sort_key = super().create_sort_key_function(sort_key)
+        return lambda task: status_sort_key(task) + [regular_sort_key(task)]
 
-    def __createStatusSortKey(self):
-        if self.__sortByTaskStatusFirst:
-            if self.isAscending():
+    def __create_status_sort_key(self):
+        if self.__sort_by_task_status_first:
+            if self.is_ascending():
                 # Negate priority so higher priority (more urgent) sorts first
                 return lambda task: [-task.computedStatus().getSortPriority(task.settings)]
             else:

--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -2316,7 +2316,7 @@ class LocalCategoryViewer(viewer.BaseCategoryViewer):  # pylint: disable=W0223
         for item in self.domainObjectsToView():
             item.expand(context=self.settingsSection(), notify=False)
 
-    def getIsItemChecked(self, category):  # pylint: disable=W0621
+    def get_is_item_checked(self, category):  # pylint: disable=W0621
         items_with_category = sum(
             1 for item in self.__items if category in item.categories()
         )
@@ -2585,7 +2585,7 @@ class LocalPrerequisiteViewer(
         self.__items = items
         super().__init__(*args, **kwargs)
 
-    def getIsItemChecked(self, item):
+    def get_is_item_checked(self, item):
         return item in self.__items[0].prerequisites()
 
     def getIsItemCheckable(self, item):
@@ -2594,7 +2594,7 @@ class LocalPrerequisiteViewer(
     def onCheck(self, event, final):
         item = self.widget.GetItemPyData(event.GetItem())
         is_checked = event.GetItem().IsChecked()
-        if is_checked != self.getIsItemChecked(item):
+        if is_checked != self.get_is_item_checked(item):
             checked, unchecked = ([item], []) if is_checked else ([], [item])
             command.TogglePrerequisiteCommand(
                 None,

--- a/taskcoachlib/gui/dialog/export.py
+++ b/taskcoachlib/gui/dialog/export.py
@@ -63,7 +63,7 @@ class ExportDialog(sized_controls.SizedDialog):
         return self.window.viewer
 
     def activeViewer(self):
-        return self.window.viewer.activeViewer()
+        return self.window.viewer.active_viewer()
 
     def options(self):
         result = dict()
@@ -213,7 +213,7 @@ class ColumnPicker(sized_controls.SizedPanel):
         objectType = getattr(viewer, 'coreObjectType', '')
         excluded = self.EXCLUDED_EXPORT_COLUMNS.get(objectType, set())
         headers = []
-        for column in viewer.selectableColumns():
+        for column in viewer.selectable_columns():
             if column.name() in excluded:
                 continue
             item = self.tree.AppendItem(root, column.header(), ct_type=1)

--- a/taskcoachlib/gui/mainwindow.py
+++ b/taskcoachlib/gui/mainwindow.py
@@ -123,7 +123,7 @@ class MainWindow(
             self.__create_reminder_controller()
         finally:
             self.Thaw()
-        wx.CallAfter(self.viewer.componentsCreated)
+        wx.CallAfter(self.viewer.components_created)
 
     def _create_viewer_container(self):  # Not private for test purposes
         # pylint: disable=W0201
@@ -153,9 +153,9 @@ class MainWindow(
             self, self.taskFile.tasks(), self.taskFile.efforts(), self.settings
         )
 
-    def addPane(self, page, caption, floating=False):  # pylint: disable=W0221
+    def add_pane(self, page, caption, floating=False):  # pylint: disable=W0221
         name = page.settingsSection()
-        super().addPane(page, caption, name, floating=floating)
+        super().add_pane(page, caption, name, floating=floating)
 
     def __init_window(self):
         self.__filename = self.taskFile.filename()
@@ -358,7 +358,7 @@ If this happens again, please make a copy of your TaskCoach.ini file """
         # Close ALL viewers (not just floating)
         viewers_to_close = list(self.viewer.viewers)  # Copy the list
         for v in viewers_to_close:
-            self.viewer.closeViewer(v)
+            self.viewer.close_viewer(v)
             self.viewer.viewers.remove(v)
 
         # Process closures
@@ -548,7 +548,7 @@ If this happens again, please make a copy of your TaskCoach.ini file """
     # Viewers
 
     def advanceSelection(self, forward):
-        self.viewer.advanceSelection(forward)
+        self.viewer.advance_selection(forward)
 
     def viewerCount(self):
         return len(self.viewer)

--- a/taskcoachlib/gui/uicommand/uicommand.py
+++ b/taskcoachlib/gui/uicommand/uicommand.py
@@ -713,9 +713,9 @@ class FileExportAsICalendar(FileExportCommand):
     @staticmethod
     def exportableViewer(aViewer):
         """Return whether the viewer can be exported to iCalendar format."""
-        return aViewer.isShowingTasks() or (
-            aViewer.isShowingEffort()
-            and not aViewer.isShowingAggregatedEffort()
+        return aViewer.is_showing_tasks() or (
+            aViewer.is_showing_effort()
+            and not aViewer.is_showing_aggregated_effort()
         )
 
 
@@ -1393,19 +1393,19 @@ class RenameViewer(ViewerCommand):
         )
 
     def do_command(self, event):
-        activeViewer = self.viewer.activeViewer()
-        viewerNameDialog = wx.TextEntryDialog(
+        active_viewer = self.viewer.active_viewer()
+        viewer_name_dialog = wx.TextEntryDialog(
             self.main_window(),
             _("New title for the viewer:"),
             _("Rename viewer"),
-            activeViewer.title(),
+            active_viewer.title(),
         )
-        if viewerNameDialog.ShowModal() == wx.ID_OK:
-            activeViewer.setTitle(viewerNameDialog.GetValue())
-        viewerNameDialog.Destroy()
+        if viewer_name_dialog.ShowModal() == wx.ID_OK:
+            active_viewer.set_title(viewer_name_dialog.GetValue())
+        viewer_name_dialog.Destroy()
 
     def enabled(self, event):
-        return bool(self.viewer.activeViewer())
+        return bool(self.viewer.active_viewer())
 
 
 class ActivateViewer(ViewerCommand):
@@ -1414,7 +1414,7 @@ class ActivateViewer(ViewerCommand):
         super().__init__(*args, **kwargs)
 
     def do_command(self, event):
-        self.viewer.containerWidget.advanceSelection(self.direction)
+        self.viewer.containerWidget.advance_selection(self.direction)
 
     def enabled(self, event):
         return self.viewer.containerWidget.viewerCount() > 1
@@ -1431,7 +1431,7 @@ class HideCurrentColumn(ViewerCommand):
 
     def do_command(self, event):
         columnPopupMenu = event.GetEventObject()
-        self.viewer.hideColumn(columnPopupMenu.columnIndex)
+        self.viewer.hide_column(columnPopupMenu.columnIndex)
 
     def enabled(self, event):
         # Unfortunately the event (an UpdateUIEvent) does not give us any
@@ -1447,7 +1447,7 @@ class HideCurrentColumn(ViewerCommand):
         # don't understand why. Work around as follows:
         if columnIndex == -1:
             columnIndex = 0
-        return self.viewer.isHideableColumn(columnIndex)
+        return self.viewer.is_hideable_column(columnIndex)
 
 
 class ViewColumn(ViewerCommand, settings_uicommand.UICheckCommand):
@@ -1532,7 +1532,7 @@ class ViewExpandAll(ViewerCommand):
         return self.viewer.is_tree_viewer()
 
     def do_command(self, event):
-        self.viewer.expandAll()
+        self.viewer.expand_all()
 
 
 class ViewCollapseAll(ViewerCommand):
@@ -1554,7 +1554,7 @@ class ViewCollapseAll(ViewerCommand):
         return self.viewer.is_tree_viewer()
 
     def do_command(self, event):
-        self.viewer.collapseAll()
+        self.viewer.collapse_all()
 
 
 class ViewerSortByCommand(ViewerCommand, settings_uicommand.UIRadioCommand):
@@ -2451,7 +2451,7 @@ class ToggleCategory(ViewerCommand):
             return False
         if not (self.viewer.is_task or self.viewer.is_note):
             return False
-        if self.viewer.isShowingCategories():
+        if self.viewer.is_showing_categories():
             return False
         mutual_exclusive_ancestors = [
             ancestor
@@ -2654,18 +2654,18 @@ class EffortNew(
         if not self.taskList:
             return False
         # When viewer is showing tasks, require a task to be selected
-        if self.viewer and self.viewer.isShowingTasks():
+        if self.viewer and self.viewer.is_showing_tasks():
             return bool(self.viewer.curselection())
         return True
 
     def do_command(self, event, show=True):
         if (
             self.viewer
-            and self.viewer.isShowingTasks()
+            and self.viewer.is_showing_tasks()
             and self.viewer.curselection()
         ):
             selected_tasks = self.viewer.curselection()
-        elif self.viewer and self.viewer.isShowingEffort():
+        elif self.viewer and self.viewer.is_showing_effort():
             selected_efforts = self.viewer.curselection()
             if selected_efforts:
                 selected_tasks = [selected_efforts[0].task()]
@@ -3041,7 +3041,7 @@ class CategoryCheckAll(ViewerCommand):
         )
 
     def do_command(self, event):
-        self.viewer.checkAllCategories()
+        self.viewer.check_all_categories()
 
 
 class CategoryUncheckAll(ViewerCommand):
@@ -3060,7 +3060,7 @@ class CategoryUncheckAll(ViewerCommand):
         )
 
     def do_command(self, event):
-        self.viewer.uncheckAllCategories()
+        self.viewer.uncheck_all_categories()
 
 
 class NoteNew(NotesCommand, settings_uicommand.SettingsCommand, ViewerCommand):
@@ -3077,7 +3077,7 @@ class NoteNew(NotesCommand, settings_uicommand.SettingsCommand, ViewerCommand):
         )
 
     def do_command(self, event, show=True):  # pylint: disable=W0221
-        if self.viewer and self.viewer.isShowingNotes():
+        if self.viewer and self.viewer.is_showing_notes():
             noteDialog = self.viewer.newItemDialog(icon_id=self.icon_id)
         else:
             newNoteCommand = command.NewNoteCommand(
@@ -3199,7 +3199,7 @@ class AttachmentOpen(
 
 
     def enabled(self, event):
-        return self.viewer.has_selection and self.viewer.isShowingAttachments()
+        return self.viewer.has_selection and self.viewer.is_showing_attachments()
 
     def do_command(
         self, event, showerror=wx.MessageBox

--- a/taskcoachlib/gui/viewer/attachment.py
+++ b/taskcoachlib/gui/viewer/attachment.py
@@ -96,7 +96,7 @@ class AttachmentViewer(
     def domainObjectsToView(self):
         return self.attachments
 
-    def isShowingAttachments(self):
+    def is_showing_attachments(self):
         return True
 
     def getSupportedPasteTypes(self):

--- a/taskcoachlib/gui/viewer/base.py
+++ b/taskcoachlib/gui/viewer/base.py
@@ -65,7 +65,7 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         # memory leakage:
         self._popupMenus = []
         # What are we presenting:
-        self.__presentation = self.createSorter(
+        self.__presentation = self.create_sorter(
             self.createFilter(self.domainObjectsToView())
         )
         # The widget used to present the presentation:
@@ -75,19 +75,17 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         )
         self.toolbar = toolbar.ToolBar(self, settings,
                                        (toolbar.TOOLBAR_ICON_SIZE,) * 2)
-        self.initLayout()
-        self.registerPresentationObservers()
+        self.init_layout()
+        self.register_presentation_observers()
         self.refresh()
 
-        pub.subscribe(self.onBeginIO, "taskfile.aboutToRead")
-        pub.subscribe(self.onBeginIO, "taskfile.aboutToClear")
-        pub.subscribe(self.onBeginIO, "taskfile.aboutToSave")
-        pub.subscribe(self.onEndIO, "taskfile.justRead")
-        pub.subscribe(self.onEndIO, "taskfile.justCleared")
-        pub.subscribe(self.onEndIO, "taskfile.justSaved")
+        pub.subscribe(self.on_begin_io, "taskfile.aboutToRead")
+        pub.subscribe(self.on_begin_io, "taskfile.aboutToClear")
+        pub.subscribe(self.on_end_io, "taskfile.justRead")
+        pub.subscribe(self.on_end_io, "taskfile.justCleared")
         # Subscribe to bulk operation signals to freeze/thaw during batch updates
-        pub.subscribe(self.onBeginBulkOperation, "command.aboutToBulkModify")
-        pub.subscribe(self.onEndBulkOperation, "command.justBulkModified")
+        pub.subscribe(self.on_begin_bulk_operation, "command.aboutToBulkModify")
+        pub.subscribe(self.on_end_bulk_operation, "command.justBulkModified")
 
         wx.CallAfter(self.__DisplayBalloon)
 
@@ -117,22 +115,22 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
                 ),
             )
 
-    def onBeginIO(self, taskFile):
+    def on_begin_io(self, taskFile):
         self.__freezeCount += 1
         self.__presentation.freeze()
 
-    def onEndIO(self, taskFile):
+    def on_end_io(self, taskFile):
         self.__freezeCount -= 1
         self.__presentation.thaw()
         if self.__freezeCount == 0:
             self.refresh()
 
-    def onBeginBulkOperation(self):
+    def on_begin_bulk_operation(self):
         """Freeze viewer and presentation to batch updates during bulk operations."""
         self.__freezeCount += 1
         self.__presentation.freeze()
 
-    def onEndBulkOperation(self):
+    def on_end_bulk_operation(self):
         """Thaw viewer and presentation after bulk operation, refresh only changed items."""
         self.__freezeCount -= 1
         self.__presentation.thaw()
@@ -176,19 +174,19 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         of objects passed to the viewer constructor."""
         raise NotImplementedError
 
-    def registerPresentationObservers(self):
-        self.removeObserver(self.onPresentationChanged)
+    def register_presentation_observers(self):
+        self.removeObserver(self.on_presentation_changed)
         self.registerObserver(
-            self.onPresentationChanged,
+            self.on_presentation_changed,
             eventType=self.presentation().addItemEventType(),
             eventSource=self.presentation(),
         )
         self.registerObserver(
-            self.onPresentationChanged,
+            self.on_presentation_changed,
             eventType=self.presentation().removeItemEventType(),
             eventSource=self.presentation(),
         )
-        self.registerObserver(self.onNewItem, eventType="newitem")
+        self.registerObserver(self.on_new_item, eventType="newitem")
 
     def detach(self):
         """Should be called by viewer.container before closing the viewer"""
@@ -205,27 +203,25 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
             if hasattr(observer, 'removeInstance'):
                 observer.removeInstance()
 
-        for popupMenu in self._popupMenus:
+        for popup_menu in self._popupMenus:
             try:
-                popupMenu.clearMenu()
-                popupMenu.Destroy()
+                popup_menu.clearMenu()
+                popup_menu.Destroy()
             except RuntimeError:
                 log_step("detach: popup menu already dead %x" %
-                         id(popupMenu), prefix="DEAD-OBJ")
+                         id(popup_menu), prefix="DEAD-OBJ")
 
-        pub.unsubscribe(self.onBeginIO, "taskfile.aboutToRead")
-        pub.unsubscribe(self.onBeginIO, "taskfile.aboutToClear")
-        pub.unsubscribe(self.onBeginIO, "taskfile.aboutToSave")
-        pub.unsubscribe(self.onEndIO, "taskfile.justRead")
-        pub.unsubscribe(self.onEndIO, "taskfile.justCleared")
-        pub.unsubscribe(self.onEndIO, "taskfile.justSaved")
-        pub.unsubscribe(self.onBeginBulkOperation, "command.aboutToBulkModify")
-        pub.unsubscribe(self.onEndBulkOperation, "command.justBulkModified")
+        pub.unsubscribe(self.on_begin_io, "taskfile.aboutToRead")
+        pub.unsubscribe(self.on_begin_io, "taskfile.aboutToClear")
+        pub.unsubscribe(self.on_end_io, "taskfile.justRead")
+        pub.unsubscribe(self.on_end_io, "taskfile.justCleared")
+        pub.unsubscribe(self.on_begin_bulk_operation, "command.aboutToBulkModify")
+        pub.unsubscribe(self.on_end_bulk_operation, "command.justBulkModified")
 
         self.presentation().detach()
         self.toolbar.detach()
 
-    def viewerStatusEventType(self):
+    def viewer_status_event_type(self):
         return "viewer%s.status" % id(self)
 
     def selection_changed_event_type(self):
@@ -274,8 +270,8 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         mixins."""
         return False
 
-    def sendViewerStatusEvent(self):
-        pub.sendMessage(self.viewerStatusEventType(), viewer=self)
+    def send_viewer_status_event(self):
+        pub.sendMessage(self.viewer_status_event_type(), viewer=self)
 
     def statusMessages(self):
         return "", ""
@@ -286,15 +282,15 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
             or self.defaultTitle
         )
 
-    def setTitle(self, title):
+    def set_title(self, title):
         titleToSaveInSettings = "" if title == self.defaultTitle else title
         self.settings.set(
             self.settingsSection(), "title", titleToSaveInSettings
         )
-        self.parent.setPaneTitle(self, title)
+        self.parent.set_pane_title(self, title)
         self.parent.manager.Update()
 
-    def initLayout(self):
+    def init_layout(self):
         self._sizer = wx.BoxSizer(wx.VERTICAL)  # pylint: disable=W0201
         self._sizer.Add(self.toolbar, flag=wx.EXPAND)
         self._sizer.Add(self.widget, proportion=1, flag=wx.EXPAND)
@@ -320,7 +316,7 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
             log_step("SetFocus on dead widget %s: %s" %
                      (self.__class__.__name__, e), prefix="DEAD-OBJ")
 
-    def createSorter(self, collection):
+    def create_sorter(self, collection):
         """This method can be overridden to decorate the presentation with a
         sorter."""
         return collection
@@ -345,7 +341,7 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         else:
             self.refreshItems(*event.sources())
 
-    def onNewItem(self, event):
+    def on_new_item(self, event):
         self.select(
             [
                 item
@@ -354,30 +350,30 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
             ]
         )
 
-    def onPresentationChanged(self, event):  # pylint: disable=W0613
+    def on_presentation_changed(self, event):  # pylint: disable=W0613
         """Whenever our presentation is changed (items added, items removed)
         the viewer refreshes itself."""
 
-        def itemsRemoved():
+        def items_removed():
             return event.type() == self.presentation().removeItemEventType()
 
         # BEFORE refresh - capture selection info while widget has old state
-        selectionInfo = None
-        if itemsRemoved():
-            selectionInfo = self._captureSelectionInfo()
+        selection_info = None
+        if items_removed():
+            selection_info = self._captureSelectionInfo()
 
         self.refresh()
 
         # AFTER refresh - select next if selection became empty
-        if itemsRemoved() and hasattr(self.widget, 'curselection') and not self.widget.curselection() and selectionInfo:
-            self.selectNextItemsAfterRemoval(selectionInfo)
+        if items_removed() and hasattr(self.widget, 'curselection') and not self.widget.curselection() and selection_info:
+            self.selectNextItemsAfterRemoval(selection_info)
         # Center on selected item — tree views use scrollToSelectionCentered,
         # list views use ensureSelectionVisible (native wx scrollbar management)
         if hasattr(self.widget, 'scrollToSelectionCentered'):
             self.widget.scrollToSelectionCentered()
         elif hasattr(self.widget, 'ensureSelectionVisible'):
             self.widget.ensureSelectionVisible()
-        self.sendViewerStatusEvent()
+        self.send_viewer_status_event()
 
     def _captureSelectionInfo(self):
         """Capture selection info before refresh. Override in subclasses."""
@@ -408,19 +404,19 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
 
             # Fire status event - StatusBar has its own 500ms debounce
             # No need to query selection here; status bar queries fresh when displaying
-            wx.CallAfter(self.sendViewerStatusEvent)
+            wx.CallAfter(self.send_viewer_status_event)
         except RuntimeError as e:
             log_step("onSelect on dead viewer %s: %s" %
                      (self.__class__.__name__, e), prefix="DEAD-OBJ")
 
-    def updateSelection(self, sendViewerStatusEvent=True):
+    def updateSelection(self, send_status_event=True):
         """Legacy method - kept for subclass compatibility.
 
         With SSOT selection (curselection() queries widget fresh),
         there's no cache to update. Just fires status event if requested.
         """
-        if sendViewerStatusEvent:
-            self.sendViewerStatusEvent()
+        if send_status_event:
+            self.send_viewer_status_event()
 
     def freeze(self):
         self.widget.Freeze()
@@ -463,9 +459,9 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         self.widget.select_all()
         # Use CallAfter to make sure we start processing selection events
         # after all selection events have been fired (and ignored):
-        wx.CallAfter(self.endOfSelectAll)
+        wx.CallAfter(self.end_of_select_all)
 
-    def endOfSelectAll(self):
+    def end_of_select_all(self):
         # Guard against deleted C++ object - can happen when wx.CallAfter
         # callback executes after window destruction (e.g., closing nested dialogs)
         try:
@@ -489,29 +485,29 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         displaying."""
         return self.__presentation
 
-    def setPresentation(self, presentation):
+    def set_presentation(self, presentation):
         """Change the presentation of the viewer."""
         self.__presentation = presentation
 
     def widgetCreationKeywordArguments(self):
         return {}
 
-    def isViewerContainer(self):
+    def is_viewer_container(self):
         return False
 
-    def isShowingTasks(self):
+    def is_showing_tasks(self):
         return False
 
-    def isShowingEffort(self):
+    def is_showing_effort(self):
         return False
 
-    def isShowingCategories(self):
+    def is_showing_categories(self):
         return False
 
-    def isShowingNotes(self):
+    def is_showing_notes(self):
         return False
 
-    def isShowingAttachments(self):
+    def is_showing_attachments(self):
         return False
 
     def visibleColumns(self):
@@ -838,13 +834,13 @@ class ListViewer(Viewer):  # pylint: disable=W0223
 class TreeViewer(Viewer):  # pylint: disable=W0223
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.widget.Bind(wx.EVT_TREE_ITEM_EXPANDED, self.onItemExpanded)
-        self.widget.Bind(wx.EVT_TREE_ITEM_COLLAPSED, self.onItemCollapsed)
+        self.widget.Bind(wx.EVT_TREE_ITEM_EXPANDED, self.on_item_expanded)
+        self.widget.Bind(wx.EVT_TREE_ITEM_COLLAPSED, self.on_item_collapsed)
 
-    def onItemExpanded(self, event):
+    def on_item_expanded(self, event):
         self.__handleExpandedOrCollapsedItem(event, expanded=True)
 
-    def onItemCollapsed(self, event):
+    def on_item_collapsed(self, event):
         self.__handleExpandedOrCollapsedItem(event, expanded=False)
 
     def __handleExpandedOrCollapsedItem(self, event, expanded):
@@ -856,7 +852,7 @@ class TreeViewer(Viewer):  # pylint: disable=W0223
         item = self.widget.GetItemPyData(treeItem)
         item.expand(expanded, context=self.settingsSection())
 
-    def expandAll(self):
+    def expand_all(self):
         """Expand all items, recursively."""
         # Since the widget does not send EVT_TREE_ITEM_EXPANDED when expanding
         # all items, we have to do the bookkeeping ourselves:
@@ -864,7 +860,7 @@ class TreeViewer(Viewer):  # pylint: disable=W0223
             item.expand(True, context=self.settingsSection(), notify=False)
         self.refresh()
 
-    def collapseAll(self):
+    def collapse_all(self):
         """Collapse all items, recursively."""
         # Since the widget does not send EVT_TREE_ITEM_COLLAPSED when collapsing
         # all items, we have to do the bookkeeping ourselves:
@@ -976,7 +972,7 @@ class ViewerWithColumns(Viewer):  # pylint: disable=W0223
         self.__visibleColumns = []
         self.__columnUICommands = []
         super().__init__(*args, **kwargs)
-        self.initColumns()
+        self.init_columns()
         self.__initDone = True
         self.refresh()
 
@@ -1001,7 +997,7 @@ class ViewerWithColumns(Viewer):  # pylint: disable=W0223
         if self and self.__initDone:
             super().refresh(*args, **kwargs)
 
-    def initColumns(self):
+    def init_columns(self):
         for column in self.columns():
             self.initColumn(column)
         if self.hasOrderingColumn():
@@ -1023,7 +1019,7 @@ class ViewerWithColumns(Viewer):  # pylint: disable=W0223
             self.__startObserving(column.eventTypes())
 
     def showColumnByName(self, columnName, show=True):
-        for column in self.hideableColumns():
+        for column in self.hideable_columns():
             if columnName == column.name():
                 isVisibleColumn = self.isVisibleColumn(column)
                 if (show and not isVisibleColumn) or (
@@ -1056,14 +1052,14 @@ class ViewerWithColumns(Viewer):  # pylint: disable=W0223
         if refresh:
             self.widget.RefreshAllItems(len(self.presentation()))
 
-    def hideColumn(self, visibleColumnIndex):
+    def hide_column(self, visibleColumnIndex):
         column = self.visibleColumns()[visibleColumnIndex]
         self.showColumn(column, show=False)
 
     def columns(self):
         return self._columns
 
-    def selectableColumns(self):
+    def selectable_columns(self):
         return self._columns
 
     def isVisibleColumnByName(self, columnName):
@@ -1077,7 +1073,7 @@ class ViewerWithColumns(Viewer):  # pylint: disable=W0223
     def visibleColumns(self):
         return self.__visibleColumns
 
-    def hideableColumns(self):
+    def hideable_columns(self):
         return [
             column
             for column in self._columns
@@ -1087,12 +1083,12 @@ class ViewerWithColumns(Viewer):  # pylint: disable=W0223
             )
         ]
 
-    def isHideableColumn(self, visibleColumnIndex):
+    def is_hideable_column(self, visibleColumnIndex):
         column = self.visibleColumns()[visibleColumnIndex]
-        unhideableColumns = self.settings.getlist(
+        unhideable_columns = self.settings.getlist(
             self.settingsSection(), "columnsalwaysvisible"
         )
-        return column.name() not in unhideableColumns
+        return column.name() not in unhideable_columns
 
     def getColumnWidth(self, column_name):
         column_widths = self.settings.getdict(
@@ -1266,28 +1262,28 @@ class SortableViewerWithColumns(
     def initColumn(self, column):
         super().initColumn(column)
         if self.isSortedBy(column.name()):
-            self.widget.showSortColumn(column)
-            self.showSortOrder()
+            self.widget.show_sort_column(column)
+            self.show_sort_order()
 
     def setSortOrderAscending(self, *args, **kwargs):  # pylint: disable=W0221
         super().setSortOrderAscending(*args, **kwargs)
-        self.showSortOrder()
+        self.show_sort_order()
 
     def sortBy(self, *args, **kwargs):  # pylint: disable=W0221
         super().sortBy(*args, **kwargs)
-        self.showSortColumn()
-        self.showSortOrder()
+        self.show_sort_column()
+        self.show_sort_order()
 
-    def showSortColumn(self):
+    def show_sort_column(self):
         for column in self.columns():
             if self.isSortedBy(column.name()):
-                self.widget.showSortColumn(column)
+                self.widget.show_sort_column(column)
                 break
 
-    def showSortOrder(self):
-        self.widget.showSortOrder(image_list_cache.get_index(self.getSortOrderImage()))
+    def show_sort_order(self):
+        self.widget.show_sort_order(image_list_cache.get_index(self.get_sort_order_image()))
 
-    def getSortOrderImage(self):
+    def get_sort_order_image(self):
         # Arrow points in direction of sort: down for A→Z/old→new, up for Z→A/new→old
         return (
             "nuvola_actions_go-down"

--- a/taskcoachlib/gui/viewer/category.py
+++ b/taskcoachlib/gui/viewer/category.py
@@ -211,13 +211,13 @@ class BaseCategoryViewer(
             uicommand.NewSubItem(viewer=self),
         )
 
-    def checkAllCategories(self):
+    def check_all_categories(self):
         """Set all categories to filtered (checked) state."""
         for cat in self.presentation():
             cat.setFiltered(True)
         self.refresh()
 
-    def uncheckAllCategories(self):
+    def uncheck_all_categories(self):
         """Set all categories to unfiltered (unchecked) state."""
         for cat in self.presentation():
             cat.setFiltered(False)
@@ -303,18 +303,18 @@ class BaseCategoryViewer(
     def onCheck(self, event, final):
         categoryToFilter = self.widget.GetItemPyData(event.GetItem())
         categoryToFilter.setFiltered(event.GetItem().IsChecked())
-        self.sendViewerStatusEvent()  # Notify status observers like the status bar
+        self.send_viewer_status_event()  # Notify status observers like the status bar
 
-    def getIsItemChecked(self, item):
+    def get_is_item_checked(self, item):
         if isinstance(item, category.Category):
             return item.isFiltered()
         return False
 
-    def getItemParentHasExclusiveChildren(self, item):
+    def get_item_parent_has_exclusive_children(self, item):
         parent = item.parent()
         return parent and parent.hasExclusiveSubcategories()
 
-    def isShowingCategories(self):
+    def is_showing_categories(self):
         return True
 
     def statusMessages(self):

--- a/taskcoachlib/gui/viewer/container.py
+++ b/taskcoachlib/gui/viewer/container.py
@@ -39,18 +39,18 @@ class ViewerContainer(object):
         self.viewers = []
         super().__init__(*args, **kwargs)
 
-    def componentsCreated(self):
+    def components_created(self):
         self._notifyActiveViewer = True
         # Activate the first viewer (TaskViewer) as the default at startup
         if self.viewers:
-            self.activateViewer(self.viewers[0])
+            self.activate_viewer(self.viewers[0])
 
-    def advanceSelection(self, forward):
+    def advance_selection(self, forward):
         """Activate the next viewer if forward is true else the previous
         viewer."""
         if len(self.viewers) <= 1:
             return  # Not enough viewers to advance selection
-        active_viewer = self.activeViewer()
+        active_viewer = self.active_viewer()
         current_index = (
             self.viewers.index(active_viewer) if active_viewer else 0
         )
@@ -67,19 +67,19 @@ class ViewerContainer(object):
                 if minimum_index < current_index <= maximum_index
                 else maximum_index
             )
-        self.activateViewer(self.viewers[new_index])
+        self.activate_viewer(self.viewers[new_index])
 
-    def isViewerContainer(self):
+    def is_viewer_container(self):
         """Return whether this is a viewer container or an actual viewer."""
         return True
 
     def __bind_event_handlers(self):
         """Register for pane closing, activating and floating events."""
-        self.containerWidget.Bind(aui.EVT_AUI_PANE_CLOSE, self.onPageClosed)
+        self.containerWidget.Bind(aui.EVT_AUI_PANE_CLOSE, self.on_page_closed)
         self.containerWidget.Bind(
-            aui.EVT_AUI_PANE_ACTIVATED, self.onPageChanged
+            aui.EVT_AUI_PANE_ACTIVATED, self.on_page_changed
         )
-        self.containerWidget.Bind(aui.EVT_AUI_PANE_FLOATED, self.onPageFloated)
+        self.containerWidget.Bind(aui.EVT_AUI_PANE_FLOATED, self.on_page_floated)
 
     def __getitem__(self, index):
         return self.viewers[index]
@@ -87,27 +87,27 @@ class ViewerContainer(object):
     def __len__(self):
         return len(self.viewers)
 
-    def addViewer(self, viewer, floating=False):
+    def add_viewer(self, viewer, floating=False):
         """Add a new pane with the specified viewer."""
-        self.containerWidget.addPane(viewer, viewer.title(), floating=floating)
+        self.containerWidget.add_pane(viewer, viewer.title(), floating=floating)
         self.viewers.append(viewer)
         if len(self.viewers) == 1:
-            self.activateViewer(viewer)
-        pub.subscribe(self.onStatusChanged, viewer.viewerStatusEventType())
+            self.activate_viewer(viewer)
+        pub.subscribe(self.on_status_changed, viewer.viewer_status_event_type())
 
-    def closeViewer(self, viewer):
+    def close_viewer(self, viewer):
         """Close the specified viewer."""
-        if viewer == self.activeViewer():
-            self.advanceSelection(False)
+        if viewer == self.active_viewer():
+            self.advance_selection(False)
         pane = self.containerWidget.manager.GetPane(viewer)
         self.containerWidget.manager.ClosePane(pane)
 
     def __getattr__(self, attribute):
         """Forward unknown attributes to the active viewer or the first
         viewer if there is no active viewer."""
-        return getattr(self.activeViewer() or self.viewers[0], attribute)
+        return getattr(self.active_viewer() or self.viewers[0], attribute)
 
-    def activeViewer(self):
+    def active_viewer(self):
         """Return the active (selected) viewer."""
         all_panes = self.containerWidget.manager.GetAllPanes()
         for pane in all_panes:
@@ -121,31 +121,31 @@ class ViewerContainer(object):
                     return pane.window
         return None
 
-    def activateViewer(self, viewer_to_activate):
+    def activate_viewer(self, viewer_to_activate):
         """Activate (select) the specified viewer."""
         self.containerWidget.manager.ActivatePane(viewer_to_activate)
-        paneInfo = self.containerWidget.manager.GetPane(viewer_to_activate)
-        if paneInfo.IsNotebookPage():
+        pane_info = self.containerWidget.manager.GetPane(viewer_to_activate)
+        if pane_info.IsNotebookPage():
             self.containerWidget.manager.ShowPane(viewer_to_activate, True)
-        self.sendViewerStatusEvent()
+        self.send_viewer_status_event()
 
     def __del__(self):
         pass  # Don't forward del to one of the viewers.
 
-    def onStatusChanged(self, viewer):
-        if self.activeViewer() == viewer:
-            self.sendViewerStatusEvent()
+    def on_status_changed(self, viewer):
+        if self.active_viewer() == viewer:
+            self.send_viewer_status_event()
         pub.sendMessage("all.viewer.status", viewer=viewer)
 
-    def onPageChanged(self, event):
+    def on_page_changed(self, event):
         """Handle pane activation events from AUI."""
         self.__ensure_active_viewer_has_focus()
-        self.sendViewerStatusEvent()
-        if self._notifyActiveViewer and self.activeViewer() is not None:
-            self.activeViewer().activate()
+        self.send_viewer_status_event()
+        if self._notifyActiveViewer and self.active_viewer() is not None:
+            self.active_viewer().activate()
         event.Skip()
 
-    def sendViewerStatusEvent(self):
+    def send_viewer_status_event(self):
         pub.sendMessage("viewer.status")
 
     def __ensure_active_viewer_has_focus(self):
@@ -154,7 +154,7 @@ class ViewerContainer(object):
         Simple rule: always set focus on the active viewer EXCEPT when a text
         control (search box, etc.) inside that viewer already has focus.
         """
-        viewer = self.activeViewer()
+        viewer = self.active_viewer()
         if not viewer:
             return
 
@@ -174,7 +174,7 @@ class ViewerContainer(object):
         except RuntimeError:
             pass
 
-    def onPageClosed(self, event):
+    def on_page_closed(self, event):
         if event.GetPane().IsToolbar():
             return
         window = event.GetPane().window
@@ -186,8 +186,8 @@ class ViewerContainer(object):
             # Window is a viewer, close it
             self.__close_viewer(window)
         # Make sure we have an active viewer
-        if not self.activeViewer():
-            self.activateViewer(self.viewers[0])
+        if not self.active_viewer():
+            self.activate_viewer(self.viewers[0])
         event.Skip()
 
     def __close_viewer(self, viewer):
@@ -199,13 +199,13 @@ class ViewerContainer(object):
             self.viewers.remove(viewer)
             # Unsubscribe from the viewer's status event before detaching
             try:
-                pub.unsubscribe(self.onStatusChanged, viewer.viewerStatusEventType())
+                pub.unsubscribe(self.on_status_changed, viewer.viewer_status_event_type())
             except Exception:
                 pass  # May already be unsubscribed
             viewer.detach()
 
     @staticmethod
-    def onPageFloated(event):
+    def on_page_floated(event):
         """Give floating pane accelerator keys for activating next and previous
         viewer."""
         viewer = event.GetPane().window

--- a/taskcoachlib/gui/viewer/effort.py
+++ b/taskcoachlib/gui/viewer/effort.py
@@ -115,7 +115,7 @@ class EffortViewer(
         self.__initRoundingToolBarUICommands()
 
     def __initRoundingToolBarUICommands(self):
-        aggregated = self.isShowingAggregatedEffort()
+        aggregated = self.is_showing_aggregated_effort()
         rounding = self.__round_precision() if aggregated else 0
         self.roundingUICommand.set_choice(rounding)
         self.roundingUICommand.enable(aggregated)
@@ -152,7 +152,7 @@ class EffortViewer(
         super().detach()
         self.secondRefresher.removeInstance()
 
-    def isShowingEffort(self):
+    def is_showing_effort(self):
         return True
 
     def getSupportedPasteTypes(self):
@@ -193,11 +193,11 @@ class EffortViewer(
     def _refresh(self, clear=False):
         if clear:
             self.__domainObjectsToView = None
-        self.setPresentation(
-            self.createSorter(self.createFilter(self.domainObjectsToView()))
+        self.set_presentation(
+            self.create_sorter(self.createFilter(self.domainObjectsToView()))
         )
         self.secondRefresher.updatePresentation()
-        self.registerPresentationObservers()
+        self.register_presentation_observers()
         # Invalidate the UICommands used for the column popup menu:
         self.__columnUICommands = None
         # Clear the selection to remove the cached selection
@@ -218,7 +218,7 @@ class EffortViewer(
         self.__initRoundingToolBarUICommands()
         pub.sendMessage("effortviewer.aggregation")
 
-    def isShowingAggregatedEffort(self):
+    def is_showing_aggregated_effort(self):
         return self.aggregation != "details"
 
     def createFilter(self, taskList):
@@ -759,7 +759,7 @@ class EffortViewer(
         if anEffort.getStart() != previousEffort.getStart():
             # Starts are not equal, so period cannot be repeated
             return False
-        if self.isShowingAggregatedEffort():
+        if self.is_showing_aggregated_effort():
             # Starts and length of period are equal, so period is repeated
             return True
         # If we get here, we are in details mode and the starts are equal
@@ -776,7 +776,7 @@ class EffortViewer(
         else:
             timeSpent = anEffort.timeSpent()
         # Check for aggregation because we never round in details mode
-        if self.isShowingAggregatedEffort():
+        if self.is_showing_aggregated_effort():
             timeSpent = self.__roundTimeSpent(timeSpent)
             showSeconds = self.__show_seconds()
         else:
@@ -880,10 +880,10 @@ class EffortViewerForSelectedTasks(EffortViewer):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("settingsSection", "effortviewerforselectedtasks")
         self.__viewerContainer = kwargs.pop("viewerContainer")
-        activeViewer = self.__viewerContainer.activeViewer()
+        active_viewer = self.__viewerContainer.active_viewer()
         self.__currentTaskViewer = (
-            activeViewer
-            if activeViewer is not None and activeViewer.isShowingTasks()
+            active_viewer
+            if active_viewer is not None and active_viewer.is_showing_tasks()
             else None
         )
         pub.subscribe(self.onTaskSelectionChanged, "all.viewer.status")
@@ -897,6 +897,6 @@ class EffortViewerForSelectedTasks(EffortViewer):
         return []
 
     def onTaskSelectionChanged(self, viewer):
-        if viewer.isShowingTasks():
+        if viewer.is_showing_tasks():
             self.__currentTaskViewer = viewer
             self._refresh(clear=True)

--- a/taskcoachlib/gui/viewer/factory.py
+++ b/taskcoachlib/gui/viewer/factory.py
@@ -102,7 +102,7 @@ class addViewers(object):  # pylint: disable=C0103, R0903
             viewer_instance = viewer_class(
                 *self.__viewer_init_args, **self._viewer_kwargs(viewer_class)
             )
-            self.__viewer_container.addViewer(
+            self.__viewer_container.add_viewer(
                 viewer_instance, floating=self.floating
             )
 

--- a/taskcoachlib/gui/viewer/mixin.py
+++ b/taskcoachlib/gui/viewer/mixin.py
@@ -285,58 +285,58 @@ class SortableViewerMixin(object):
     def isSortable(self):
         return True
 
-    def registerPresentationObservers(self):
-        super().registerPresentationObservers()
+    def register_presentation_observers(self):
+        super().register_presentation_observers()
         pub.subscribe(
-            self.onSortOrderChanged, self.presentation().sortEventType()
+            self.on_sort_order_changed, self.presentation().sort_event_type()
         )
 
     def detach(self):
         super().detach()
         pub.unsubscribe(
-            self.onSortOrderChanged, self.presentation().sortEventType()
+            self.on_sort_order_changed, self.presentation().sort_event_type()
         )
 
-    def onSortOrderChanged(self, sender):
+    def on_sort_order_changed(self, sender):
         if sender == self.presentation():
             self.refresh()
-            self.sendViewerStatusEvent()
+            self.send_viewer_status_event()
 
-    def createSorter(self, presentation):
-        return self.SorterClass(presentation, **self.sorterOptions())
+    def create_sorter(self, presentation):
+        return self.SorterClass(presentation, **self.sorter_options())
 
-    def sorterOptions(self):
+    def sorter_options(self):
         return dict(
             sortBy=self.sortKey(), sortCaseSensitive=self.isSortCaseSensitive()
         )
 
-    def sortBy(self, sortKey):
-        self.presentation().sortBy(sortKey)
+    def sortBy(self, sort_key):
+        self.presentation().sort_by(sort_key)
         self.settings.set(
             self.settingsSection(),
             "sortby",
-            str(self.presentation().sortKeys()),
+            str(self.presentation().sort_keys()),
         )
 
-    def isSortedBy(self, sortKey):
-        sortKeys = self.presentation().sortKeys()
-        return sortKeys and (
-            sortKeys[0] == sortKey or sortKeys[0] == "-" + sortKey
+    def isSortedBy(self, sort_key):
+        sort_keys = self.presentation().sort_keys()
+        return sort_keys and (
+            sort_keys[0] == sort_key or sort_keys[0] == "-" + sort_key
         )
 
     def sortKey(self):
         return ast.literal_eval(self.settings.get(self.settingsSection(), "sortby"))
 
     def isSortOrderAscending(self):
-        sortKeys = self.presentation().sortKeys()
-        return sortKeys and not sortKeys[0].startswith("-")
+        sort_keys = self.presentation().sort_keys()
+        return sort_keys and not sort_keys[0].startswith("-")
 
     def setSortOrderAscending(self, ascending=True):
-        self.presentation().sortAscending(ascending)
+        self.presentation().sort_ascending(ascending)
         self.settings.set(
             self.settingsSection(),
             "sortby",
-            str(self.presentation().sortKeys()),
+            str(self.presentation().sort_keys()),
         )
 
     def isSortCaseSensitive(self):
@@ -344,11 +344,12 @@ class SortableViewerMixin(object):
             self.settingsSection(), "sortcasesensitive"
         )
 
-    def setSortCaseSensitive(self, sortCaseSensitive=True):
+    def setSortCaseSensitive(self, sort_case_sensitive=True):
         self.settings.set(
-            self.settingsSection(), "sortcasesensitive", str(sortCaseSensitive)
+            self.settingsSection(), "sortcasesensitive",
+            str(sort_case_sensitive),
         )
-        self.presentation().sortCaseSensitive(sortCaseSensitive)
+        self.presentation().sort_case_sensitive(sort_case_sensitive)
 
     def getSortUICommands(self):
         if not self._sortUICommands:
@@ -526,16 +527,16 @@ class SortableViewerForTasksMixin(
             self.settingsSection(), "sortbystatusfirst"
         )
 
-    def setSortByTaskStatusFirst(self, sortByTaskStatusFirst):
+    def setSortByTaskStatusFirst(self, sort_by_status_first):
         self.settings.set(
             self.settingsSection(),
             "sortbystatusfirst",
-            str(sortByTaskStatusFirst),
+            str(sort_by_status_first),
         )
-        self.presentation().sortByTaskStatusFirst(sortByTaskStatusFirst)
+        self.presentation().sort_by_task_status_first(sort_by_status_first)
 
-    def sorterOptions(self):
-        options = super().sorterOptions()
+    def sorter_options(self):
+        options = super().sorter_options()
         options.update(
             tree_mode=self.is_tree_viewer(),
             sortByTaskStatusFirst=self.isSortByTaskStatusFirst(),
@@ -624,9 +625,9 @@ class AttachmentDropTargetMixin(object):
         kwargs = super(
             AttachmentDropTargetMixin, self
         ).widgetCreationKeywordArguments()
-        kwargs["onDropURL"] = self.onDropURL
-        kwargs["onDropFiles"] = self.onDropFiles
-        kwargs["onDropMail"] = self.onDropMail
+        kwargs["on_drop_url"] = self.onDropURL
+        kwargs["on_drop_files"] = self.onDropFiles
+        kwargs["on_drop_mail"] = self.onDropMail
         return kwargs
 
     def _addAttachments(self, attachments, item, **itemDialogKwargs):

--- a/taskcoachlib/gui/viewer/note.py
+++ b/taskcoachlib/gui/viewer/note.py
@@ -283,7 +283,7 @@ class BaseNoteViewer(
             idColumn,
         ]
 
-    def isShowingNotes(self):
+    def is_showing_notes(self):
         return True
 
     def statusMessages(self):

--- a/taskcoachlib/gui/viewer/task.py
+++ b/taskcoachlib/gui/viewer/task.py
@@ -185,7 +185,7 @@ class BaseTaskViewer(
     def domainObjectsToView(self):
         return self.taskFile.tasks()
 
-    def isShowingTasks(self):
+    def is_showing_tasks(self):
         return True
 
     def createFilter(self, taskList):
@@ -1999,7 +1999,7 @@ class TaskViewer(
         self, *args, **kwargs
     ):  # pylint: disable=W0221
         super().setSortByTaskStatusFirst(*args, **kwargs)
-        self.showSortOrder()
+        self.show_sort_order()
 
     def getSortOrderImage(self):
         if self.isSortOrderAscending():
@@ -2016,7 +2016,7 @@ class TaskViewer(
     ):  # pylint: disable=W0221
         super().setSearchFilter(searchString, *args, **kwargs)
         if searchString:
-            self.expandAll()  # pylint: disable=E1101
+            self.expand_all()  # pylint: disable=E1101
 
     def set_tree_mode(self, value):
         self.settings.setboolean(self.settingsSection(), "treemode", value)

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,8 +41,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.2"  # Major.Minor.Milestone
-patch = "7"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.2.7
+patch = "8"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.2.8
 
 release_day = "13"  # Day of the release (1-31)
 release_month = "March"  # Month of the release

--- a/taskcoachlib/persistence/html/writer.py
+++ b/taskcoachlib/persistence/html/writer.py
@@ -55,11 +55,11 @@ You can edit this file, it will not be overwritten by %(name)s.
 class _ViewerProxy(object):
     """Lightweight viewer proxy for 'All' exports when no real viewer is available."""
 
-    def __init__(self, items, columns, title, isShowingTasks=False):
+    def __init__(self, items, columns, title, is_showing_tasks=False):
         self._items = items
         self._columns = columns
         self._title = title
-        self._isShowingTasks = isShowingTasks
+        self._is_showing_tasks = is_showing_tasks
 
     def title(self):
         return self._title
@@ -82,8 +82,8 @@ class _ViewerProxy(object):
     def isSortedBy(self, name):
         return False
 
-    def isShowingTasks(self):
-        return self._isShowingTasks
+    def is_showing_tasks(self):
+        return self._is_showing_tasks
 
 
 class HTMLWriter(object):
@@ -128,12 +128,12 @@ class HTMLWriter(object):
         """Create a viewer proxy for 'All' exports."""
         items = []
         title = "Export"
-        isShowingTasks = False
+        is_showing_tasks = False
         if taskFile:
             if viewerType == self.ALL_TASKS:
                 items = list(taskFile.tasks())
                 title = "Tasks"
-                isShowingTasks = True
+                is_showing_tasks = True
             elif viewerType == self.ALL_EFFORTS:
                 items = list(taskFile.efforts())
                 title = "Efforts"
@@ -143,7 +143,7 @@ class HTMLWriter(object):
             elif viewerType == self.ALL_NOTES:
                 items = list(taskFile.notes())
                 title = "Notes"
-        return _ViewerProxy(items, columns or [], title, isShowingTasks)
+        return _ViewerProxy(items, columns or [], title, is_showing_tasks)
 
     def _writeCSS(self, open=open):  # pylint: disable=W0622
         if not self.__cssFilename or os.path.exists(self.__cssFilename):

--- a/taskcoachlib/widgets/frame.py
+++ b/taskcoachlib/widgets/frame.py
@@ -21,24 +21,24 @@ import wx.lib.agw.aui as aui
 from taskcoachlib import operating_system
 
 
-# --- Rebuild guard: block input during list/tree rebuilds ---
+# --- Rebuild guard: block motion events during list/tree rebuilds ---
 
-# Mouse and keyboard event types to eat during rebuild
-_INPUT_EVENTS = {
-    wx.wxEVT_LEFT_DOWN, wx.wxEVT_LEFT_UP, wx.wxEVT_LEFT_DCLICK,
-    wx.wxEVT_RIGHT_DOWN, wx.wxEVT_RIGHT_UP, wx.wxEVT_RIGHT_DCLICK,
-    wx.wxEVT_MIDDLE_DOWN, wx.wxEVT_MIDDLE_UP, wx.wxEVT_MIDDLE_DCLICK,
-    wx.wxEVT_MOTION, wx.wxEVT_MOUSEWHEEL,
+# Motion event types to eat during rebuild.  Only motion events are
+# suppressed - clicks, keyboard, and scroll are passed through so
+# the app remains responsive.  Motion events drive the AUI cascade
+# (OnMotion -> hover -> repaint -> repeat) and must be suppressed.
+_MOTION_EVENTS = {
+    wx.wxEVT_MOTION,
     wx.wxEVT_ENTER_WINDOW, wx.wxEVT_LEAVE_WINDOW,
-    wx.wxEVT_KEY_DOWN, wx.wxEVT_KEY_UP, wx.wxEVT_CHAR, wx.wxEVT_CHAR_HOOK,
 }
 
 
 class _RebuildInputFilter(wx.EventFilter):
-    """Silently eat mouse and keyboard events during rebuild.
+    """Silently eat mouse motion events during rebuild.
 
-    No visual effect — no gray, no disable flicker.  Just drops
-    input events so mouse movement can't drive the AUI cascade.
+    No visual effect - no gray, no disable flicker.  Just drops
+    motion events so mouse movement can't drive the AUI cascade.
+    Clicks, keyboard, and scroll events pass through normally.
     """
     active = False
     _refcount = 0
@@ -47,8 +47,7 @@ class _RebuildInputFilter(wx.EventFilter):
     def FilterEvent(self, event):
         if not self.active:
             return self.Event_Skip
-        etype = event.GetEventType()
-        if etype in _INPUT_EVENTS:
+        if event.GetEventType() in _MOTION_EVENTS:
             return self.Event_Processed
         return self.Event_Skip
 
@@ -127,7 +126,7 @@ class AuiManagedFrameWithDynamicCenterPane(wx.Frame):
         super().__init__(*args, **kwargs)
 
         # Build AUI style flags with live resize for visual feedback when dragging sashes
-        agwStyle = (
+        agw_style = (
             aui.AUI_MGR_DEFAULT
             | aui.AUI_MGR_ALLOW_ACTIVE_PANE
             | aui.AUI_MGR_LIVE_RESIZE  # Live visual feedback when dragging sashes
@@ -135,9 +134,9 @@ class AuiManagedFrameWithDynamicCenterPane(wx.Frame):
 
         if not operating_system.isWindows():
             # With this style on Windows, you can't dock back floating frames
-            agwStyle |= aui.AUI_MGR_USE_NATIVE_MINIFRAMES
+            agw_style |= aui.AUI_MGR_USE_NATIVE_MINIFRAMES
 
-        self.manager = aui.AuiManager(self, agwStyle)
+        self.manager = aui.AuiManager(self, agw_style)
 
         # Throttle AUI sash resize updates to ~30fps to reduce flickering
         _install_sash_resize_optimization(self.manager)
@@ -148,32 +147,32 @@ class AuiManagedFrameWithDynamicCenterPane(wx.Frame):
             | aui.AUI_NB_SUB_NOTEBOOK
             | aui.AUI_NB_SCROLL_BUTTONS
         )
-        self.bindEvents()
+        self.bind_events()
 
-    def bindEvents(self):
-        for eventType in aui.EVT_AUI_PANE_CLOSE, aui.EVT_AUI_PANE_FLOATING:
-            self.manager.Bind(eventType, self.onPaneClosingOrFloating)
+    def bind_events(self):
+        for event_type in aui.EVT_AUI_PANE_CLOSE, aui.EVT_AUI_PANE_FLOATING:
+            self.manager.Bind(event_type, self.on_pane_closing_or_floating)
 
-    def onPaneClosingOrFloating(self, event):
+    def on_pane_closing_or_floating(self, event):
         pane = event.GetPane()
-        dockedPanes = self.dockedPanes()
-        if self.isCenterPane(pane) and len(dockedPanes) == 1:
+        docked_panes = self.docked_panes()
+        if self.is_center_pane(pane) and len(docked_panes) == 1:
             event.Veto()
         else:
             event.Skip()
-            if self.isCenterPane(pane):
-                if pane in dockedPanes:
-                    dockedPanes.remove(pane)
-                dockedPanes[0].Center()
+            if self.is_center_pane(pane):
+                if pane in docked_panes:
+                    docked_panes.remove(pane)
+                docked_panes[0].Center()
 
-    def addPane(self, window, caption, name, floating=False):
+    def add_pane(self, window, caption, name, floating=False):
         x, y = 0, 0
         if self.GetTopLevelParent().IsShown():
             x, y = window.GetPosition()
             x, y = window.ClientToScreen(x, y)
-        paneInfo = aui.AuiPaneInfo()
-        paneInfo = (
-            paneInfo.CloseButton(True)
+        pane_info = aui.AuiPaneInfo()
+        pane_info = (
+            pane_info.CloseButton(True)
             .Floatable(True)
             .Name(name)
             .Caption(caption)
@@ -186,17 +185,17 @@ class AuiManagedFrameWithDynamicCenterPane(wx.Frame):
             .DestroyOnClose()
         )
         if floating:
-            paneInfo.Float()
-        if not self.dockedPanes():
+            pane_info.Float()
+        if not self.docked_panes():
             # First pane goes to center
-            paneInfo = paneInfo.Center()
-        self.manager.AddPane(window, paneInfo)
+            pane_info = pane_info.Center()
+        self.manager.AddPane(window, pane_info)
         self.manager.Update()
 
-    def setPaneTitle(self, window, title):
+    def set_pane_title(self, window, title):
         self.manager.GetPane(window).Caption(title)
 
-    def dockedPanes(self):
+    def docked_panes(self):
         return [
             pane
             for pane in self.manager.GetAllPanes()
@@ -209,5 +208,5 @@ class AuiManagedFrameWithDynamicCenterPane(wx.Frame):
         self.manager.GetPane(window).Float()
 
     @staticmethod
-    def isCenterPane(pane):
+    def is_center_pane(pane):
         return pane.dock_direction_get() == aui.AUI_DOCK_CENTER

--- a/taskcoachlib/widgets/itemctrl.py
+++ b/taskcoachlib/widgets/itemctrl.py
@@ -81,19 +81,19 @@ class _CtrlWithItemPopupMenuMixin(_CtrlWithPopupMenuMixin):
                 self._attachPopupMenu(
                     self,
                     (wx.EVT_LIST_ITEM_RIGHT_CLICK,),
-                    self.onListItemRightClick,
+                    self.on_list_item_right_click,
                 )
                 self._attachPopupMenu(
                     self,
                     (wx.EVT_CONTEXT_MENU,),
-                    self.onListContextMenu,
+                    self.on_list_context_menu,
                 )
             else:
                 # For tree controls: use EVT_TREE_ITEM_RIGHT_CLICK and EVT_CONTEXT_MENU
                 self._attachPopupMenu(
                     self,
                     (wx.EVT_TREE_ITEM_RIGHT_CLICK, wx.EVT_CONTEXT_MENU),
-                    self.onItemPopupMenu,
+                    self.on_item_popup_menu,
                 )
                 # Also bind to MainWindow to catch right-clicks on empty space
                 self.GetMainWindow().Bind(
@@ -121,7 +121,7 @@ class _CtrlWithItemPopupMenuMixin(_CtrlWithPopupMenuMixin):
         if hasattr(self._itemPopupMenu, '_update_menu_state'):
             self._itemPopupMenu._update_menu_state()
 
-    def onItemPopupMenu(self, event):
+    def on_item_popup_menu(self, event):
         """Handle popup menu for tree controls (EVT_TREE_ITEM_RIGHT_CLICK, EVT_CONTEXT_MENU)."""
         # Make sure the window this control is in has focus:
         try:
@@ -156,7 +156,7 @@ class _CtrlWithItemPopupMenuMixin(_CtrlWithPopupMenuMixin):
         self._updateMenuUI()
         self.PopupMenu(self._itemPopupMenu)
 
-    def onListItemRightClick(self, event):
+    def on_list_item_right_click(self, event):
         """Handle EVT_LIST_ITEM_RIGHT_CLICK for ListCtrl controls.
 
         This event fires when right-clicking on an item and provides
@@ -165,16 +165,16 @@ class _CtrlWithItemPopupMenuMixin(_CtrlWithPopupMenuMixin):
         """
         self.SetFocus()
         # Get the clicked item index from the event
-        itemIndex = event.GetIndex()
+        item_index = event.GetIndex()
         # Select the item if not already selected
-        if not self.IsSelected(itemIndex):
+        if not self.IsSelected(item_index):
             self.clear_selection()
-            self.Select(itemIndex, True)
+            self.Select(item_index, True)
         # Update menu and show popup
         self._updateMenuUI()
         self.PopupMenu(self._itemPopupMenu)
 
-    def onListContextMenu(self, event):
+    def on_list_context_menu(self, event):
         """Handle EVT_CONTEXT_MENU for ListCtrl controls.
 
         This handles right-clicks on empty space (EVT_LIST_ITEM_RIGHT_CLICK
@@ -184,8 +184,8 @@ class _CtrlWithItemPopupMenuMixin(_CtrlWithPopupMenuMixin):
         pos = event.GetPosition()
         if pos != wx.DefaultPosition:
             # Mouse-triggered context menu - check if on empty space
-            clientPoint = self.ScreenToClient(pos)
-            item = self.HitTest(clientPoint)[0]
+            client_point = self.ScreenToClient(pos)
+            item = self.HitTest(client_point)[0]
             if self._itemIsOk(item):
                 # Click was on an item - EVT_LIST_ITEM_RIGHT_CLICK already handled it
                 return
@@ -207,15 +207,15 @@ class _CtrlWithColumnPopupMenuMixin(_CtrlWithPopupMenuMixin):
         super().__init__(*args, **kwargs)
         if self.__popupMenu is not None:
             self._attachPopupMenu(
-                self, [wx.EVT_LIST_COL_RIGHT_CLICK], self.onColumnPopupMenu
+                self, [wx.EVT_LIST_COL_RIGHT_CLICK], self.on_column_popup_menu
             )
 
-    def onColumnPopupMenu(self, event):
+    def on_column_popup_menu(self, event):
         # We store the columnIndex in the menu, because it's near to
         # impossible for commands in the menu to determine on what column the
         # menu was popped up.
-        columnIndex = event.GetColumn()
-        self.__popupMenu.columnIndex = columnIndex
+        column_index = event.GetColumn()
+        self.__popupMenu.columnIndex = column_index
         # Because right-clicking on column headers does not automatically give
         # focus to the control, we force the focus:
         try:
@@ -232,9 +232,9 @@ class _CtrlWithDropTargetMixin(_CtrlWithItemsMixin):
     """Control that accepts files, e-mails or URLs being dropped onto items."""
 
     def __init__(self, *args, **kwargs):
-        self.__onDropURLCallback = kwargs.pop("onDropURL", None)
-        self.__onDropFilesCallback = kwargs.pop("onDropFiles", None)
-        self.__onDropMailCallback = kwargs.pop("onDropMail", None)
+        self.__on_drop_url_callback = kwargs.pop("on_drop_url", None)
+        self.__on_drop_files_callback = kwargs.pop("on_drop_files", None)
+        self.__on_drop_mail_callback = kwargs.pop("on_drop_mail", None)
         self.__dropHighlightItem = None  # Track highlighted item during drag
         # Hover-expand timer: auto-expand collapsed items after hover delay
         self.__hoverExpandTimerId = wx.NewIdRef()
@@ -242,43 +242,43 @@ class _CtrlWithDropTargetMixin(_CtrlWithItemsMixin):
         self.__hoverExpandItem = None  # Item currently being hovered for expansion
         super().__init__(*args, **kwargs)
         if (
-            self.__onDropURLCallback
-            or self.__onDropFilesCallback
-            or self.__onDropMailCallback
+            self.__on_drop_url_callback
+            or self.__on_drop_files_callback
+            or self.__on_drop_mail_callback
         ):
-            dropTarget = draganddrop.DropTarget(
-                self.onDropURL,
-                self.onDropFiles,
-                self.onDropMail,
-                self.onDragOver,
+            drop_target = draganddrop.DropTarget(
+                self.on_drop_url,
+                self.on_drop_files,
+                self.on_drop_mail,
+                self.on_drag_over,
             )
-            self.GetMainWindow().SetDropTarget(dropTarget)
+            self.GetMainWindow().SetDropTarget(drop_target)
             # Initialize hover-expand timer
             self.__hoverExpandTimer = wx.Timer(self, self.__hoverExpandTimerId)
             self.Bind(wx.EVT_TIMER, self.__onHoverExpandTimer, id=self.__hoverExpandTimerId)
 
-    def onDropURL(self, x, y, url):
+    def on_drop_url(self, x, y, url):
         self._clearDropHighlight()  # Clear highlight on drop
         self.__stopHoverExpandTimer()  # Cancel any pending expand
         item = self.HitTest((x, y))[0]
-        if self.__onDropURLCallback:
-            self.__onDropURLCallback(self._objectBelongingTo(item), url)
+        if self.__on_drop_url_callback:
+            self.__on_drop_url_callback(self._objectBelongingTo(item), url)
 
-    def onDropFiles(self, x, y, filenames):
+    def on_drop_files(self, x, y, filenames):
         self._clearDropHighlight()  # Clear highlight on drop
         self.__stopHoverExpandTimer()  # Cancel any pending expand
         item = self.HitTest((x, y))[0]
-        if self.__onDropFilesCallback:
-            self.__onDropFilesCallback(self._objectBelongingTo(item), filenames)
+        if self.__on_drop_files_callback:
+            self.__on_drop_files_callback(self._objectBelongingTo(item), filenames)
 
-    def onDropMail(self, x, y, mail):
+    def on_drop_mail(self, x, y, mail):
         self._clearDropHighlight()  # Clear highlight on drop
         self.__stopHoverExpandTimer()  # Cancel any pending expand
         item = self.HitTest((x, y))[0]
-        if self.__onDropMailCallback:
-            self.__onDropMailCallback(self._objectBelongingTo(item), mail)
+        if self.__on_drop_mail_callback:
+            self.__on_drop_mail_callback(self._objectBelongingTo(item), mail)
 
-    def onDragOver(self, x, y, defaultResult):
+    def on_drag_over(self, x, y, defaultResult):
         item, flags = self.HitTest((x, y))[:2]
         if self._itemIsOk(item):
             # Auto-expand collapsed items on hover (modern UX behavior)
@@ -618,11 +618,11 @@ class _CtrlWithSortableColumnsMixin(_BaseCtrlWithColumnsMixin):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.Bind(wx.EVT_LIST_COL_CLICK, self.onColumnClick)
+        self.Bind(wx.EVT_LIST_COL_CLICK, self.on_column_click)
         self.__currentSortColumn = self._getColumn(0)
         self.__currentSortImageIndex = -1
 
-    def onColumnClick(self, event):
+    def on_column_click(self, event):
         event.Skip(False)
         # Make sure the window this control is in has focus:
         try:
@@ -646,14 +646,14 @@ class _CtrlWithSortableColumnsMixin(_BaseCtrlWithColumnsMixin):
             # wrapped C/C++ object has been deleted
             pass
 
-    def showSortColumn(self, column):
+    def show_sort_column(self, column):
         if column != self.__currentSortColumn:
             self._clearSortImage()
         self.__currentSortColumn = column
         self._showSortImage()
 
-    def showSortOrder(self, imageIndex):
-        self.__currentSortImageIndex = imageIndex
+    def show_sort_order(self, image_index):
+        self.__currentSortImageIndex = image_index
         self._showSortImage()
 
     def _clearSortImage(self):
@@ -684,9 +684,9 @@ class _CtrlWithAutoResizedColumnsMixin(autowidth.AutoColumnWidthMixin):
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.Bind(wx.EVT_LIST_COL_END_DRAG, self.onEndColumnResize)
+        self.Bind(wx.EVT_LIST_COL_END_DRAG, self.on_end_column_resize)
 
-    def onEndColumnResize(self, event):
+    def on_end_column_resize(self, event):
         """Save the column widths after the user did a resize."""
         for index, column in enumerate(self._visibleColumns()):
             column.setWidth(self.GetColumnWidth(index))

--- a/taskcoachlib/widgets/treectrl.py
+++ b/taskcoachlib/widgets/treectrl.py
@@ -324,7 +324,51 @@ class TreeListCtrl(
         and selection suppression — NOT as a re-entry guard."""
         return self.__refreshing
 
+    def _snapshot_tree(self, parent_item):
+        """Return list of object IDs in depth-first order for current tree."""
+        result = []
+        child_item, cookie = self.GetFirstChild(parent_item)
+        while child_item:
+            obj = self.GetItemPyData(child_item)
+            result.append(obj.id() if obj else None)
+            result.extend(self._snapshot_tree(child_item))
+            child_item, cookie = self.GetNextChild(parent_item, cookie)
+        return result
+
+    def _snapshot_adapter(self, parent_object=None):
+        """Return list of object IDs in depth-first order from adapter."""
+        result = []
+        for child_object in self.__adapter.children(parent_object):
+            result.append(child_object.id())
+            if self.__adapter.getItemExpanded(child_object):
+                result.extend(self._snapshot_adapter(child_object))
+        return result
+
     def RefreshAllItems(self, count=0):  # pylint: disable=W0613
+        # Check if tree structure actually changed before rebuilding
+        root_item = self.GetRootItem()
+        if root_item:
+            current = self._snapshot_tree(root_item)
+            desired = self._snapshot_adapter()
+            if current and current == desired:
+                # Structure unchanged - refresh items in place
+                self._refresh_all_items_in_place(root_item)
+                return
+
+        self._do_full_rebuild()
+
+    def _refresh_all_items_in_place(self, parent_item):
+        """Refresh text, colors, font for all items without rebuilding."""
+        child_item, cookie = self.GetFirstChild(parent_item)
+        while child_item:
+            obj = self.GetItemPyData(child_item)
+            if obj is not None:
+                self._refreshObjectCompletely(child_item, obj)
+            self._refresh_all_items_in_place(child_item)
+            child_item, cookie = self.GetNextChild(parent_item, cookie)
+
+    def _do_full_rebuild(self):
+        """Full delete-and-recreate rebuild of the tree."""
         from taskcoachlib.widgets.frame import (
             _input_filter, _ensure_filter_installed,
         )
@@ -409,12 +453,12 @@ class TreeListCtrl(
             main.AdjustMyScrollbars()
             item = selections[0]
             item_y = item.GetY()
-            xUnit, yUnit = main.GetScrollPixelsPerUnit()
+            x_unit, y_unit = main.GetScrollPixelsPerUnit()
             client_h = main.GetClientSize().GetHeight()
             line_h = main.GetLineHeight(item)
             center_y = max(0, item_y - client_h // 2 + line_h // 2)
             x_pos = main.GetScrollPos(wx.HORIZONTAL)
-            main.Scroll(x_pos, center_y // yUnit if yUnit > 0 else 0)
+            main.Scroll(x_pos, center_y // y_unit if y_unit > 0 else 0)
 
     def RefreshItems(self, *objects):
         self.__selection = self.curselection()
@@ -767,9 +811,9 @@ class CheckTreeCtrl(TreeListCtrl):
             if hasattr(parent, "getIsItemCheckable")
             else lambda item: True
         )
-        self.getIsItemChecked = parent.getIsItemChecked
-        self.getItemParentHasExclusiveChildren = (
-            parent.getItemParentHasExclusiveChildren
+        self.get_is_item_checked = parent.get_is_item_checked
+        self.get_item_parent_has_exclusive_children = (
+            parent.get_item_parent_has_exclusive_children
         )
 
     def getItemCTType(self, domain_object):
@@ -779,7 +823,7 @@ class CheckTreeCtrl(TreeListCtrl):
         if self.getIsItemCheckable(domain_object):
             return (
                 2
-                if self.getItemParentHasExclusiveChildren(domain_object)
+                if self.get_item_parent_has_exclusive_children(domain_object)
                 else 1
             )
         else:
@@ -849,7 +893,7 @@ class CheckTreeCtrl(TreeListCtrl):
 
     def _refreshCheckState(self, item, domain_object):
         # Use CheckItem2 so no events get sent:
-        checked = self.getIsItemChecked(domain_object)
+        checked = self.get_is_item_checked(domain_object)
         if checked is None:
             # Mixed state - enable 3-state and set undetermined
             item.Set3State(True)


### PR DESCRIPTION
Sort idempotency: add UUID as first (least significant) sort pass to guarantee deterministic ordering for items with equal sort keys. Without this, pairs with identical subjects flip-flop on every re-sort due to the missing statusSortFunction silently falling back to subject (creating conflicting forward/reversed subject passes).  Log the silent fallback so missing sort functions are visible.

Skip redundant rebuilds: before deleting and recreating all tree nodes, snapshot the current tree structure (object IDs in depth-first order) and compare against what the presentation would produce.  If identical, refresh items in place (text, colors, font) without rebuilding.

Remove save freeze/rebuild: viewers no longer subscribe to aboutToSave/justSaved - saving to disk does not change the presentation.

Narrow EventFilter to motion events only: clicks, keyboard, and scroll pass through so the app stays responsive during rebuilds.

PEP 8 renames across sorter, viewer, container, frame, itemctrl, and all callers: snake_case for methods, locals, and parameters.  Renamed ~80 identifiers across 22 files including sort_by, sort_keys, sort_ascending, sort_case_sensitive, sort_event_type, is_ascending, create_sort_key_function, add_pane, set_pane_title, docked_panes, is_center_pane, bind_events, active_viewer, activate_viewer, add_viewer, close_viewer, advance_selection, components_created, is_showing_tasks/effort/notes/attachments/categories, on_begin_io, on_end_io, register_presentation_observers, send_viewer_status_event, on_presentation_changed, init_layout, set_title, show_sort_column, show_sort_order, expand_all, collapse_all, hide_column, check_all_categories, get_is_item_checked, on_item_popup_menu, on_drop_url/files/mail, on_column_click, on_end_column_resize.