### PR TITLE
Fix rebuild blank screen, CompositeEffort crash, PEP 8 renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.9-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.9-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.9_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.9_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.9_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.9-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.10-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.10-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.10_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.10_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.10_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.10-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.9-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.9-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.9_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.9_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.2.9-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.2.9-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.10-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.10-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.10_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.10_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.2.10-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.2.10-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.9_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.2.9_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.10_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.2.10_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.9-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.2.9-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.10-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.2.10-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.9-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.2.9-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.10-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.2.10-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.9-x86_64.AppImage
-chmod +x TaskCoach-2.0.2.9-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.10-x86_64.AppImage
+chmod +x TaskCoach-2.0.2.10-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.2.9-x86_64.AppImage
+./TaskCoach-2.0.2.10-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/docs/LIST_MANAGEMENT.md
+++ b/docs/LIST_MANAGEMENT.md
@@ -719,68 +719,49 @@ position and movement** relative to the app window.  Toolbar toggle
 is fast (mouse stays on toolbar); menu toggle varies (depends on mouse
 position after menu dismiss).
 
-### Current Solution (3 layers)
+### Current Solution (2 layers)
 
-**1. Paint suppression on TreeListCtrl** (`treectrl.py`):
-Replaces the tree widget's `OnPaint` handler.  **Only active during
-refresh** (`__refreshing=True`) — normal paints (hover, scroll, mouse
-interaction) are never affected.  During refresh, **ALL** paints are
-suppressed with an empty `wx.PaintDC` (validates the GDK region to
-prevent infinite expose loops, but draws nothing).  This completely
-breaks the AUI cascade at its source — each cascade paint of 291 items
-takes ~280ms, and without suppression 5+ cascade paints cause a
-1.4+ second freeze.  A single clean `Refresh()` is triggered when
-`__refreshing` clears, rendering the final state with correct item
-positions.
+**1. Synchronous rebuild** (`treectrl.py`):
+`_do_full_rebuild()` is synchronous: Freeze, delete, rebuild, Thaw,
+`Refresh(eraseBackground=False)`.  The `__refreshing` flag is set
+during Freeze/Thaw to suppress selection events, then cleared
+immediately after Thaw.  No paint suppression, no idle wait.
 
