### PR TITLE
fix: prerequisite tab no longer loads due to method name mismatch

### DIFF
--- a/taskcoachlib/widgets/treectrl.py
+++ b/taskcoachlib/widgets/treectrl.py
@@ -812,8 +812,8 @@ class CheckTreeCtrl(TreeListCtrl):
             else lambda item: True
         )
         self.get_is_item_checked = parent.get_is_item_checked
-        self.get_item_parent_has_exclusive_children = (
-            parent.get_item_parent_has_exclusive_children
+        self.getItemParentHasExclusiveChildren = (
+            parent.getItemParentHasExclusiveChildren
         )
 
     def getItemCTType(self, domain_object):
@@ -823,7 +823,7 @@ class CheckTreeCtrl(TreeListCtrl):
         if self.getIsItemCheckable(domain_object):
             return (
                 2
-                if self.get_item_parent_has_exclusive_children(domain_object)
+                if self.getItemParentHasExclusiveChildren(domain_object)
                 else 1
             )
         else:


### PR DESCRIPTION
## Problem

Fixes #415

The Prerequisites tab was failing to load with an AttributeError:



## Root Cause

The `CheckTreeCtrl` class in `treectrl.py` was trying to access `get_item_parent_has_exclusive_children` (snake_case) on the parent viewer, but the actual method defined in the viewer classes is `getItemParentHasExclusiveChildren` (camelCase).

This naming mismatch caused the Prerequisites tab to fail completely when trying to create the `CheckTreeCtrl` widget.

## Solution

Changed the method name references in `treectrl.py` from snake_case to camelCase:

- `self.get_item_parent_has_exclusive_children` → `self.getItemParentHasExclusiveChildren`
- `parent.get_item_parent_has_exclusive_children` → `parent.getItemParentHasExclusiveChildren`

## Files Changed

- `taskcoachlib/widgets/treectrl.py`: Fixed 3 occurrences of the incorrect method name

## Verification

- The existing test file `TreeCtrlTest.py` already uses the correct camelCase method name, confirming this is the intended naming convention
- The fix is minimal and only changes the incorrect references

## Contributor License Agreement
By submitting this pull request, I confirm that my contribution is made under the terms of the project's license and I have the right to submit it.
- [x] I have read and agree to the project's contributing guidelines
- [x] This contribution is my original work (or properly attributed)
- [x] I license this contribution under the project's existing license