### PR TITLE
Fix #415: Prerequisites tab no longer loads

### DIFF
--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -2585,6 +2585,11 @@ class LocalPrerequisiteViewer(
         self.__items = items
         super().__init__(*args, **kwargs)
 
+    # Alias for snake_case compatibility with CheckTreeCtrl
+    get_item_parent_has_exclusive_children = (
+        viewer.CheckableTaskViewer.getItemParentHasExclusiveChildren
+    )
+
     def get_is_item_checked(self, item):
         return item in self.__items[0].prerequisites()
 

--- a/tests/unittests/guiTests/LocalPrerequisiteViewerTest.py
+++ b/tests/unittests/guiTests/LocalPrerequisiteViewerTest.py
@@ -1,0 +1,28 @@
+import unittest
+from taskcoachlib.gui.dialog import editor
+from taskcoachlib.gui import viewer
+
+
+class LocalPrerequisiteViewerTest(unittest.TestCase):
+    """Tests for the LocalPrerequisiteViewer class."""
+
+    def test_has_snake_case_method(self):
+        """Test that LocalPrerequisiteViewer has the snake_case method
+        required by CheckTreeCtrl."""
+        # The method should exist as a class attribute
+        self.assertTrue(
+            hasattr(editor.LocalPrerequisiteViewer, 'get_item_parent_has_exclusive_children'),
+            "LocalPrerequisiteViewer should have get_item_parent_has_exclusive_children method"
+        )
+
+    def test_snake_case_method_is_same_as_camel_case(self):
+        """Test that the snake_case method is the same as camelCase method."""
+        # The method should be the same as getItemParentHasExclusiveChildren
+        self.assertEqual(
+            editor.LocalPrerequisiteViewer.get_item_parent_has_exclusive_children,
+            viewer.CheckableTaskViewer.getItemParentHasExclusiveChildren
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes the Prerequisites tab not loading by adding the missing `get_item_parent_has_exclusive_children` method alias.

## Problem
The `CheckTreeCtrl` widget in `treectrl.py` expects a `get_item_parent_has_exclusive_children` method (snake_case) on its parent, but `LocalPrerequisiteViewer` only inherits `getItemParentHasExclusiveChildren` (camelCase) from `CheckableTaskViewer`.

This caused the following error when opening the Prerequisites tab:
```
AttributeError: 'LocalPrerequisiteViewer' object has no attribute 'get_item_parent_has_exclusive_children'
```

## Solution
Added a snake_case alias in `LocalPrerequisiteViewer`:
```python
get_item_parent_has_exclusive_children = (
    viewer.CheckableTaskViewer.getItemParentHasExclusiveChildren
)
```

## Testing
- Added `LocalPrerequisiteViewerTest.py` with 2 tests:
  1. Verify the snake_case method exists
  2. Verify it points to the correct camelCase method
- Both tests pass

## Changes
- Modified `taskcoachlib/gui/dialog/editor.py`
- Added `tests/unittests/guiTests/LocalPrerequisiteViewerTest.py`

Fixes #415

## Contributor License Agreement
By submitting this pull request, I confirm that my contribution is made under the terms of the project's license and I have the right to submit it.
- [x] I have read and agree to the project's contributing guidelines
- [x] This contribution is my original work
- [x] I license this contribution under the project's existing license
