### PR TITLE
Fix effort copy/paste crash, hypertreelist column sync, display override

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.10-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.10-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.10_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.10_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.10_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.10-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.11-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.11-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.11_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.11_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.11_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.11-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.10-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.10-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.10_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.10_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.2.10-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.2.10-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.11-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.11-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.11_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.11_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.2.11-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.2.11-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.10_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.2.10_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.11_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.2.11_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.10-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.2.10-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.11-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.2.11-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.10-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.2.10-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.11-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.2.11-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.10-x86_64.AppImage
-chmod +x TaskCoach-2.0.2.10-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.11-x86_64.AppImage
+chmod +x TaskCoach-2.0.2.11-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.2.10-x86_64.AppImage
+./TaskCoach-2.0.2.11-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/README_INSTALL_MACOS.md
+++ b/README_INSTALL_MACOS.md
@@ -17,7 +17,7 @@ Download the DMG for your Mac from the [latest release](https://github.com/taskc
 - **Apple Silicon** (M1/M2/M3/M4): `TaskCoach-<version>-macos-arm64.dmg`
 - **Intel**: `TaskCoach-<version>-macos-intel.dmg`
 
-Where `<version>` is the release version (e.g., `2.0.2.5`).
+Where `<version>` is the release version (e.g., `2.0.2.11`).
 
 Not sure which Mac you have? Click the Apple menu → "About This Mac". Look for "Chip" (Apple Silicon) or "Processor" (Intel).
 

--- a/README_INSTALL_WINDOWS.md
+++ b/README_INSTALL_WINDOWS.md
@@ -19,7 +19,7 @@ Download the installer from the [latest release](https://github.com/taskcoach/ta
 - **Installer**: `TaskCoach-<version>-windows-x64-setup.exe` - Standard installation
 - **Portable**: `TaskCoach-<version>-windows-x64-portable.zip` - No installation required
 
-Where `<version>` is the release version (e.g., `2.0.2.5`).
+Where `<version>` is the release version (e.g., `2.0.2.11`).
 
 ## <a id="security-warning"></a>Security Warning
 

--- a/taskcoachlib/config/defaults.py
+++ b/taskcoachlib/config/defaults.py
@@ -62,6 +62,10 @@ defaults = {
         # Date format override: "" = automatic (detect from locale), or explicit format
         # Possible values: "", "YMD-", "MDY/", "DMY/", "DMY.", "YMD/"
         "dateformat": "",
+        # Display-only override applied on top of dateformat when rendering
+        # dates (does not affect date entry controls). "" = no override, use
+        # dateformat as-is. Possible values: "", "LONG_DMY", "ISO_ABBREV".
+        "dateformat_display_override": "",
         # Time format override: "24" = 24-hour (default), "12" = 12-hour with AM/PM, "" = automatic
         "timeformat": "24",
         # Decimal separator override: "" = automatic (from locale), "." = period, "," = comma

--- a/taskcoachlib/domain/base/object.py
+++ b/taskcoachlib/domain/base/object.py
@@ -49,29 +49,34 @@ class SynchronizedObject(object):
         return "object.marknotdeleted"
 
     def __getstate__(self):
-        try:
-            state = super().__getstate__()
-        except AttributeError:
-            state = dict()
-
-        state["status"] = self.__status
-        return state
+        # Python 3.11 added object.__getstate__, which returns the instance's
+        # __dict__ as a live reference. Mutating that dict (as the subclass
+        # chain below does via state.update) would write shadow attributes
+        # onto self. Start from a fresh dict instead.
+        return {"status": self.__status}
 
     @patterns.eventSource
     def __setstate__(self, state, event=None):
-        try:
+        # object does not define __setstate__; only invoke super if available.
+        if hasattr(super(), "__setstate__"):
             super().__setstate__(state, event=event)
-        except AttributeError:
-            pass
-        if state["status"] != self.__status:
-            if state["status"] == self.STATUS_CHANGED:
-                self.markDirty(event=event)
-            elif state["status"] == self.STATUS_DELETED:
-                self.markDeleted(event=event)
-            elif state["status"] == self.STATUS_NEW:
-                self.markNew(event=event)
-            elif state["status"] == self.STATUS_NONE:
-                self.cleanDirty(event=event)
+        new_status = state["status"]
+        if new_status == self.__status:
+            return
+        if new_status == self.STATUS_CHANGED:
+            self.markDirty(event=event)
+        elif new_status == self.STATUS_DELETED:
+            self.markDeleted(event=event)
+        elif new_status == self.STATUS_NEW:
+            self.markNew(event=event)
+        elif new_status == self.STATUS_NONE:
+            self.cleanDirty(event=event)
+        else:
+            from taskcoachlib.meta.debug import log_step
+            log_step(
+                "unknown status value %r in __setstate__" % (new_status,),
+                prefix="SYNC-OBJ",
+            )
 
     def getStatus(self):
         return self.__status
@@ -220,10 +225,7 @@ class Object(SynchronizedObject):
         return hash(self.id())
 
     def __getstate__(self):
-        try:
-            state = super().__getstate__()
-        except AttributeError:
-            state = dict()
+        state = super().__getstate__()
         state.update(
             dict(
                 id=self.__id,
@@ -243,10 +245,7 @@ class Object(SynchronizedObject):
 
     @patterns.eventSource
     def __setstate__(self, state, event=None):
-        try:
-            super().__setstate__(state, event=event)
-        except AttributeError:
-            pass
+        super().__setstate__(state, event=event)
         self.__id = state["id"]
         self.setSubject(state["subject"], event=event)
         self.setDescription(state["description"], event=event)
@@ -266,9 +265,11 @@ class Object(SynchronizedObject):
         a copy of the object.
 
         E.g. copy = obj.__class__(**original.__getcopystate__())"""
-        try:
+        # SynchronizedObject does not define __getcopystate__; only invoke
+        # super if some other class in the MRO provides it.
+        if hasattr(super(), "__getcopystate__"):
             state = super().__getcopystate__()
-        except AttributeError:
+        else:
             state = dict()
         # Note that we don't put the id and the creation date/time in the state
         # dict, because a copy should get a new id and a new creation date/time
@@ -647,9 +648,12 @@ class Object(SynchronizedObject):
 
     @classmethod
     def modificationEventTypes(class_):
-        try:
-            eventTypes = super(Object, class_).modificationEventTypes()
-        except AttributeError:
+        # SynchronizedObject does not define modificationEventTypes; only
+        # invoke super if some other class in the MRO provides it.
+        parent = super(Object, class_)
+        if hasattr(parent, "modificationEventTypes"):
+            eventTypes = parent.modificationEventTypes()
+        else:
             eventTypes = []
         return eventTypes + [
             class_.subjectChangedEventType(),

--- a/taskcoachlib/domain/effort/base.py
+++ b/taskcoachlib/domain/effort/base.py
@@ -36,14 +36,13 @@ class BaseEffort(object):
         pass
 
     def task(self):
-        # Access _task directly to avoid potential attribute shadowing
         return None if self._task is None else self._task()
 
     def parent(self):
         # Efforts don't have real parents since they are not composite.
         # However, we pretend the parent of an effort is its task for the
         # benefit of the search filter.
-        return None if self._task is None else self._task()
+        return self.task()
 
     def getStart(self):
         return self._start.get()
@@ -52,23 +51,23 @@ class BaseEffort(object):
         return self._stop.get()
 
     def subject(self, *args, **kwargs):
-        task = self._task() if self._task else None
+        task = self.task()
         return task.subject(*args, **kwargs) if task else ""
 
     def categories(self, *args, **kwargs):
-        task = self._task() if self._task else None
+        task = self.task()
         return task.categories(*args, **kwargs) if task else set()
 
     def foregroundColor(self, recursive=False):
-        task = self._task() if self._task else None
+        task = self.task()
         return task.foregroundColor(recursive) if task else None
 
     def backgroundColor(self, recursive=False):
-        task = self._task() if self._task else None
+        task = self.task()
         return task.backgroundColor(recursive) if task else None
 
     def font(self, recursive=False):
-        task = self._task() if self._task else None
+        task = self.task()
         return task.font(recursive) if task else None
 
     def duration(self, recursive=False):

--- a/taskcoachlib/domain/effort/effort.py
+++ b/taskcoachlib/domain/effort/effort.py
@@ -39,30 +39,6 @@ class Effort(baseeffort.BaseEffort, base.Object):
         )
         self.__duration = Attribute(self._computeDuration(), self, self._onDurationChanged)
 
-    def __getattribute__(self, name):
-        """Override to prevent methods from being shadowed by instance attributes.
-
-        During copy/paste operations, kwargs from __getcopystate__ can end up
-        as instance attributes that shadow the class methods. This override
-        ensures method lookups always find the class method, not instance attrs.
-        """
-        # Methods that might get shadowed - check directly to avoid recursion
-        _protected = (
-            'id', 'task', 'subject', 'description', 'font',
-            'foregroundColor', 'backgroundColor', 'icon', 'selectedIcon', 'ordering',
-            'creationDateTime', 'modificationDateTime'
-        )
-        if name in _protected:
-            # Get the method from the class, not the instance
-            for cls in type(self).__mro__:
-                if name in cls.__dict__:
-                    method = cls.__dict__[name]
-                    if callable(method):
-                        # Return bound method
-                        return method.__get__(self, type(self))
-                    break
-        return object.__getattribute__(self, name)
-
     def setTask(self, task):
         if self._task is None:
             # We haven't been fully initialised yet, so allow setting of the
@@ -71,18 +47,14 @@ class Effort(baseeffort.BaseEffort, base.Object):
             # new task itself.
             self._task = None if task is None else weakref.ref(task)
             return
-        # Get current task by dereferencing weakref directly to avoid any
-        # potential attribute lookup issues (see issue with copy/paste efforts)
-        current_task = self._task() if self._task else None
+        current_task = self.task()
         if task in (current_task, None):
             # command.PasteCommand may try to set the parent to None
             return
-        event = (
-            patterns.Event()
-        )  # Change monitor needs one event to detect task change
-        self._task().removeEffort(self)
+        event = patterns.Event()  # Change monitor needs one event
+        current_task.removeEffort(self)
         self._task = weakref.ref(task)
-        self._task().addEffort(self)
+        task.addEffort(self)
         event.send()
         pub.sendMessage(
             self.taskChangedEventType(), newValue=task, sender=self
@@ -94,41 +66,38 @@ class Effort(baseeffort.BaseEffort, base.Object):
     def monitoredAttributes(class_):
         return base.Object.monitoredAttributes() + ["start", "stop"]
 
-    # Note: task() and id() are now handled by __getattribute__ to prevent
-    # attribute shadowing issues during copy/paste operations.
-
     @classmethod
     def taskChangedEventType(class_):
         return "pubsub.effort.task"
 
     def __str__(self):
-        task = self._task() if self._task else None
-        return "Effort(%s, %s, %s)" % (task, self._start.get(), self._stop.get())
+        return "Effort(%s, %s, %s)" % (
+            self.task(), self._start.get(), self._stop.get()
+        )
 
     __repr__ = __str__
 
     def __eq__(self, other):
         if not isinstance(other, Effort):
             return NotImplemented
-        # Access _Object__id directly to avoid potential attribute shadowing
-        return self._Object__id == other._Object__id
+        return self.id() == other.id()
 
     def __lt__(self, other):
         if not isinstance(other, Effort):
             return NotImplemented
-        # Compare by start time first, then stop time, then id for total ordering
         self_stop = self._stop.get() if self._stop.get() is not None else date.DateTime.max
         other_stop = other._stop.get() if other._stop.get() is not None else date.DateTime.max
-        return (self._start.get(), self_stop, self._Object__id) < (other._start.get(), other_stop, other._Object__id)
+        return (self._start.get(), self_stop, self.id()) < (
+            other._start.get(), other_stop, other.id()
+        )
 
     def __hash__(self):
-        return hash(self._Object__id)
+        return hash(self.id())
 
     def __getstate__(self):
         state = super().__getstate__()
-        task = self._task() if self._task else None
         state.update(
-            dict(task=task, start=self._start.get(), stop=self._stop.get(),
+            dict(task=self.task(), start=self._start.get(), stop=self._stop.get(),
                  entryMode=self.__entryMode.get(), duration=self.__duration.get())
         )
         return state
@@ -144,9 +113,8 @@ class Effort(baseeffort.BaseEffort, base.Object):
 
     def __getcopystate__(self):
         state = super().__getcopystate__()
-        task = self._task() if self._task else None
         state.update(
-            dict(task=task, start=self._start.get(), stop=self._stop.get(),
+            dict(task=self.task(), start=self._start.get(), stop=self._stop.get(),
                  entryMode=self.__entryMode.get(), duration=self.__duration.get())
         )
         return state
@@ -157,7 +125,7 @@ class Effort(baseeffort.BaseEffort, base.Object):
 
     def _onDurationChanged(self, event):
         self.sendDurationChangedMessage()
-        task = self._task() if self._task else None
+        task = self.task()
         if task and task.hourlyFee():
             self.sendRevenueChangedMessage()
 
@@ -203,7 +171,7 @@ class Effort(baseeffort.BaseEffort, base.Object):
         pub.sendMessage(
             self.startChangedEventType(), newValue=self.getStart(), sender=self
         )
-        task = self._task() if self._task else None
+        task = self.task()
         if task:
             task.sendTimeSpentChangedMessage()
 
@@ -222,7 +190,7 @@ class Effort(baseeffort.BaseEffort, base.Object):
     def _onStopChanged(self, event):
         previousStop = getattr(self, '_previousStop', None)
         newStop = self._stop.get()
-        task = self._task() if self._task else None
+        task = self.task()
         if newStop is None:
             pub.sendMessage(
                 self.trackingChangedEventType(), newValue=True, sender=self
@@ -249,7 +217,7 @@ class Effort(baseeffort.BaseEffort, base.Object):
         return self._stop.get() is None
 
     def revenue(self):
-        task = self._task() if self._task else None
+        task = self.task()
         hourlyFee = task.hourlyFee() if task else 0
         return self.timeSpent().hours() * hourlyFee
 
@@ -260,7 +228,7 @@ class Effort(baseeffort.BaseEffort, base.Object):
         return lambda effort: (
             effort.getStart(),
             effort.isTotal(),
-            (effort._task().subject(recursive=True) if effort._task else ""),
+            effort.task().subject(recursive=True) if effort.task() else "",
         )
 
     @classmethod

--- a/taskcoachlib/domain/effort/effortlist.py
+++ b/taskcoachlib/domain/effort/effortlist.py
@@ -121,8 +121,7 @@ class EffortList(
         Since that wouldn't work we remove the efforts from the tasks by
         hand."""
         for effort in efforts:
-            # Access _task directly to avoid potential attribute shadowing
-            task = effort._task() if effort._task else None
+            task = effort.task()
             if task:
                 task.removeEffort(effort)
 
@@ -133,9 +132,7 @@ class EffortList(
         Since that wouldn't work we add the efforts to the tasks by
         hand."""
         for effort in efforts:
-            # Access _task directly to avoid potential attribute shadowing
-            # that can occur during copy/paste operations
-            task = effort._task() if effort._task else None
+            task = effort.task()
             if task:
                 task.addEffort(effort)
 

--- a/taskcoachlib/gui/dialog/preferences.py
+++ b/taskcoachlib/gui/dialog/preferences.py
@@ -1294,11 +1294,11 @@ class LanguagePage(SettingsPage):
 
         # === LANGUAGE SECTION ===
         # Restart warning above the dropdown (covers language and format changes)
-        self._restartWarningBase = _("Changing the language or date/time format requires a restart of %s.") % meta.name
-        self._restartWarning = wx.StaticText(self, label=self._restartWarningBase)
-        self._restartWarningDefaultColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
-        self._restartWarning.SetForegroundColour(self._restartWarningDefaultColor)
-        self.addEntry("", self._restartWarning)
+        self._restart_warning_base = _("Changing the language or date/time format requires a restart of %s.") % meta.name
+        self._restart_warning = wx.StaticText(self, label=self._restart_warning_base)
+        self._restart_warning_default_color = wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
+        self._restart_warning.SetForegroundColour(self._restart_warning_default_color)
+        self.addEntry("", self._restart_warning)
 
         languages = [
             ("ar", "الْعَرَبيّة (Arabic)"),
@@ -1386,13 +1386,13 @@ class LanguagePage(SettingsPage):
         sizer = wx.BoxSizer(wx.VERTICAL)
 
         # Locale warning - only shown when selected locale is not installed
-        self._localeWarning = wx.StaticText(
+        self._locale_warning = wx.StaticText(
             panel,
             label=_("WARNING: The selected language's locale is not installed on your system. "
                     "Some date and time formats may appear in your system's format instead.")
         )
-        self._localeWarning.SetForegroundColour(wx.Colour(180, 0, 0))
-        sizer.Add(self._localeWarning, 0, wx.BOTTOM, 10)
+        self._locale_warning.SetForegroundColour(wx.Colour(180, 0, 0))
+        sizer.Add(self._locale_warning, 0, wx.BOTTOM, 10)
 
         # Help text
         text = wx.StaticText(
@@ -1410,15 +1410,15 @@ class LanguagePage(SettingsPage):
         self.addEntry("", panel)
 
         # Store original language to detect changes
-        self._originalLanguage = self._getSelectedLanguageCode()
+        self._original_language = self._get_selected_language_code()
 
         # Check if current language has locale installed and update warning visibility
-        self._updateLocaleWarning()
+        self._update_locale_warning()
 
         # Bind to dropdown change to update warnings dynamically
         for section, setting, choiceCtrls in self._choiceSettings:
             if setting == "language_set_by_user":
-                choiceCtrls[0].Bind(wx.EVT_CHOICE, self._onLanguageChange)
+                choiceCtrls[0].Bind(wx.EVT_CHOICE, self._on_language_change)
 
         # Separator line between language and spell check sections
         self.addLine()
@@ -1431,12 +1431,12 @@ class LanguagePage(SettingsPage):
 
         # === DATE FORMAT SECTION ===
         # Date format dropdown with detected format label
-        dateFormatPanel = wx.Panel(self)
-        dateFormatSizer = wx.BoxSizer(wx.HORIZONTAL)
+        date_format_panel = wx.Panel(self)
+        date_format_sizer = wx.BoxSizer(wx.HORIZONTAL)
 
         # Date format choices: value is the format string (e.g., "YMD-", "MDY/")
-        self._dateFormatChoice = wx.Choice(dateFormatPanel)
-        dateFormats = [
+        self._date_format_choice = wx.Choice(date_format_panel)
+        date_formats = [
             ("", _("Automatic (detect from system)")),
             ("YMD-", _("YYYY-MM-DD (ISO format)")),
             ("YMD/", _("YYYY/MM/DD (East Asian)")),
@@ -1444,90 +1444,146 @@ class LanguagePage(SettingsPage):
             ("DMY/", _("DD/MM/YYYY (European)")),
             ("DMY.", _("DD.MM.YYYY (German)")),
         ]
-        currentFormat = self.gettext("view", "dateformat")
-        selectedIdx = 0
-        for i, (value, label) in enumerate(dateFormats):
-            self._dateFormatChoice.Append(label, value)
-            if value == currentFormat:
-                selectedIdx = i
-        self._dateFormatChoice.SetSelection(selectedIdx)
-        self._dateFormatChoice.Bind(wx.EVT_CHOICE, self._onDateFormatChange)
-        dateFormatSizer.Add(self._dateFormatChoice, 0, wx.ALIGN_CENTER_VERTICAL)
+        current_format = self.gettext("view", "dateformat")
+        selected_idx = 0
+        for i, (value, label) in enumerate(date_formats):
+            self._date_format_choice.Append(label, value)
+            if value == current_format:
+                selected_idx = i
+        self._date_format_choice.SetSelection(selected_idx)
+        self._date_format_choice.Bind(wx.EVT_CHOICE, self._on_date_format_change)
+        date_format_sizer.Add(self._date_format_choice, 0, wx.ALIGN_CENTER_VERTICAL)
 
         # Detected format label
         from taskcoachlib.widgets.maskedtimectrl import getDetectedLocaleDateFormat
-        detectedOrder, detectedSep = getDetectedLocaleDateFormat()
-        detectedStr = self._formatOrderToString(detectedOrder, detectedSep)
-        self._detectedFormatLabel = wx.StaticText(
-            dateFormatPanel,
-            label=_("Detected: %s") % detectedStr
+        detected_order, detected_sep = getDetectedLocaleDateFormat()
+        detected_str = self._format_order_to_string(detected_order, detected_sep)
+        self._detected_format_label = wx.StaticText(
+            date_format_panel,
+            label=_("Detected: %s") % detected_str
         )
-        self._detectedFormatLabel.SetForegroundColour(
+        self._detected_format_label.SetForegroundColour(
             wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
         )
-        dateFormatSizer.Add(self._detectedFormatLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 15)
+        date_format_sizer.Add(
+            self._detected_format_label,
+            0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 15,
+        )
 
-        dateFormatPanel.SetSizer(dateFormatSizer)
-        self.addEntry(_("Date format"), dateFormatPanel)
+        date_format_panel.SetSizer(date_format_sizer)
+        self.addEntry(_("Date format"), date_format_panel)
 
         # Demo DateComboRouterCtrl showing the selected format (interactive, starts with today)
-        demoPanel = wx.Panel(self)
-        demoSizer = wx.BoxSizer(wx.HORIZONTAL)
-        demoLabel = wx.StaticText(demoPanel, label=_("Preview:"))
-        demoSizer.Add(demoLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10)
-        demoPanel.SetSizer(demoSizer)
-        self._demoDatePanel = demoPanel
-        self._demoDateCtrl = None
-        self._rebuildDemoDateCtrl(currentFormat or None)
-        self.addEntry("", demoPanel)
+        demo_panel = wx.Panel(self)
+        demo_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        demo_label = wx.StaticText(demo_panel, label=_("Preview:"))
+        demo_sizer.Add(demo_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10)
+        demo_panel.SetSizer(demo_sizer)
+        self._demo_date_panel = demo_panel
+        self._demo_date_ctrl = None
+        self._rebuild_demo_date_ctrl(current_format or None)
+        self.addEntry("", demo_panel)
+
+        # === DISPLAY OVERRIDE SECTION ===
+        # Optional display-only override (does not affect date entry).
+        display_override_panel = wx.Panel(self)
+        display_override_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        self._display_override_choice = wx.Choice(display_override_panel)
+        display_overrides = [
+            ("", _("None")),
+            ("LONG_DMY", _("Saturday, 28 March 2026")),
+            ("ISO_ABBREV", _("2026-Mar-28-Sat")),
+        ]
+        current_override = self.gettext("view", "dateformat_display_override")
+        selected_override_idx = 0
+        for i, (value, label) in enumerate(display_overrides):
+            self._display_override_choice.Append(label, value)
+            if value == current_override:
+                selected_override_idx = i
+        self._display_override_choice.SetSelection(selected_override_idx)
+        self._display_override_choice.Bind(
+            wx.EVT_CHOICE, self._on_display_override_change
+        )
+        display_override_sizer.Add(
+            self._display_override_choice, 0, wx.ALIGN_CENTER_VERTICAL
+        )
+        display_override_panel.SetSizer(display_override_sizer)
+        self.addEntry(_("Display override"), display_override_panel)
+
+        # Preview below the override dropdown (empty when None).
+        override_preview_panel = wx.Panel(self)
+        override_preview_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        override_preview_label = wx.StaticText(
+            override_preview_panel, label=_("Preview:")
+        )
+        override_preview_sizer.Add(
+            override_preview_label,
+            0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10,
+        )
+        override_preview_panel.SetSizer(override_preview_sizer)
+        self._display_override_preview_panel = override_preview_panel
+        self._display_override_preview_ctrl = None
+        self._rebuild_display_override_preview(current_override)
+        self.addEntry("", override_preview_panel)
 
         # === TIME FORMAT SECTION ===
         # Time format dropdown with detected format label
-        timeFormatPanel = wx.Panel(self)
-        timeFormatSizer = wx.BoxSizer(wx.HORIZONTAL)
+        time_format_panel = wx.Panel(self)
+        time_format_sizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        self._timeFormatChoice = wx.Choice(timeFormatPanel)
-        timeFormats = [
+        self._time_format_choice = wx.Choice(time_format_panel)
+        time_formats = [
             ("", _("Automatic (detect from system)")),
             ("24", _("24-hour (14:30)")),
             ("12", _("12-hour (2:30 PM)")),
         ]
-        currentTimeFormat = self.gettext("view", "timeformat")
-        selectedTimeIdx = 0
-        for i, (value, label) in enumerate(timeFormats):
-            self._timeFormatChoice.Append(label, value)
-            if value == currentTimeFormat:
-                selectedTimeIdx = i
-        self._timeFormatChoice.SetSelection(selectedTimeIdx)
-        timeFormatSizer.Add(self._timeFormatChoice, 0, wx.ALIGN_CENTER_VERTICAL)
+        current_time_format = self.gettext("view", "timeformat")
+        selected_time_idx = 0
+        for i, (value, label) in enumerate(time_formats):
+            self._time_format_choice.Append(label, value)
+            if value == current_time_format:
+                selected_time_idx = i
+        self._time_format_choice.SetSelection(selected_time_idx)
+        time_format_sizer.Add(
+            self._time_format_choice, 0, wx.ALIGN_CENTER_VERTICAL
+        )
 
         # Detected time format label
         from taskcoachlib.widgets.maskedtimectrl import getDetectedLocaleTimeFormat
-        detectedTimeFormat = getDetectedLocaleTimeFormat()
-        detectedTimeStr = "24-hour" if detectedTimeFormat == "24" else "12-hour"
-        self._detectedTimeFormatLabel = wx.StaticText(
-            timeFormatPanel,
-            label=_("Detected: %s") % detectedTimeStr
+        detected_time_format = getDetectedLocaleTimeFormat()
+        detected_time_str = (
+            "24-hour" if detected_time_format == "24" else "12-hour"
         )
-        self._detectedTimeFormatLabel.SetForegroundColour(
+        self._detected_time_format_label = wx.StaticText(
+            time_format_panel,
+            label=_("Detected: %s") % detected_time_str
+        )
+        self._detected_time_format_label.SetForegroundColour(
             wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
         )
-        timeFormatSizer.Add(self._detectedTimeFormatLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 15)
+        time_format_sizer.Add(
+            self._detected_time_format_label,
+            0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 15,
+        )
 
-        timeFormatPanel.SetSizer(timeFormatSizer)
-        self._timeFormatChoice.Bind(wx.EVT_CHOICE, self._onTimeFormatChange)
-        self.addEntry(_("Time format"), timeFormatPanel)
+        time_format_panel.SetSizer(time_format_sizer)
+        self._time_format_choice.Bind(wx.EVT_CHOICE, self._on_time_format_change)
+        self.addEntry(_("Time format"), time_format_panel)
 
         # Demo TimeCtrl showing the selected format (interactive, starts with current time)
-        timeDemoPanel = wx.Panel(self)
-        timeDemoSizer = wx.BoxSizer(wx.HORIZONTAL)
-        timeDemoLabel = wx.StaticText(timeDemoPanel, label=_("Preview:"))
-        timeDemoSizer.Add(timeDemoLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10)
-        timeDemoPanel.SetSizer(timeDemoSizer)
-        self._demoTimePanel = timeDemoPanel
-        self._demoTimeCtrl = None
-        self._rebuildDemoTimeCtrl(currentTimeFormat if currentTimeFormat else "24")
-        self.addEntry("", timeDemoPanel)
+        time_demo_panel = wx.Panel(self)
+        time_demo_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        time_demo_label = wx.StaticText(time_demo_panel, label=_("Preview:"))
+        time_demo_sizer.Add(
+            time_demo_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10
+        )
+        time_demo_panel.SetSizer(time_demo_sizer)
+        self._demo_time_panel = time_demo_panel
+        self._demo_time_ctrl = None
+        self._rebuild_demo_time_ctrl(
+            current_time_format if current_time_format else "24"
+        )
+        self.addEntry("", time_demo_panel)
 
         # Note about 12-hour mode and working hours
         self.addHintRow(
@@ -1539,104 +1595,113 @@ class LanguagePage(SettingsPage):
 
         # === NUMBER FORMAT SECTION ===
         # Decimal separator dropdown
-        decSepPanel = wx.Panel(self)
-        decSepSizer = wx.BoxSizer(wx.HORIZONTAL)
+        dec_sep_panel = wx.Panel(self)
+        dec_sep_sizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        self._decimalSepChoice = wx.Choice(decSepPanel)
-        decimalSepFormats = [
+        self._decimal_sep_choice = wx.Choice(dec_sep_panel)
+        decimal_sep_formats = [
             ("", _("Automatic (detect from system)")),
             (".", _("Period (.)")),
             (",", _("Comma (,)")),
         ]
-        currentDecSep = self.gettext("view", "decimal_separator")
-        selectedDecSepIdx = 0
-        for i, (value, label) in enumerate(decimalSepFormats):
-            self._decimalSepChoice.Append(label, value)
-            if value == currentDecSep:
-                selectedDecSepIdx = i
-        self._decimalSepChoice.SetSelection(selectedDecSepIdx)
-        self._decimalSepChoice.Bind(wx.EVT_CHOICE, self._onDecimalSepChange)
-        decSepSizer.Add(self._decimalSepChoice, 0, wx.ALIGN_CENTER_VERTICAL)
+        current_dec_sep = self.gettext("view", "decimal_separator")
+        selected_dec_sep_idx = 0
+        for i, (value, label) in enumerate(decimal_sep_formats):
+            self._decimal_sep_choice.Append(label, value)
+            if value == current_dec_sep:
+                selected_dec_sep_idx = i
+        self._decimal_sep_choice.SetSelection(selected_dec_sep_idx)
+        self._decimal_sep_choice.Bind(wx.EVT_CHOICE, self._on_decimal_sep_change)
+        dec_sep_sizer.Add(self._decimal_sep_choice, 0, wx.ALIGN_CENTER_VERTICAL)
 
         # Detected decimal separator label
         import locale as _locale
-        detectedDecSep = _locale.localeconv().get("decimal_point", ".") or "."
-        self._detectedDecSepLabel = wx.StaticText(
-            decSepPanel,
-            label=_("Detected: %s") % ('"%s"' % detectedDecSep)
+        detected_dec_sep = _locale.localeconv().get("decimal_point", ".") or "."
+        self._detected_dec_sep_label = wx.StaticText(
+            dec_sep_panel,
+            label=_("Detected: %s") % ('"%s"' % detected_dec_sep)
         )
-        self._detectedDecSepLabel.SetForegroundColour(
+        self._detected_dec_sep_label.SetForegroundColour(
             wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
         )
-        decSepSizer.Add(self._detectedDecSepLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 15)
+        dec_sep_sizer.Add(
+            self._detected_dec_sep_label,
+            0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 15,
+        )
 
-        decSepPanel.SetSizer(decSepSizer)
-        self.addEntry(_("Decimal separator"), decSepPanel)
+        dec_sep_panel.SetSizer(dec_sep_sizer)
+        self.addEntry(_("Decimal separator"), dec_sep_panel)
 
         # Currency decimal places dropdown
-        currDpPanel = wx.Panel(self)
-        currDpSizer = wx.BoxSizer(wx.HORIZONTAL)
+        curr_dp_panel = wx.Panel(self)
+        curr_dp_sizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        self._currencyDpChoice = wx.Choice(currDpPanel)
-        currencyDpOptions = [
+        self._currency_dp_choice = wx.Choice(curr_dp_panel)
+        currency_dp_options = [
             ("", _("Automatic (from locale)")),
             ("0", _("0 (e.g. JPY, KRW)")),
             ("2", _("2 (e.g. USD, EUR)")),
             ("3", _("3 (e.g. BHD, KWD)")),
         ]
-        currentCurrDp = self.gettext("view", "currency_decimal_places")
-        selectedCurrDpIdx = 0
-        for i, (value, label) in enumerate(currencyDpOptions):
-            self._currencyDpChoice.Append(label, value)
-            if value == currentCurrDp:
-                selectedCurrDpIdx = i
-        self._currencyDpChoice.SetSelection(selectedCurrDpIdx)
-        self._currencyDpChoice.Bind(wx.EVT_CHOICE, self._onCurrencyDpChange)
-        currDpSizer.Add(self._currencyDpChoice, 0, wx.ALIGN_CENTER_VERTICAL)
+        current_curr_dp = self.gettext("view", "currency_decimal_places")
+        selected_curr_dp_idx = 0
+        for i, (value, label) in enumerate(currency_dp_options):
+            self._currency_dp_choice.Append(label, value)
+            if value == current_curr_dp:
+                selected_curr_dp_idx = i
+        self._currency_dp_choice.SetSelection(selected_curr_dp_idx)
+        self._currency_dp_choice.Bind(wx.EVT_CHOICE, self._on_currency_dp_change)
+        curr_dp_sizer.Add(self._currency_dp_choice, 0, wx.ALIGN_CENTER_VERTICAL)
 
         # Detected currency decimal places label
-        detectedFrac = _locale.localeconv().get("frac_digits", 2)
-        if detectedFrac == 127:
-            detectedFrac = 2
-        self._detectedCurrDpLabel = wx.StaticText(
-            currDpPanel,
-            label=_("Detected: %d") % detectedFrac
+        detected_frac = _locale.localeconv().get("frac_digits", 2)
+        if detected_frac == 127:
+            detected_frac = 2
+        self._detected_curr_dp_label = wx.StaticText(
+            curr_dp_panel,
+            label=_("Detected: %d") % detected_frac
         )
-        self._detectedCurrDpLabel.SetForegroundColour(
+        self._detected_curr_dp_label.SetForegroundColour(
             wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
         )
-        currDpSizer.Add(self._detectedCurrDpLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 15)
+        curr_dp_sizer.Add(
+            self._detected_curr_dp_label,
+            0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 15,
+        )
 
-        currDpPanel.SetSizer(currDpSizer)
-        self.addEntry(_("Currency decimal places"), currDpPanel)
+        curr_dp_panel.SetSizer(curr_dp_sizer)
+        self.addEntry(_("Currency decimal places"), curr_dp_panel)
 
         # Demo CurrencyCtrl showing the selected decimal separator and places (live update)
         from taskcoachlib.widgets.numericctrl import NumericCtrl
-        currDemoPanel = wx.Panel(self)
-        currDemoSizer = wx.BoxSizer(wx.HORIZONTAL)
-        currDemoLabel = wx.StaticText(currDemoPanel, label=_("Preview:"))
-        currDemoSizer.Add(currDemoLabel, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10)
-        # Resolve effective decimal char and places for initial demo
-        effectiveDecChar = currentDecSep or detectedDecSep
-        if currentCurrDp:
-            effectiveCurrDp = int(currentCurrDp)
-        else:
-            effectiveCurrDp = detectedFrac
-        self._demoCurrencyCtrl = NumericCtrl(
-            currDemoPanel,
-            value=1234.56,
-            decimal_places=effectiveCurrDp,
-            decimal_char=effectiveDecChar,
+        curr_demo_panel = wx.Panel(self)
+        curr_demo_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        curr_demo_label = wx.StaticText(curr_demo_panel, label=_("Preview:"))
+        curr_demo_sizer.Add(
+            curr_demo_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 10
         )
-        currDemoSizer.Add(self._demoCurrencyCtrl, 0, wx.ALIGN_CENTER_VERTICAL)
-        currDemoPanel.SetSizer(currDemoSizer)
-        self.addEntry("", currDemoPanel)
+        # Resolve effective decimal char and places for initial demo
+        effective_dec_char = current_dec_sep or detected_dec_sep
+        if current_curr_dp:
+            effective_curr_dp = int(current_curr_dp)
+        else:
+            effective_curr_dp = detected_frac
+        self._demo_currency_ctrl = NumericCtrl(
+            curr_demo_panel,
+            value=1234.56,
+            decimal_places=effective_curr_dp,
+            decimal_char=effective_dec_char,
+        )
+        curr_demo_sizer.Add(self._demo_currency_ctrl, 0, wx.ALIGN_CENTER_VERTICAL)
+        curr_demo_panel.SetSizer(curr_demo_sizer)
+        self.addEntry("", curr_demo_panel)
 
         # Store original formats to detect changes
-        self._originalDateFormat = currentFormat
-        self._originalTimeFormat = currentTimeFormat
-        self._originalDecimalSep = currentDecSep
-        self._originalCurrencyDp = currentCurrDp
+        self._original_date_format = current_format
+        self._original_display_override = current_override
+        self._original_time_format = current_time_format
+        self._original_decimal_sep = current_dec_sep
+        self._original_currency_dp = current_curr_dp
 
         self.fit()
 
@@ -1726,13 +1791,13 @@ class LanguagePage(SettingsPage):
         self._spellCheckLangChoice.Enable(enabled and ENCHANT_AVAILABLE)
         event.Skip()
 
-    def _formatOrderToString(self, field_order, separator):
+    def _format_order_to_string(self, field_order, separator):
         """Convert field order and separator to a human-readable format string."""
         field_map = {'year': 'YYYY', 'month': 'MM', 'date_day': 'DD'}
         parts = [field_map.get(f, '??') for f in field_order]
         return separator.join(parts)
 
-    def _getSelectedLanguageCode(self):
+    def _get_selected_language_code(self):
         """Get the currently selected language code from the dropdown."""
         for section, setting, choiceCtrls in self._choiceSettings:
             if setting == "language_set_by_user":
@@ -1740,185 +1805,243 @@ class LanguagePage(SettingsPage):
                 return choice.GetClientData(choice.GetSelection())
         return ""
 
-    def _rebuildDemoDateCtrl(self, dateFormat):
+    def _rebuild_demo_date_ctrl(self, date_format):
         """(Re)create the demo DateComboRouterCtrl with the given format."""
         from taskcoachlib.widgets.maskedtimectrl import DateComboRouterCtrl
         import datetime
         today = datetime.date.today()
-        parent = self._demoDatePanel
+        parent = self._demo_date_panel
         sizer = parent.GetSizer()
-        if self._demoDateCtrl:
-            self._demoDateCtrl.Destroy()
-        self._demoDateCtrl = DateComboRouterCtrl(
+        if self._demo_date_ctrl:
+            self._demo_date_ctrl.Destroy()
+        self._demo_date_ctrl = DateComboRouterCtrl(
             parent,
             year=today.year, month=today.month, day=today.day,
-            dateFormat=dateFormat
+            dateFormat=date_format
         )
-        sizer.Add(self._demoDateCtrl, 0, wx.ALIGN_CENTER_VERTICAL)
+        sizer.Add(self._demo_date_ctrl, 0, wx.ALIGN_CENTER_VERTICAL)
         parent.Layout()
         parent.Fit()
 
-    def _rebuildDemoTimeCtrl(self, timeFormat):
+    def _rebuild_demo_time_ctrl(self, time_format):
         """(Re)create the demo TimeCtrl with the given format."""
         from taskcoachlib.widgets.maskedtimectrl import TimeCtrl
         import datetime
         now = datetime.datetime.now()
-        parent = self._demoTimePanel
+        parent = self._demo_time_panel
         sizer = parent.GetSizer()
-        if self._demoTimeCtrl:
-            self._demoTimeCtrl.Destroy()
-        self._demoTimeCtrl = TimeCtrl(
+        if self._demo_time_ctrl:
+            self._demo_time_ctrl.Destroy()
+        self._demo_time_ctrl = TimeCtrl(
             parent,
             hours=now.hour, minutes=now.minute,
-            timeFormat=timeFormat
+            timeFormat=time_format
         )
-        sizer.Add(self._demoTimeCtrl, 0, wx.ALIGN_CENTER_VERTICAL)
+        sizer.Add(self._demo_time_ctrl, 0, wx.ALIGN_CENTER_VERTICAL)
         parent.Layout()
         parent.Fit()
 
-    def _onDateFormatChange(self, event):
+    def _on_date_format_change(self, event):
         """Handle date format dropdown change - update demo control and restart warning."""
         choice = event.GetEventObject()
-        newFormat = choice.GetClientData(choice.GetSelection())
-        self._rebuildDemoDateCtrl(newFormat or None)
-        self._updateRestartWarning()
+        new_format = choice.GetClientData(choice.GetSelection())
+        self._rebuild_demo_date_ctrl(new_format or None)
+        self._update_restart_warning()
         event.Skip()
 
-    def _onTimeFormatChange(self, event):
+    def _rebuild_display_override_preview(self, override):
+        """(Re)build the preview for the Display Override setting.
+
+        Empty override renders no preview (clears the slot). A recognized
+        override renders a static label formatted via strftime with today.
+        An unrecognized non-empty value is logged and rendered as blank.
+        """
+        from taskcoachlib.render import _DISPLAY_ONLY_DATE_FORMATS
+        import datetime
+        parent = self._display_override_preview_panel
+        sizer = parent.GetSizer()
+        if self._display_override_preview_ctrl:
+            self._display_override_preview_ctrl.Destroy()
+            self._display_override_preview_ctrl = None
+        if override in _DISPLAY_ONLY_DATE_FORMATS:
+            self._display_override_preview_ctrl = wx.StaticText(
+                parent,
+                label=datetime.date.today().strftime(
+                    _DISPLAY_ONLY_DATE_FORMATS[override]
+                ),
+            )
+            sizer.Add(
+                self._display_override_preview_ctrl,
+                0, wx.ALIGN_CENTER_VERTICAL,
+            )
+        elif override:
+            from taskcoachlib.meta.debug import log_step
+            log_step(
+                "unknown display override %r; no preview shown" % override,
+                prefix="PREFS",
+            )
+        parent.Layout()
+        parent.Fit()
+
+    def _on_display_override_change(self, event):
+        """Handle display-override dropdown change."""
+        choice = event.GetEventObject()
+        new_override = choice.GetClientData(choice.GetSelection())
+        self._rebuild_display_override_preview(new_override)
+        self._update_restart_warning()
+        event.Skip()
+
+    def _on_time_format_change(self, event):
         """Handle time format dropdown change - update demo control and restart warning."""
         choice = event.GetEventObject()
-        newFormat = choice.GetClientData(choice.GetSelection())
-        self._rebuildDemoTimeCtrl(newFormat if newFormat else "24")
-        self._updateRestartWarning()
+        new_format = choice.GetClientData(choice.GetSelection())
+        self._rebuild_demo_time_ctrl(new_format if new_format else "24")
+        self._update_restart_warning()
         event.Skip()
 
-    def _onDecimalSepChange(self, event):
+    def _on_decimal_sep_change(self, event):
         """Handle decimal separator dropdown change - update demo and restart warning."""
-        self._updateCurrencyDemo()
-        self._updateRestartWarning()
+        self._update_currency_demo()
+        self._update_restart_warning()
         event.Skip()
 
-    def _onCurrencyDpChange(self, event):
+    def _on_currency_dp_change(self, event):
         """Handle currency decimal places dropdown change - update demo and restart warning."""
-        self._updateCurrencyDemo()
-        self._updateRestartWarning()
+        self._update_currency_demo()
+        self._update_restart_warning()
         event.Skip()
 
-    def _updateCurrencyDemo(self):
+    def _update_currency_demo(self):
         """Recreate the demo NumericCtrl with current dropdown selections."""
         import locale as _locale
         from taskcoachlib.widgets.numericctrl import NumericCtrl
 
         # Resolve effective decimal char
-        selectedDecSep = self._decimalSepChoice.GetClientData(
-            self._decimalSepChoice.GetSelection()
+        selected_dec_sep = self._decimal_sep_choice.GetClientData(
+            self._decimal_sep_choice.GetSelection()
         )
-        if not selectedDecSep:
-            selectedDecSep = _locale.localeconv().get("decimal_point", ".")
+        if not selected_dec_sep:
+            selected_dec_sep = _locale.localeconv().get("decimal_point", ".")
 
         # Resolve effective currency decimal places
-        selectedCurrDp = self._currencyDpChoice.GetClientData(
-            self._currencyDpChoice.GetSelection()
+        selected_curr_dp = self._currency_dp_choice.GetClientData(
+            self._currency_dp_choice.GetSelection()
         )
-        if selectedCurrDp:
-            effectiveDp = int(selectedCurrDp)
+        if selected_curr_dp:
+            effective_dp = int(selected_curr_dp)
         else:
-            effectiveDp = _locale.localeconv().get("frac_digits", 2)
-            if effectiveDp == 127:
-                effectiveDp = 2
+            effective_dp = _locale.localeconv().get("frac_digits", 2)
+            if effective_dp == 127:
+                effective_dp = 2
 
         # Destroy old and create new
-        parent = self._demoCurrencyCtrl.GetParent()
+        parent = self._demo_currency_ctrl.GetParent()
         sizer = parent.GetSizer()
-        self._demoCurrencyCtrl.Destroy()
-        self._demoCurrencyCtrl = NumericCtrl(
+        self._demo_currency_ctrl.Destroy()
+        self._demo_currency_ctrl = NumericCtrl(
             parent, value=1234.56,
-            decimal_places=effectiveDp, decimal_char=selectedDecSep,
+            decimal_places=effective_dp, decimal_char=selected_dec_sep,
         )
-        sizer.Add(self._demoCurrencyCtrl, 0, wx.ALIGN_CENTER_VERTICAL)
+        sizer.Add(self._demo_currency_ctrl, 0, wx.ALIGN_CENTER_VERTICAL)
         parent.Layout()
         parent.Fit()
 
-    def _onLanguageChange(self, event):
+    def _on_language_change(self, event):
         """Handle language dropdown change."""
-        self._updateLocaleWarning()
-        self._updateRestartWarning()
+        self._update_locale_warning()
+        self._update_restart_warning()
         event.Skip()
 
-    def _updateRestartWarning(self):
+    def _update_restart_warning(self):
         """Update restart warning to show change detected state."""
-        selected_lang = self._getSelectedLanguageCode()
-        selected_date_format = self._dateFormatChoice.GetClientData(
-            self._dateFormatChoice.GetSelection()
+        selected_lang = self._get_selected_language_code()
+        selected_date_format = self._date_format_choice.GetClientData(
+            self._date_format_choice.GetSelection()
         )
-        selected_time_format = self._timeFormatChoice.GetClientData(
-            self._timeFormatChoice.GetSelection()
+        selected_time_format = self._time_format_choice.GetClientData(
+            self._time_format_choice.GetSelection()
         )
 
-        selected_decimal_sep = self._decimalSepChoice.GetClientData(
-            self._decimalSepChoice.GetSelection()
+        selected_decimal_sep = self._decimal_sep_choice.GetClientData(
+            self._decimal_sep_choice.GetSelection()
         )
-        selected_currency_dp = self._currencyDpChoice.GetClientData(
-            self._currencyDpChoice.GetSelection()
+        selected_currency_dp = self._currency_dp_choice.GetClientData(
+            self._currency_dp_choice.GetSelection()
+        )
+
+        selected_display_override = self._display_override_choice.GetClientData(
+            self._display_override_choice.GetSelection()
         )
 
         # Check if any regional setting has changed
-        language_changed = selected_lang != self._originalLanguage
-        date_format_changed = selected_date_format != self._originalDateFormat
-        time_format_changed = selected_time_format != self._originalTimeFormat
-        decimal_sep_changed = selected_decimal_sep != self._originalDecimalSep
-        currency_dp_changed = selected_currency_dp != self._originalCurrencyDp
+        language_changed = selected_lang != self._original_language
+        date_format_changed = selected_date_format != self._original_date_format
+        display_override_changed = (
+            selected_display_override != self._original_display_override
+        )
+        time_format_changed = selected_time_format != self._original_time_format
+        decimal_sep_changed = selected_decimal_sep != self._original_decimal_sep
+        currency_dp_changed = selected_currency_dp != self._original_currency_dp
 
-        if language_changed or date_format_changed or time_format_changed or decimal_sep_changed or currency_dp_changed:
+        if (language_changed or date_format_changed
+                or display_override_changed or time_format_changed
+                or decimal_sep_changed or currency_dp_changed):
             # Change detected - show red warning
-            self._restartWarning.SetLabel(
-                self._restartWarningBase + " " + _("Change detected, restart required!")
+            self._restart_warning.SetLabel(
+                self._restart_warning_base + " " + _("Change detected, restart required!")
             )
-            self._restartWarning.SetForegroundColour(wx.Colour(180, 0, 0))
+            self._restart_warning.SetForegroundColour(wx.Colour(180, 0, 0))
         else:
             # Reverted to original - restore normal state
-            self._restartWarning.SetLabel(self._restartWarningBase)
-            self._restartWarning.SetForegroundColour(self._restartWarningDefaultColor)
-        self._restartWarning.Refresh()
+            self._restart_warning.SetLabel(self._restart_warning_base)
+            self._restart_warning.SetForegroundColour(self._restart_warning_default_color)
+        self._restart_warning.Refresh()
         self.Layout()
 
-    def _updateLocaleWarning(self):
+    def _update_locale_warning(self):
         """Show or hide the locale warning based on selected language's locale availability."""
         from taskcoachlib import i18n
         # Check if the selected language's locale is available on the system
-        selected_lang = self._getSelectedLanguageCode()
-        showWarning = not i18n.isLocaleAvailable(selected_lang)
-        self._localeWarning.Show(showWarning)
+        selected_lang = self._get_selected_language_code()
+        show_warning = not i18n.isLocaleAvailable(selected_lang)
+        self._locale_warning.Show(show_warning)
         self.Layout()
 
     def ok(self):
         super().ok()
         self.set("view", "language", self.get("view", "language_set_by_user"))
         # Save date format setting
-        selectedFormat = self._dateFormatChoice.GetClientData(
-            self._dateFormatChoice.GetSelection()
+        selected_format = self._date_format_choice.GetClientData(
+            self._date_format_choice.GetSelection()
         )
-        self.set("view", "dateformat", selectedFormat)
+        self.set("view", "dateformat", selected_format)
+        # Save display-only override (applies only to rendering)
+        selected_display_override = self._display_override_choice.GetClientData(
+            self._display_override_choice.GetSelection()
+        )
+        self.set(
+            "view", "dateformat_display_override", selected_display_override
+        )
         # Save time format setting
-        selectedTimeFormat = self._timeFormatChoice.GetClientData(
-            self._timeFormatChoice.GetSelection()
+        selected_time_format = self._time_format_choice.GetClientData(
+            self._time_format_choice.GetSelection()
         )
-        self.set("view", "timeformat", selectedTimeFormat)
+        self.set("view", "timeformat", selected_time_format)
         # Save decimal separator setting
-        selectedDecSep = self._decimalSepChoice.GetClientData(
-            self._decimalSepChoice.GetSelection()
+        selected_dec_sep = self._decimal_sep_choice.GetClientData(
+            self._decimal_sep_choice.GetSelection()
         )
-        self.set("view", "decimal_separator", selectedDecSep)
+        self.set("view", "decimal_separator", selected_dec_sep)
         # Save currency decimal places setting
-        selectedCurrDp = self._currencyDpChoice.GetClientData(
-            self._currencyDpChoice.GetSelection()
+        selected_curr_dp = self._currency_dp_choice.GetClientData(
+            self._currency_dp_choice.GetSelection()
         )
-        self.set("view", "currency_decimal_places", selectedCurrDp)
+        self.set("view", "currency_decimal_places", selected_curr_dp)
         # Save spell check language (enabled checkbox saved by base ok())
-        selectedSpellLang = self._spellCheckLangChoice.GetClientData(
+        selected_spell_lang = self._spellCheckLangChoice.GetClientData(
             self._spellCheckLangChoice.GetSelection()
         )
-        self.set("spellcheck", "language", selectedSpellLang)
+        self.set("spellcheck", "language", selected_spell_lang)
 
 
 class StatusesPage(SettingsPage):
@@ -2047,11 +2170,11 @@ class FeaturesPage(SettingsPage):
 
     def __init__(self, *args, **kwargs):
         super().__init__(columns=2, growableColumn=-1, *args, **kwargs)
-        self._restartWarningBase = _("All settings on this tab require a restart of %s to take effect.") % meta.name
-        self._restartWarning = wx.StaticText(self, label=self._restartWarningBase)
-        self._restartWarningDefaultColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
-        self._restartWarning.SetForegroundColour(self._restartWarningDefaultColor)
-        self.addEntry("", self._restartWarning)
+        self._restart_warning_base = _("All settings on this tab require a restart of %s to take effect.") % meta.name
+        self._restart_warning = wx.StaticText(self, label=self._restart_warning_base)
+        self._restart_warning_default_color = wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
+        self._restart_warning.SetForegroundColour(self._restart_warning_default_color)
+        self.addEntry("", self._restart_warning)
         self.addChoiceSetting(
             "view",
             "weekstart",
@@ -2144,10 +2267,10 @@ class FeaturesPage(SettingsPage):
         self.fit()
 
     def _onSettingChange(self, event):
-        self._updateRestartWarning()
+        self._update_restart_warning()
         event.Skip()
 
-    def _updateRestartWarning(self):
+    def _update_restart_warning(self):
         changed = False
         for section, setting, checkBox in self._booleanSettings:
             if checkBox.IsChecked() != self._originalValues.get((section, setting)):
@@ -2171,14 +2294,14 @@ class FeaturesPage(SettingsPage):
                 changed = True
 
         if changed:
-            self._restartWarning.SetLabel(
-                self._restartWarningBase + " " + _("Change detected, restart required!")
+            self._restart_warning.SetLabel(
+                self._restart_warning_base + " " + _("Change detected, restart required!")
             )
-            self._restartWarning.SetForegroundColour(wx.Colour(180, 0, 0))
+            self._restart_warning.SetForegroundColour(wx.Colour(180, 0, 0))
         else:
-            self._restartWarning.SetLabel(self._restartWarningBase)
-            self._restartWarning.SetForegroundColour(self._restartWarningDefaultColor)
-        self._restartWarning.Refresh()
+            self._restart_warning.SetLabel(self._restart_warning_base)
+            self._restart_warning.SetForegroundColour(self._restart_warning_default_color)
+        self._restart_warning.Refresh()
 
     def ok(self):
         super().ok()

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,11 +41,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.2"  # Major.Minor.Milestone
-patch = "10"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.2.10
+patch = "11"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.2.11
 
-release_day = "20"  # Day of the release (1-31)
-release_month = "March"  # Month of the release
+release_day = "13"  # Day of the release (1-31)
+release_month = "April"  # Month of the release
 release_year = "2026"  # Year of the release
 
 # =============================================================================

--- a/taskcoachlib/patches/hypertreelist.py
+++ b/taskcoachlib/patches/hypertreelist.py
@@ -1634,12 +1634,22 @@ class TreeListItem(GenericTreeItem):
 
         column = (column is not None and [column] or [self._owner.GetMainColumn()])[0]
 
-        if len(self._text) > 0:
-            if self._owner.IsVirtual():
-                return self._owner.GetItemText(self._data, column)
-            else:
-                return self._text[column]
-
+        if len(self._text) == 0:
+            return ""
+        if self._owner.IsVirtual():
+            return self._owner.GetItemText(self._data, column)
+        if column < len(self._text):
+            return self._text[column]
+        # Invariant violation: column count and item _text length have
+        # drifted. HyperTreeList.AddColumn/InsertColumn must extend every
+        # item's _text when a column is added; if this fires, that path
+        # was bypassed.
+        from taskcoachlib.meta.debug import log_step
+        log_step(
+            "GetText column=%d out of range (len(_text)=%d) on item %r"
+            % (column, len(self._text), self),
+            prefix="TREELIST",
+        )
         return ""
 
 
@@ -5157,6 +5167,28 @@ class HyperTreeList(wx.Control):
         return self._header_win.GetColumnText(column)
 
 
+    def _extend_item_texts_for_columns(self, insert_at=None):
+        """Ensure every tree item has a _text entry for every column.
+
+        Called after adding or inserting a column so GetText() doesn't
+        index past the end of an item's _text list during repaint.
+
+        :param `insert_at`: if given, splice an empty string into each
+         item's _text at this index (for InsertColumn). If None, append
+         empty strings to reach the current column count (for AddColumn).
+        """
+        if self._main_win is None or self._main_win._anchor is None:
+            return
+        target_len = self._header_win.GetColumnCount()
+        pending = [self._main_win._anchor]
+        while pending:
+            item = pending.pop()
+            if insert_at is not None and insert_at <= len(item._text):
+                item._text.insert(insert_at, "")
+            while len(item._text) < target_len:
+                item._text.append("")
+            pending.extend(item._children)
+
     def AddColumn(self, text, width=_DEFAULT_COL_WIDTH, flag=wx.ALIGN_LEFT,
                   image=-1, shown=True, colour=None, edit=False):
         """
@@ -5175,6 +5207,7 @@ class HyperTreeList(wx.Control):
         """
 
         self._header_win.AddColumn(text, width, flag, image, shown, colour, edit)
+        self._extend_item_texts_for_columns()
         self.DoHeaderLayout()
 
 
@@ -5186,6 +5219,7 @@ class HyperTreeList(wx.Control):
         """
 
         self._header_win.AddColumnInfo(colInfo)
+        self._extend_item_texts_for_columns()
         self.DoHeaderLayout()
 
 
@@ -5199,6 +5233,7 @@ class HyperTreeList(wx.Control):
         """
 
         self._header_win.InsertColumnInfo(before, colInfo)
+        self._extend_item_texts_for_columns(insert_at=before)
         self._header_win.Refresh()
 
 
@@ -5224,6 +5259,7 @@ class HyperTreeList(wx.Control):
 
         self._header_win.InsertColumn(before, text, width, flag, image,
                                       shown, colour, edit)
+        self._extend_item_texts_for_columns(insert_at=before)
         self._header_win.Refresh()
 
 
@@ -5235,6 +5271,13 @@ class HyperTreeList(wx.Control):
         """
 
         self._header_win.RemoveColumn(column)
+        if self._main_win is not None and self._main_win._anchor is not None:
+            pending = [self._main_win._anchor]
+            while pending:
+                item = pending.pop()
+                if column < len(item._text):
+                    del item._text[column]
+                pending.extend(item._children)
         self._header_win.Refresh()
 
 

--- a/taskcoachlib/render.py
+++ b/taskcoachlib/render.py
@@ -139,12 +139,52 @@ else:
     timeWithMinutesFormat = "%H:%M"
     timeWithSecondsFormat = "%H:%M:%S"
 
+# Display-only overrides applied on top of the entry-compatible date
+# format when rendering. Cannot be used for date input (no name parsing).
+_DISPLAY_ONLY_DATE_FORMATS = {
+    "LONG_DMY": "%A, %d %B %Y",      # Saturday, 28 March 2026
+    "ISO_ABBREV": "%Y-%b-%d-%a",     # 2026-Mar-28-Sat
+}
+
+
+def _get_display_override_from_settings():
+    try:
+        from taskcoachlib.config import settings
+        return settings.Settings().get("view", "dateformat_display_override")
+    except Exception as exc:
+        from taskcoachlib.meta.debug import log_step
+        log_step(
+            "could not read dateformat_display_override (%s); treating as empty"
+            % exc,
+            prefix="RENDER",
+        )
+        return ""
+
+
 try:
-    from taskcoachlib.widgets.maskedtimectrl import getEffectiveDateFormat
-    _field_order, _separator = getEffectiveDateFormat()
-    _format_map = {'year': '%Y', 'month': '%m', 'date_day': '%d'}
-    dateFormat = _separator.join(_format_map.get(f, '%Y') for f in _field_order)
-except Exception:
+    _display_override = _get_display_override_from_settings()
+    if _display_override in _DISPLAY_ONLY_DATE_FORMATS:
+        dateFormat = _DISPLAY_ONLY_DATE_FORMATS[_display_override]
+    else:
+        if _display_override:
+            from taskcoachlib.meta.debug import log_step
+            log_step(
+                "unknown dateformat_display_override %r; ignoring"
+                % _display_override,
+                prefix="RENDER",
+            )
+        from taskcoachlib.widgets.maskedtimectrl import getEffectiveDateFormat
+        _field_order, _separator = getEffectiveDateFormat()
+        _format_map = {'year': '%Y', 'month': '%m', 'date_day': '%d'}
+        dateFormat = _separator.join(
+            _format_map.get(f, '%Y') for f in _field_order
+        )
+except Exception as exc:
+    from taskcoachlib.meta.debug import log_step
+    log_step(
+        "failed to resolve dateFormat (%s); falling back to locale %%x" % exc,
+        prefix="RENDER",
+    )
     dateFormat = "%x"
 
 

--- a/taskcoachlib/widgets/maskedtimectrl.py
+++ b/taskcoachlib/widgets/maskedtimectrl.py
@@ -132,14 +132,15 @@ def getLocaleDateFormat(override=None):
     This mimics the approach from smartdatetimectrl.py to ensure the same
     locale-aware date formatting.
     """
-    # Check for override setting
+    # Override grammar: 3 chars from {Y, M, D} followed by a separator,
+    # e.g. "YMD-", "MDY/". Raises IndexError/KeyError on malformed input
+    # rather than silently falling back, so bad settings surface loudly.
     if override:
         field_map = {'Y': 'year', 'M': 'month', 'D': 'date_day'}
-        if len(override) >= 4:
-            order_str = override[:3].upper()
-            separator = override[3]
-            field_order = [field_map.get(c, 'year') for c in order_str]
-            return (field_order, separator)
+        order_str = override[:3].upper()
+        separator = override[3]
+        field_order = [field_map[c] for c in order_str]
+        return (field_order, separator)
 
     # Use a test date with unique values that are easy to identify:
     # year=3333, month=11, day=22 - these won't be confused with each other


### PR DESCRIPTION
Root cause of copy/paste + save corruption: SynchronizedObject.__getstate__ called super().__getstate__() which in Python 3.11+ returns the instance's live __dict__; subsequent state.update() calls wrote shadow attributes onto self, hiding methods (entryMode, subject, task, ...). Writer crashed trying to call a now-shadowed method, leaving a 0-byte tsk file.

Also fix a pre-existing HyperTreeList bug exposed by enabling the Modification date column: AddColumn/InsertColumn/RemoveColumn only touched the header, not item _text lists. Paint then indexed past the end with IndexError. Now sync all items' _text when columns mutate; GetText returns "" and logs [TREELIST] if an invariant still leaks through.

New Display override setting (view/dateformat_display_override) lets users render dates as "Saturday, 28 March 2026" or "2026-Mar-28-Sat" without affecting date entry controls (which still use the numeric YMD format). Added to preferences with a conditional preview that disappears when None.

PEP 8: removed band-aid shadowing workarounds (Effort.__getattribute__, self._Object__id accesses, "# attribute shadowing" comments), renamed preferences.py regional-settings attrs/methods/locals to snake_case, and renamed the new hypertreelist helper to _extend_item_texts_for_columns.

No silent failures: AttributeError in __getstate__/__setstate__ chain is now either unreachable (SynchronizedObject returns a fresh dict) or replaced with hasattr() guards; unexpected status values in __setstate__ are logged under [SYNC-OBJ]; render.py failures log under [RENDER]; preferences override failures log under [PREFS].

When copying and pasting an effort, the .tsk file gets currupted #429
Would like the option to include the day of week in the date. #428
Sort tasks by Most Recently Used #427
