### PR TITLE
Restore dead camelCase overrides left behind by PEP 8 rename

### DIFF
--- a/taskcoachlib/gui/dialog/editor.py
+++ b/taskcoachlib/gui/dialog/editor.py
@@ -2336,7 +2336,7 @@ class LocalCategoryViewer(viewer.BaseCategoryViewer):  # pylint: disable=W0223
                 None, self.__items, category=category
             ).do()
 
-    def checkAllCategories(self):
+    def check_all_categories(self):
         """Assign all categories to the items being edited."""
         for cat in self.presentation():
             for item in self.__items:
@@ -2344,7 +2344,7 @@ class LocalCategoryViewer(viewer.BaseCategoryViewer):  # pylint: disable=W0223
                     item.addCategory(cat)
         self.widget.refreshAllCheckStates()
 
-    def uncheckAllCategories(self):
+    def uncheck_all_categories(self):
         """Remove all categories from the items being edited."""
         for cat in self.presentation():
             for item in self.__items:

--- a/taskcoachlib/gui/taskbaricon.py
+++ b/taskcoachlib/gui/taskbaricon.py
@@ -203,8 +203,8 @@ class TaskBarIcon(patterns.Observer, wx.adv.TaskBarIcon):
         # Update state-dependent labels (e.g. Hide/Restore toggle)
         for item in self.popupmenu.GetMenuItems():
             cmd = getattr(item, '_command', None)
-            if cmd and hasattr(cmd, 'getMenuText'):
-                item.SetItemLabel(cmd.getMenuText())
+            if cmd and hasattr(cmd, 'get_menu_text'):
+                item.SetItemLabel(cmd.get_menu_text())
         self.PopupMenu(self.popupmenu)
 
     # Getters:

--- a/taskcoachlib/gui/uicommand/uicommand.py
+++ b/taskcoachlib/gui/uicommand/uicommand.py
@@ -3463,13 +3463,13 @@ class MainWindowRestore(base_uicommand.UICommand):
         else:
             window.Iconize()
 
-    def getHelpText(self):
+    def get_help_text(self):
         window = self.main_window()
         if window.IsIconized() or not window.IsShown():
             return _("Restore the window to its previous state")
         return _("Hide the main window")
 
-    def getMenuText(self):
+    def get_menu_text(self):
         window = self.main_window()
         if window.IsIconized() or not window.IsShown():
             return _("&Restore")

--- a/taskcoachlib/gui/viewer/effort.py
+++ b/taskcoachlib/gui/viewer/effort.py
@@ -78,7 +78,7 @@ class EffortViewer(
             "settings.%s.consolidateeffortspertask" % self.settingsSection(),
         )
 
-    def selectableColumns(self):
+    def selectable_columns(self):
         columns = list()
         for column in self.columns():
             if (

--- a/taskcoachlib/gui/viewer/task.py
+++ b/taskcoachlib/gui/viewer/task.py
@@ -2004,7 +2004,7 @@ class TaskViewer(
         super().setSortByTaskStatusFirst(*args, **kwargs)
         self.show_sort_order()
 
-    def getSortOrderImage(self):
+    def get_sort_order_image(self):
         if self.isSortOrderAscending():
             if self.isSortByTaskStatusFirst():  # pylint: disable=E1101
                 return "taskcoach_actions_arrow_down_with_status_icon"

--- a/tests/unittests/guiTests/ExportDialogTest.py
+++ b/tests/unittests/guiTests/ExportDialogTest.py
@@ -50,7 +50,7 @@ class DummyViewer(object):
     def columns(self):
         return [self.col1, self.col2]
 
-    def selectableColumns(self):
+    def selectable_columns(self):
         return [self.col2]
 
 

--- a/tests/unittests/persistenceTests/CSVWriterTest.py
+++ b/tests/unittests/persistenceTests/CSVWriterTest.py
@@ -407,7 +407,7 @@ class EffortWriterTest(CSVWriterTestCase):
             render.dateTimePeriod(
                 self.effort.getStart(), self.effort.getStop()
             ),
-            columns=self.viewer.selectableColumns(),
+            columns=self.viewer.selectable_columns(),
         )
 
     def testExportAllColumns_Split(self):
@@ -420,7 +420,7 @@ class EffortWriterTest(CSVWriterTestCase):
                 render.time(self.effort.getStop().time()),
             ),
             separateDateAndTimeColumns=True,
-            columns=self.viewer.selectableColumns(),
+            columns=self.viewer.selectable_columns(),
         )
 
 


### PR DESCRIPTION
Several subclass methods defined in camelCase are meant to override a base-class method that was already PEP 8 renamed to snake_case. Python treats them as separate methods, so the override becomes dead code and the base implementation runs instead. User-visible effects:

- TaskViewer.getSortOrderImage was dead; 'sort by status first' never showed the arrow-with-status bitmap (just plain up/down arrows).
- LocalCategoryViewer.checkAllCategories / uncheckAllCategories were dead; clicking Check/Uncheck All in the task editor's Categories tab triggered the base behavior (filter all categories in the main category panel) instead of assigning/removing categories on the items being edited.
- MainWindowRestore.getHelpText / getMenuText didn't override the base UICommand.get_help_text / get_menu_text; the tray menu only updated the label because taskbaricon.popupTaskBarMenu happened to probe the camelCase name. Renamed both sides to snake_case.
- EffortViewer.selectableColumns was dead; export dialogs call viewer.selectable_columns() via the base, ignoring the effort- specific column filtering.

Renamed all of them to match the base's snake_case, and updated taskbaricon.popupTaskBarMenu plus affected unit tests to use the new names.