-**Why suppress ALL paints, not throttle?**  The cascade is
-self-sustaining: AUI paint → GDK damage on children → child repaint →
-AUI repaint → repeat.  Each tree paint takes ~280ms for a 291-item
-list, so a 100ms throttle lets every cascade paint through (they're
-always >100ms apart).  Only total suppression breaks the cycle.
-
-**2. `__refreshing` lifecycle flag** (`treectrl.py`):
-`RefreshAllItems()` sets `__refreshing=True` before rebuild.  An
-`EVT_IDLE` handler (`_on_refresh_idle`) monitors the upstream
-`_dirty` flag on the tree's main window; when `_dirty=False` + one
-extra idle cycle (for the paint from `OnInternalIdle`'s `Refresh()`),
-it clears `__refreshing` and triggers one final `Refresh()` for a
-clean paint with correct item positions (after `CalculatePositions()`).
-`__refreshing` is NOT used as a re-entry guard — multiple
-`RefreshAllItems` calls can overlap.  It only drives paint suppression
-and selection event suppression.
-
-**3. EventFilter motion blocking** (`frame.py`):
+**2. EventFilter motion blocking** (`frame.py`):
 `_RebuildInputFilter` is a `wx.EventFilter` that silently eats mouse
 **motion** events (MOTION, ENTER_WINDOW, LEAVE_WINDOW) at the wx level.
 Clicks, keyboard, and scroll events pass through normally so the app
 stays responsive.  Only motion events are suppressed because they drive
 the AUI cascade (OnMotion -> hover state change -> repaint -> repeat).
-Each `RefreshAllItems` call increments a refcount via `acquire()`; each
-`_on_refresh_idle` decrements via `release()`.  When the last widget
-completes, a 1-second deferred release timer starts to cover the
-post-rebuild settling period.  If a new rebuild starts during the
-settling, the timer is cancelled and the filter stays active.
+Each `_do_full_rebuild` call increments a refcount via `acquire()` and
+decrements via `release()`.  When the last widget completes, a
+1-second deferred release timer starts to cover the post-rebuild
+settling period.  If a new rebuild starts during the settling, the
+timer is cancelled and the filter stays active.
 
 ### How the layers work together
 
 ```
 RefreshAllItems()
+    ├── snapshot comparison: tree unchanged? -> refresh in place, return
     ├── _input_filter.acquire()  (refcount++, filter active)
-    ├── __refreshing = True  (paint suppression activates)
-    ├── Freeze → build items → Thaw → restore selection
-    ├── Thaw triggers paint → SUPPRESSED (empty PaintDC)
-    ├── AUI cascade paints → ALL SUPPRESSED (zero drawing work)
-    ├── EVT_IDLE → OnInternalIdle → CalculatePositions → _dirty=False
-    ├── _on_refresh_idle (extra idle cycle for safety)
-    │   ├── __refreshing = False  (paint suppression deactivates)
-    │   ├── _input_filter.release()  (refcount--, deferred release if 0)
-    │   └── Refresh() → ONE clean paint with correct positions
+    ├── __refreshing = True  (selection events suppressed)
+    ├── Freeze -> delete -> rebuild -> Thaw
+    ├── __refreshing = False
+    ├── restore selection, scroll
+    ├── Refresh(eraseBackground=False)  (immediate paint)
+    ├── _input_filter.release()  (refcount--, deferred release if 0)
     └── 1s later: filter deactivates (motion events resume)
 ```
 
-Total elapsed: rebuild ~80ms + CalculatePositions + one paint ~280ms.
-Cascade eliminated (down from 1.4+ seconds with 5+ cascade paints).
+The rebuild is synchronous - no blank screen, no idle wait.  The
+motion filter prevents the AUI cascade that was the original problem.
+
+**History:** v2.0.2.6-v2.0.2.8 used paint suppression (intercepting
+OnPaint with empty PaintDC during `__refreshing`) and an idle wait
+(2-3 EVT_IDLE cycles to clear `__refreshing`).  This caused the tree
+to go blank for 50-200ms per rebuild.  Removed in v2.0.2.10 because
+the motion-only input filter is sufficient to prevent the cascade.
 
 ### What was tried and abandoned
 
@@ -799,6 +780,7 @@ Cascade eliminated (down from 1.4+ seconds with 5+ cascade paints).
 | 11 | Per-widget EventFilter release (each `_on_refresh_idle` sets `active=False`) | First widget to finish clears the filter while other widgets still need it. Global singleton filter requires refcount + deferred release |
 | 12 | `__refreshing` as re-entry guard for `RefreshAllItems` | Blocks legitimate refresh calls for 703ms during idle wait, causing empty lists on startup. Removed re-entry guard - `__refreshing` now only drives paint suppression and selection suppression |
 | 13 | EventFilter eating ALL input (clicks, keyboard, scroll, motion) | Clicks and keyboard events lost during rebuild + 1s settling period makes the app feel unresponsive. Only motion events drive the AUI cascade; clicks and keyboard do not. Narrowed filter to motion events only |
+| 14 | Paint suppression (empty PaintDC during `__refreshing`) + idle wait (2-3 EVT_IDLE cycles) | Tree goes blank for 50-200ms per rebuild because ALL paints are suppressed until idle completes. Multiple rebuilds (filter + sort + presentation) stack the blank time to seconds. The motion-only input filter is sufficient to prevent the AUI cascade without paint suppression |
 
 ### Resolved Questions
 
@@ -873,22 +855,10 @@ Cascade eliminated (down from 1.4+ seconds with 5+ cascade paints).
 
 | File | Role |
 |------|------|
-| `taskcoachlib/widgets/treectrl.py` | `RefreshAllItems()`, `__refreshing` flag, paint suppression, `_on_refresh_idle` |
-| `taskcoachlib/widgets/frame.py` | `_RebuildInputFilter` (EventFilter with refcount + deferred release), sash throttle |
-| `taskcoachlib/gui/viewer/base.py` | `refresh()` — calls `RefreshAllItems` |
-| `taskcoachlib/meta/debug.py` | `log_step()` — timestamped debug logging |
-
-### Diagnostics
-
-Active diagnostics:
-
-- **`_RebuildInputFilter`** (`frame.py`, prefix `INPUT_FILTER`) — logs
-  every motion event (eaten or passed), refcount transitions, deferred
-  release timing
-- **`RefreshAllItems`** (`treectrl.py`, prefix `REBUILD_GUARD`) — logs
-  start, items built, and complete (when `__refreshing` cleared)
-- **Paint suppression** (`treectrl.py`, prefix `REBUILD_GUARD`) — logs
-  total count of suppressed paints when `__refreshing` clears
+| `taskcoachlib/widgets/treectrl.py` | `RefreshAllItems()`, snapshot comparison, synchronous rebuild |
+| `taskcoachlib/widgets/frame.py` | `_RebuildInputFilter` (motion-only EventFilter with refcount + deferred release), sash throttle |
+| `taskcoachlib/gui/viewer/base.py` | `refresh()` - calls `RefreshAllItems` |
+| `taskcoachlib/meta/debug.py` | `log_step()` - timestamped debug logging |
 
 ---
 
@@ -899,7 +869,7 @@ Active diagnostics:
 | `taskcoachlib/gui/viewer/base.py` | Base viewer with `curselection()`, `onSelect()`, `onPresentationChanged()` |
 | `taskcoachlib/gui/viewer/task.py` | `CalendarViewer.reconfig()` |
 | `taskcoachlib/gui/status.py` | Status bar with 500ms debounce |
-| `taskcoachlib/widgets/treectrl.py` | Tree widget: selection, scroll, hover, `__refreshing` debounce, paint debounce |
+| `taskcoachlib/widgets/treectrl.py` | Tree widget: selection, scroll, hover, synchronous rebuild |
 | `taskcoachlib/widgets/listctrl.py` | List widget with selection handling |
 | `taskcoachlib/widgets/iconpicker.py` | Icon picker: virtual ListCtrl (`wx.LC_VIRTUAL`) for fast population |
 | `taskcoachlib/widgets/tooltip.py` | Tooltip mixin with deferred data prep |

--- a/taskcoachlib/domain/base/sorter.py
+++ b/taskcoachlib/domain/base/sorter.py
@@ -103,7 +103,8 @@ class Sorter(patterns.ListDecorator):
         # be problematic.
         # UUID tiebreaker first (least significant) - guarantees
         # deterministic ordering for items with equal sort keys.
-        self.sort(key=lambda item: item.id())
+        # Some items (e.g. CompositeEffortPerPeriod) have no id().
+        self.sort(key=lambda item: item.id() if hasattr(item, 'id') else '')
         for sort_key in reversed(self._sortKeys):
             self.sort(
                 key=self.create_sort_key_function(sort_key.lstrip("-")),

--- a/taskcoachlib/gui/viewer/base.py
+++ b/taskcoachlib/gui/viewer/base.py
@@ -367,10 +367,10 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         # AFTER refresh - select next if selection became empty
         if items_removed() and hasattr(self.widget, 'curselection') and not self.widget.curselection() and selection_info:
             self.selectNextItemsAfterRemoval(selection_info)
-        # Center on selected item — tree views use scrollToSelectionCentered,
+        # Center on selected item — tree views use scroll_to_selection_centered,
         # list views use ensureSelectionVisible (native wx scrollbar management)
-        if hasattr(self.widget, 'scrollToSelectionCentered'):
-            self.widget.scrollToSelectionCentered()
+        if hasattr(self.widget, 'scroll_to_selection_centered'):
+            self.widget.scroll_to_selection_centered()
         elif hasattr(self.widget, 'ensureSelectionVisible'):
             self.widget.ensureSelectionVisible()
         self.send_viewer_status_event()

--- a/taskcoachlib/gui/viewer/task.py
+++ b/taskcoachlib/gui/viewer/task.py
@@ -1288,11 +1288,11 @@ class TaskViewer(
         if self.hasOrderingColumn():
             widget.SetMainColumn(1)
         widget.SetImageList(imageList)  # pylint: disable=E1101
-        widget.Bind(wx.EVT_TREE_BEGIN_LABEL_EDIT, self.onBeginEdit)
-        widget.Bind(wx.EVT_TREE_END_LABEL_EDIT, self.onEndEdit)
+        widget.Bind(wx.EVT_TREE_BEGIN_LABEL_EDIT, self.on_begin_edit)
+        widget.Bind(wx.EVT_TREE_END_LABEL_EDIT, self.on_end_edit)
         return widget
 
-    def onBeginEdit(self, event):
+    def on_begin_edit(self, event):
         """Make sure only the non-recursive part of the subject can be
         edited inline."""
         event.Skip()
@@ -1300,12 +1300,12 @@ class TaskViewer(
             # Make sure the text control only shows the non-recursive subject
             # by temporarily changing the item text into the non-recursive
             # subject. When the editing ends, we change the item text back into
-            # the recursive subject. See onEndEdit.
-            treeItem = event.GetItem()
-            editedTask = self.widget.GetItemPyData(treeItem)
-            self.widget.SetItemText(treeItem, editedTask.subject())
+            # the recursive subject. See on_end_edit.
+            tree_item = event.GetItem()
+            edited_task = self.widget.GetItemPyData(tree_item)
+            self.widget.SetItemText(tree_item, edited_task.subject())
 
-    def onEndEdit(self, event):
+    def on_end_edit(self, event):
         """Make sure only the non-recursive part of the subject can be
         edited inline."""
         event.Skip()
@@ -1313,10 +1313,10 @@ class TaskViewer(
             # Restore the recursive subject. Here we don't care whether users
             # actually changed the subject. If they did, the subject will
             # be updated via the regular notification mechanism.
-            treeItem = event.GetItem()
-            editedTask = self.widget.GetItemPyData(treeItem)
+            tree_item = event.GetItem()
+            edited_task = self.widget.GetItemPyData(tree_item)
             self.widget.SetItemText(
-                treeItem, editedTask.subject(recursive=True)
+                tree_item, edited_task.subject(recursive=True)
             )
 
     def _createColumns(self):
@@ -2024,8 +2024,8 @@ class TaskViewer(
         # Mode switch goes through Sorter.reset() which fires a sort event
         # (not add/remove), so onPresentationChanged doesn't fire.
         # Center on selected item explicitly.
-        if hasattr(self.widget, 'scrollToSelectionCentered'):
-            self.widget.scrollToSelectionCentered()
+        if hasattr(self.widget, 'scroll_to_selection_centered'):
+            self.widget.scroll_to_selection_centered()
         patterns.Event(
             self.view_settings_changed_event_type(), self
         ).send()

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,10 +41,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.2"  # Major.Minor.Milestone
-patch = "9"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.2.9
+patch = "10"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.2.10
 
-release_day = "18"  # Day of the release (1-31)
+release_day = "20"  # Day of the release (1-31)
 release_month = "March"  # Month of the release
 release_year = "2026"  # Year of the release
 

--- a/taskcoachlib/widgets/treectrl.py
+++ b/taskcoachlib/widgets/treectrl.py
@@ -57,17 +57,17 @@ class BaseHyperTreeList(hypertreelist.HyperTreeList):
         """
         event.Skip()  # Let base class handle layout first
         # Schedule scrollbar adjustment after the layout is complete
-        wx.CallAfter(self.__safeAdjustScrollbars)
+        wx.CallAfter(self.__safe_adjust_scrollbars)
 
-    def __safeAdjustScrollbars(self):
+    def __safe_adjust_scrollbars(self):
         """Safely adjust scrollbars, guarding against deleted C++ objects.
         Also re-centers on selected item after resize."""
         try:
             main_win = self.GetMainWindow()
             if main_win:
                 main_win.AdjustMyScrollbars()
-                if hasattr(self, 'scrollToSelectionCentered'):
-                    self.scrollToSelectionCentered()
+                if hasattr(self, 'scroll_to_selection_centered'):
+                    self.scroll_to_selection_centered()
         except RuntimeError:
             # wrapped C/C++ object has been deleted
             from taskcoachlib.meta.debug import log_step
@@ -90,9 +90,9 @@ class HyperTreeList(draganddrop.TreeCtrlDragAndDropMixin, BaseHyperTreeList):
         # On Ubuntu, when the user has scrolled to the bottom of the tree
         # and collapses an item, the tree is not redrawn correctly. Refreshing
         # solves this. See http://trac.wxwidgets.org/ticket/11704
-        wx.CallAfter(self.__safeRefresh)
+        wx.CallAfter(self.__safe_refresh)
 
-    def __safeRefresh(self):
+    def __safe_refresh(self):
         """Safely refresh the main window, guarding against deleted C++ objects."""
         try:
             if self.MainWindow:
@@ -100,7 +100,7 @@ class HyperTreeList(draganddrop.TreeCtrlDragAndDropMixin, BaseHyperTreeList):
         except RuntimeError:
             # wrapped C/C++ object has been deleted
             from taskcoachlib.meta.debug import log_step
-            log_step('__safeRefresh failed - widget already destroyed',
+            log_step('__safe_refresh failed - widget already destroyed',
                      prefix='DEAD-OBJ')
 
     def GetSelections(self):  # pylint: disable=C0103
@@ -132,7 +132,7 @@ class HyperTreeList(draganddrop.TreeCtrlDragAndDropMixin, BaseHyperTreeList):
             hit_test_result = (wx.TreeItemId(),) + hit_test_result[1:]
         return hit_test_result
 
-    def isClickablePartOfNodeClicked(self, event):
+    def is_clickable_part_of_node_clicked(self, event):
         """Return whether the user double clicked some part of the node that
         can also receive regular mouse clicks."""
         return self.__is_collapse_expand_button_clicked(event)
@@ -223,7 +223,6 @@ class TreeListCtrl(
         self.__columns_with_images = []
         self.__default_font = wx.NORMAL_FONT
         self.__refreshing = False
-        self.__post_dirty = False
         kwargs.setdefault("resizeableColumn", 0)
         super().__init__(
             parent,
@@ -237,7 +236,6 @@ class TreeListCtrl(
         )
         self.bindEventHandlers(selectCommand, editCommand, dragAndDropCommand)
         self.GetMainWindow().Bind(wx.EVT_LEAVE_WINDOW, self._on_hover_leave)
-        self._install_paint_debounce()
 
     def bindEventHandlers(
         self, selectCommand, editCommand, dragAndDropCommand
@@ -247,14 +245,14 @@ class TreeListCtrl(
         self.editCommand = editCommand
         self.dragAndDropCommand = dragAndDropCommand
         self.Bind(wx.EVT_TREE_SEL_CHANGED, self.onSelect)
-        self.Bind(wx.EVT_TREE_KEY_DOWN, self.onKeyDown)
-        self.Bind(wx.EVT_TREE_ITEM_ACTIVATED, self.onItemActivated)
+        self.Bind(wx.EVT_TREE_KEY_DOWN, self.on_key_down)
+        self.Bind(wx.EVT_TREE_ITEM_ACTIVATED, self.on_item_activated)
         # We deal with double clicks ourselves, to prevent the default behaviour
         # of collapsing or expanding nodes on double click.
-        self.GetMainWindow().Bind(wx.EVT_LEFT_DCLICK, self.onDoubleClick)
-        self.Bind(wx.EVT_TREE_BEGIN_LABEL_EDIT, self.onBeginEdit)
-        self.Bind(wx.EVT_TREE_END_LABEL_EDIT, self.onEndEdit)
-        self.Bind(wx.EVT_TREE_ITEM_EXPANDING, self.onItemExpanding)
+        self.GetMainWindow().Bind(wx.EVT_LEFT_DCLICK, self.on_double_click)
+        self.Bind(wx.EVT_TREE_BEGIN_LABEL_EDIT, self.on_begin_edit)
+        self.Bind(wx.EVT_TREE_END_LABEL_EDIT, self.on_end_edit)
+        self.Bind(wx.EVT_TREE_ITEM_EXPANDING, self.on_item_expanding)
         self.Bind(wx.EVT_SET_FOCUS, self.onSetFocus)
 
     def onSetFocus(self, event):  # pylint: disable=W0613
@@ -267,32 +265,10 @@ class TreeListCtrl(
         self.GetMainWindow().SetHoverItem(None)
         event.Skip()
 
-    def _install_paint_debounce(self):
-        """Suppress ALL cascade paints during refresh.
-
-        While __refreshing is True, every paint is suppressed with an
-        empty PaintDC (validates the GDK region to prevent infinite
-        expose loops).  When __refreshing clears, normal paints resume
-        and _on_refresh_idle triggers one clean Refresh().
-        """
-        main_win = self.GetMainWindow()
-        original_on_paint = main_win.OnPaint
-        tree_ctrl = self
-
-        def debounced_on_paint(event):
-            if not tree_ctrl.refreshing:
-                original_on_paint(event)
-                return
-            # During refresh: suppress ALL paints
-            dc = wx.PaintDC(main_win)
-            del dc
-
-        main_win.Bind(wx.EVT_PAINT, debounced_on_paint)
-
     def getItemTooltipData(self, item):
         return self.__adapter.getItemTooltipData(item)
 
-    def getItemCTType(self, item):  # pylint: disable=W0613
+    def get_item_ct_type(self, item):  # pylint: disable=W0613
         return self.ct_type
 
     @property
@@ -316,13 +292,6 @@ class TreeListCtrl(
         except RuntimeError:
             # wrapped C/C++ object has been deleted
             return []
-
-    @property
-    def refreshing(self):
-        """True while a rebuild is in progress (items being rebuilt or
-        widget still has pending layout work).  Used by paint debounce
-        and selection suppression — NOT as a re-entry guard."""
-        return self.__refreshing
 
     def _snapshot_tree(self, parent_item):
         """Return list of object IDs in depth-first order for current tree."""
@@ -368,7 +337,12 @@ class TreeListCtrl(
             child_item, cookie = self.GetNextChild(parent_item, cookie)
 
     def _do_full_rebuild(self):
-        """Full delete-and-recreate rebuild of the tree."""
+        """Full delete-and-recreate rebuild of the tree.
+
+        Synchronous: Freeze, rebuild, Thaw, Refresh.  The motion-only
+        input filter in frame.py prevents the AUI cascade by blocking
+        mouse motion events during and after rebuild.
+        """
         from taskcoachlib.widgets.frame import (
             _input_filter, _ensure_filter_installed,
         )
@@ -389,55 +363,16 @@ class TreeListCtrl(
             root_item = self.AddRoot("Hidden root")
         self._addObjectRecursively(root_item)
         self.Thaw()
+        self.__refreshing = False
         # Restore selection AFTER Thaw - SelectItem doesn't work while Frozen
         if self.__selection:
             self.select(self.__selection)
-        self.scrollToSelection()
-        # __refreshing stays True until _dirty is processed on idle.
-        # Input filter also stays active until then.
-        self._bind_refresh_complete()
-
-    def _bind_refresh_complete(self):
-        """Bind EVT_IDLE to detect when the widget has finished painting."""
-        wx.GetApp().Bind(wx.EVT_IDLE, self._on_refresh_idle)
-
-    def _on_refresh_idle(self, event):
-        """Release __refreshing and input filter when done painting.
-
-        Waits one extra idle cycle after _dirty=False because
-        OnInternalIdle sets _dirty=False then calls Refresh() which
-        queues a paint.  The extra cycle lets that paint process
-        (and motion events get filtered) before we re-enable input.
-        """
-        from taskcoachlib.widgets.frame import _input_filter
-        main_win = self.GetMainWindow()
-        dirty = getattr(main_win, '_dirty', False)
-        if dirty:
-            event.RequestMore()
-            event.Skip()
-            return
-        # _dirty=False — check if we already waited the extra cycle
-        if not self.__post_dirty:
-            self.__post_dirty = True
-            event.RequestMore()
-            event.Skip()
-            return
-        # Extra cycle done — this widget is done
-        self.__refreshing = False
-        self.__post_dirty = False
+        self.scroll_to_selection()
+        # Immediate repaint - no blank screen
+        self.GetMainWindow().Refresh(eraseBackground=False)
         _input_filter.release()
-        wx.GetApp().Unbind(wx.EVT_IDLE, handler=self._on_refresh_idle)
-        # One clean paint now that positions are calculated
-        try:
-            main_win.Refresh()
-        except RuntimeError:
-            # wrapped C/C++ object has been deleted
-            from taskcoachlib.meta.debug import log_step
-            log_step('Refresh() failed - widget already destroyed',
-                     prefix='DEAD-OBJ')
-        event.Skip()
 
-    def scrollToSelection(self):
+    def scroll_to_selection(self):
         """Scroll minimally to make first selected item visible."""
         selections = self.GetSelections()
         if selections:
@@ -445,7 +380,7 @@ class TreeListCtrl(
             main.AdjustMyScrollbars()
             self.ScrollTo(selections[0])
 
-    def scrollToSelectionCentered(self):
+    def scroll_to_selection_centered(self):
         """Center viewport on first selected item."""
         selections = self.GetSelections()
         if selections:
@@ -487,7 +422,7 @@ class TreeListCtrl(
             child_item = self.AppendItem(
                 parent_item,
                 "",
-                self.getItemCTType(child_object),
+                self.get_item_ct_type(child_object),
                 data=child_object,
             )
             self._refreshObjectMinimally(child_item, child_object)
@@ -514,7 +449,7 @@ class TreeListCtrl(
             refresh_aspect(*args, **kwargs)
 
     def _refreshItemType(self, item, domain_object, check=False):
-        ct_type = self.getItemCTType(domain_object)
+        ct_type = self.get_item_ct_type(domain_object)
         if not check or (check and ct_type != self.GetItemType(item)):
             self.SetItemType(item, ct_type)
 
@@ -597,10 +532,10 @@ class TreeListCtrl(
             return
         # Use CallAfter to prevent handling the select while items are
         # being deleted:
-        wx.CallAfter(self.__safeSelectCommand)
+        wx.CallAfter(self.__safe_select_command)
         event.Skip()
 
-    def __safeSelectCommand(self):
+    def __safe_select_command(self):
         """Safely call selectCommand, guarding against deleted C++ objects."""
         try:
             if self:
@@ -611,7 +546,7 @@ class TreeListCtrl(
             log_step('selectCommand() failed - widget already destroyed',
                      prefix='DEAD-OBJ')
 
-    def onKeyDown(self, event):
+    def on_key_down(self, event):
         if event.GetKeyCode() == wx.WXK_RETURN:
             self.editCommand(event)
         elif event.GetKeyCode() == wx.WXK_F2 and self.GetSelections():
@@ -629,10 +564,10 @@ class TreeListCtrl(
             self.GetItemPyData(drag_item) for drag_item in drag_items
         )
         wx.CallAfter(
-            self.__safeDragAndDropCommand, drop_item, drag_items, part, column
+            self.__safe_drag_and_drop_command, drop_item, drag_items, part, column
         )
 
-    def __safeDragAndDropCommand(self, drop_item, drag_items, part, column):
+    def __safe_drag_and_drop_command(self, drop_item, drag_items, part, column):
         """Safely call dragAndDropCommand, guarding against deleted C++ objects."""
         try:
             if self:
@@ -655,21 +590,21 @@ class TreeListCtrl(
                     self.Expand(item)
                 break
 
-    def onItemExpanding(self, event):
+    def on_item_expanding(self, event):
         event.Skip()
         item = event.GetItem()
         if self.GetChildrenCount(item, recursively=False) == 0:
             domain_object = self.GetItemPyData(item)
             self._addObjectRecursively(item, domain_object)
 
-    def onDoubleClick(self, event):
+    def on_double_click(self, event):
         self.__user_double_clicked = True
-        if self.isClickablePartOfNodeClicked(event):
+        if self.is_clickable_part_of_node_clicked(event):
             event.Skip(False)
         else:
-            self.onItemActivated(event)
+            self.on_item_activated(event)
 
-    def onItemActivated(self, event):
+    def on_item_activated(self, event):
         """Attach the column clicked on to the event so we can use it
         elsewhere."""
         column_index = self.__column_under_mouse()
@@ -693,7 +628,7 @@ class TreeListCtrl(
 
     # Inline editing
 
-    def onBeginEdit(self, event):
+    def on_begin_edit(self, event):
         if self.__user_double_clicked:
             event.Veto()
             self.__user_double_clicked = False
@@ -704,7 +639,7 @@ class TreeListCtrl(
         else:
             event.Skip()
 
-    def onEndEdit(self, event):
+    def on_end_edit(self, event):
         if event._editCancelled:  # pylint: disable=W0212
             event.Skip()
             return
@@ -804,8 +739,8 @@ class CheckTreeCtrl(TreeListCtrl):
             **kwargs
         )
         self.checkCommand = checkCommand
-        self.Bind(customtree.EVT_TREE_ITEM_CHECKED, self.onItemChecked)
-        self.GetMainWindow().Bind(wx.EVT_LEFT_DOWN, self.onMouseLeftDown)
+        self.Bind(customtree.EVT_TREE_ITEM_CHECKED, self.on_item_checked)
+        self.GetMainWindow().Bind(wx.EVT_LEFT_DOWN, self.on_mouse_left_down)
         self.getIsItemCheckable = (
             parent.getIsItemCheckable
             if hasattr(parent, "getIsItemCheckable")
@@ -816,7 +751,7 @@ class CheckTreeCtrl(TreeListCtrl):
             parent.get_item_parent_has_exclusive_children
         )
 
-    def getItemCTType(self, domain_object):
+    def get_item_ct_type(self, domain_object):
         """Use radio buttons (ct_type == 2) when the object has "exclusive"
         children, meaning that only one child can be checked at a time. Use
         check boxes (ct_type == 1) otherwise."""
@@ -837,7 +772,7 @@ class CheckTreeCtrl(TreeListCtrl):
         else:
             super().CheckItem(item, checked)
 
-    def onMouseLeftDown(self, event):
+    def on_mouse_left_down(self, event):
         """By default, the HyperTreeList widget doesn't allow for unchecking
         a radio item. Since we do want to support unchecking a radio
         item, we look for mouse left down and uncheck the item and all of
@@ -910,14 +845,14 @@ class CheckTreeCtrl(TreeListCtrl):
                 break
             parent = parent.GetParent()
 
-    def refreshAllCheckStates(self):
+    def refresh_all_check_states(self):
         """Refresh the check state of all items without rebuilding the tree."""
         for item in self.GetItemChildren(recursively=True):
             domain_object = self.GetItemPyData(item)
             if domain_object is not None:
                 self._refreshCheckState(item, domain_object)
 
-    def onItemChecked(self, event):
+    def on_item_checked(self, event):
         if self.__checking:
             # Ignore checked events while we're making the tree consistent,
             # only invoke the callback:
@@ -951,10 +886,10 @@ class CheckTreeCtrl(TreeListCtrl):
         self.__checking = False
         self.checkCommand(event, final=True)
 
-    def onItemActivated(self, event):
+    def on_item_activated(self, event):
         if self.__is_double_clicked(event):
-            # Invoke super.onItemActivated to edit the item
-            super().onItemActivated(event)
+            # Invoke super.on_item_activated to edit the item
+            super().on_item_activated(event)
         else:
             # Item is activated, let another event handler deal with the event
             event.Skip()


### PR DESCRIPTION
Remove paint suppression and idle wait that caused the tree to go blank for seconds when marking tasks complete.  The paint debounce (introduced in v2.0.2.6 to fix the AUI cascade) suppressed ALL paints during __refreshing and waited 2-3 EVT_IDLE cycles to clear it.  Multiple rebuilds (filter + sort + presentation) stacked the blank time.  The motion-only input filter in frame.py is sufficient to prevent the AUI cascade - paint suppression is redundant.

Rebuild is now synchronous (same as v2.0.2.5): Freeze, rebuild, Thaw, Refresh(eraseBackground=False).  No blank screen.

Fix CompositeEffort crash: the UUID sort tiebreaker assumed all items have id(), but CompositeEffort and CompositeEffortPerPeriod (aggregated effort views) do not.  Added hasattr guard.

PEP 8 renames in treectrl.py: scroll_to_selection, scroll_to_selection_centered, is_clickable_part_of_node_clicked, on_key_down, on_item_expanding, on_double_click, on_item_activated, on_begin_edit, on_end_edit, on_mouse_left_down, on_item_checked, get_item_ct_type, refresh_all_check_states, and private methods. Updated callers in base.py and task.py.

2.0.2.9 Issue when trying to change the efforts view filter #425
2.0.2.9 : Impossible to open a second effort view #424
rendering slowness, total blank for seconds when completing something #423