### PR TITLE
Update download-artifact to Node.js 24 compatible v6

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history for version info
 
@@ -365,7 +365,7 @@ jobs:
           echo "All tests passed!"
 
       - name: Upload AppImage artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: TaskCoach-AppImage-${{ steps.version.outputs.version }}
           path: TaskCoach-*.AppImage
@@ -401,7 +401,7 @@ jobs:
 
     steps:
       - name: Download AppImage artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: TaskCoach-AppImage-*
           merge-multiple: true

--- a/.github/workflows/build-arch.yml
+++ b/.github/workflows/build-arch.yml
@@ -45,7 +45,7 @@ jobs:
           echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -164,7 +164,7 @@ jobs:
           ls -la artifacts/
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: taskcoach-${{ steps.version.outputs.version }}-arch-linux
           path: artifacts/
@@ -178,7 +178,7 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: taskcoach-*-arch-linux
           merge-multiple: true
@@ -255,7 +255,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: taskcoach-*-arch-linux
           merge-multiple: true

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -62,7 +62,7 @@ jobs:
           apt-get install -y git ca-certificates
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -178,7 +178,7 @@ jobs:
           ls -la artifacts/
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: taskcoach-${{ steps.version.outputs.version }}-${{ matrix.os }}-${{ matrix.osver }}-${{ matrix.codename }}
           path: artifacts/
@@ -212,7 +212,7 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: taskcoach-*-${{ matrix.os }}-${{ matrix.osver }}-${{ matrix.codename }}
           merge-multiple: true
@@ -274,7 +274,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: taskcoach-*
           merge-multiple: true

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -35,12 +35,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -314,7 +314,7 @@ jobs:
           ls -la *.dmg
 
       - name: Upload DMG artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: TaskCoach-macos-${{ matrix.suffix }}-${{ steps.version.outputs.version }}
           path: TaskCoach-*.dmg
@@ -329,7 +329,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: TaskCoach-macos-*
           merge-multiple: true

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -46,7 +46,7 @@ jobs:
           dnf install -y git rpm-build rpmdevtools dnf-plugins-core
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -151,7 +151,7 @@ jobs:
           ls -la artifacts/
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: taskcoach-${{ steps.version.outputs.version }}-${{ matrix.os }}-${{ matrix.osver }}
           path: artifacts/
@@ -178,7 +178,7 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: taskcoach-*-${{ matrix.os }}-${{ matrix.osver }}
           merge-multiple: true
@@ -226,7 +226,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: taskcoach-*
           merge-multiple: true

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -375,7 +375,7 @@ jobs:
           ls -la build/TaskCoach/ | head -20
 
       - name: Upload installer artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: TaskCoach-windows-${{ matrix.suffix }}-installer-${{ steps.version.outputs.version }}
           path: dist/TaskCoach-*.exe
@@ -392,7 +392,7 @@ jobs:
           ls -la *.zip
 
       - name: Upload portable artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: TaskCoach-windows-${{ matrix.suffix }}-portable-${{ steps.version.outputs.version }}
           path: TaskCoach-*-portable.zip
@@ -407,7 +407,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: TaskCoach-windows-*
           merge-multiple: true


### PR DESCRIPTION
The previous PR (#409) updated checkout and upload-artifact but missed download-artifact@v4 (9 occurrences across all 6 workflows).

- actions/download-artifact v4 -> v6

Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 2, 2026.