### PR TITLE
fix(gui): Fix Prerequisites tab not loading (closes #415)

### DIFF
--- a/taskcoachlib/gui/viewer/task.py
+++ b/taskcoachlib/gui/viewer/task.py
@@ -2241,10 +2241,10 @@ class CheckableTaskViewer(TaskViewer):  # pylint: disable=W0223
     def onCheck(self, event, final):
         pass
 
-    def getIsItemChecked(self, task):  # pylint: disable=W0613,W0621
+    def get_is_item_checked(self, task):  # pylint: disable=W0613,W0621
         return False
 
-    def getItemParentHasExclusiveChildren(
+    def get_item_parent_has_exclusive_children(
         self, task
     ):  # pylint: disable=W0613,W0621
         return False

--- a/tests/unittests/widgetTests/TreeCtrlTest.py
+++ b/tests/unittests/widgetTests/TreeCtrlTest.py
@@ -39,7 +39,7 @@ class TreeCtrlTestCase(test.wxTestCase):
         self.frame.getItemImages = lambda item, column: {
             wx.TreeItemIcon_Normal: -1
         }
-        self.frame.getIsItemChecked = lambda item: False
+        self.frame.get_is_item_checked = lambda item: False
         self.frame.getItemExpanded = (
             lambda item: item not in self.collapsedItems
         )
@@ -262,7 +262,7 @@ class TreeListCtrlTest(TreeCtrlTestCase, CommonTestsMixin):
 
 class CheckTreeCtrlTest(TreeCtrlTestCase, CommonTestsMixin):
     def setUp(self):
-        self.frame.getItemParentHasExclusiveChildren = (
+        self.frame.get_item_parent_has_exclusive_children = (
             lambda item: item.subject().startswith("mutual")
         )
         super().setUp()


### PR DESCRIPTION
## Problem
The Prerequisites tab fails to load with the following error:
```
AttributeError: 'LocalPrerequisiteViewer' object has no attribute 'get_item_parent_has_exclusive_children'. Did you mean: 'getItemParentHasExclusiveChildren'?
```

## Root Cause
The recent PEP 8 renaming commit (6f5fae795) renamed most camelCase methods to snake_case, but missed two methods in `CheckableTaskViewer`:
- `getIsItemChecked` 
- `getItemParentHasExclusiveChildren`

The `CheckTreeCtrl` widget expects these methods to be in snake_case format, causing an `AttributeError` when the Prerequisites tab is selected.

## Fix
Renamed the missed methods to snake_case:
- `getIsItemChecked` → `get_is_item_checked`
- `getItemParentHasExclusiveChildren` → `get_item_parent_has_exclusive_children`

Also updated the corresponding test file to use the new method names.

## Testing
- [x] Verified the method names now match what `CheckTreeCtrl` expects
- [x] Updated unit tests to use the correct method names

Fixes #415