### PR TITLE
Log idle backend at startup, document idle subsystem, PEP 8 renames, …

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -103,7 +103,7 @@ jobs:
           python -c "
           from taskcoachlib.powermgt.idle import IdleQuery
           iq = IdleQuery()
-          idle = iq.getIdleSeconds()
+          idle = iq.get_idle_seconds()
           print(f'Idle time: {idle} seconds')
           "
 

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.11-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.11-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.11_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.11_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.11_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.11-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.12-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.12-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.12_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.12_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.12_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.12-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.11-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.11-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.11_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.11_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.2.11-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.2.11-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.12-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.12-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.12_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.12_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.2.12-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.2.12-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.11_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.2.11_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.12_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.2.12_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.11-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.2.11-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.12-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.2.12-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.11-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.2.11-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.12-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.2.12-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.11-x86_64.AppImage
-chmod +x TaskCoach-2.0.2.11-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.12-x86_64.AppImage
+chmod +x TaskCoach-2.0.2.12-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.2.11-x86_64.AppImage
+./TaskCoach-2.0.2.12-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/VERSION
+++ b/VERSION
@@ -10,8 +10,14 @@
 # Primary (single source of truth):
 #   taskcoachlib/meta/data.py - version, patch, release date, formatting docs
 #
-# Also update (manual, version in file):
-#   debian/changelog - version in header, add changelog entry
-#   build.in/fedora/taskcoach.spec - Version: line, add %changelog entry
+# Also update (visible to end users):
+#   README.md - all hardcoded version strings in download table and wget URLs
+#
+# Auto-updated by CI (do NOT bump manually):
+#   debian/changelog - overwritten by .github/workflows/build-deb.yml from
+#                      meta/data.py at build time
+#   build.in/fedora/taskcoach.spec - Version: line rewritten by
+#                                    .github/workflows/build-rpm.yml via sed
+#                                    (the %changelog section is cosmetic only)
 #
 # =============================================================================

--- a/docs/IDLE.md
+++ b/docs/IDLE.md
@@ -1,0 +1,249 @@
+# Idle Time Detection
+
+How Task Coach detects user inactivity and decides what to do about a
+running effort entry. Used by the "Idle time notice" feature (Preferences
+> Features > Idle time notice).
+
+## Index
+
+- [Feature Overview](#feature-overview)
+- [Platform Support Matrix](#platform-support-matrix)
+- [Backend Probe Order (Linux)](#backend-probe-order-linux)
+- [Setting](#setting)
+- [Wake-From-Idle Dialog](#wake-from-idle-dialog)
+- [State Machine](#state-machine)
+- [Startup Logging](#startup-logging)
+- [Known Gaps](#known-gaps)
+- [File Reference](#file-reference)
+- [See Also](#see-also)
+
+---
+
+## Feature Overview
+
+When a task is being tracked for effort and the user stops interacting
+with the computer for at least `feature.minidletime` minutes, Task Coach
+records a "went idle" timestamp. When the user returns, a notification
+pops up offering to back-date the effort's stop time, optionally
+resuming a fresh effort entry from "now".
+
+The feature is off by default (`minidletime = 0`). It activates as soon
+as the user sets a non-zero value in Preferences.
+
+---
+
+## Platform Support Matrix
+
+Idle detection backend per platform. Backends are tried in order on
+Linux; the first one that responds is used.
+
+| Platform | Backend | Mechanism | Notes |
+|----------|---------|-----------|-------|
+| **Windows** | `win32_GetLastInputInfo` | `user32.GetLastInputInfo` + `kernel32.GetTickCount` | Single backend, no fallback. Works on all supported Windows versions. |
+| **macOS** | `iokit_HIDIdleTime` | IOKit `IORegistryEntryCreateCFProperty` on `IOHIDSystem`, property `HIDIdleTime` | Pure-ctypes; loads `IOKit.framework` and `CoreFoundation.framework`. Replaces the pre-2026 `_idle.so` C extension. |
+| **Linux/GTK (GNOME, X11 or Wayland)** | `dbus_mutter` | DBus call `org.gnome.Mutter.IdleMonitor.GetIdletime` on `/org/gnome/Mutter/IdleMonitor/Core` | Returns milliseconds. Works for GNOME Shell sessions including Wayland. |
+| **Linux/GTK (KDE Plasma)** | `dbus_screensaver` | DBus call `org.freedesktop.ScreenSaver.GetSessionIdleTime` on `/ScreenSaver` | Returns seconds. KDE KWin implements this. Some non-KDE compositors register the bus name but do not implement `GetSessionIdleTime`. |
+| **Linux/GTK (legacy X11)** | `x11_mit_screensaver` | `libXss.so.1` `XScreenSaverQueryInfo` via the X11 MIT-SCREEN-SAVER extension | Final fallback. Works on any X11 session whose server advertises the extension. Does not work on Wayland-only compositors. |
+| **Linux/GTK (other)** | none | none | If all three probes fail, a one-time warning is logged and the feature silently disables itself for the session. |
+
+### Compositor Coverage Today
+
+| Scenario | Covered by |
+|----------|------------|
+| GNOME on X11 or Wayland | `dbus_mutter` |
+| KDE Plasma on X11 or Wayland | `dbus_screensaver` |
+| LXDE, XFCE, MATE, Cinnamon, i3, Openbox on X11 | `x11_mit_screensaver` |
+| wlroots compositors (Sway, Hyprland, niri, river, Wayfire) | not covered; would need `ext-idle-notify-v1` (Wayland protocol, not yet implemented) |
+| COSMIC (System76) | not covered; same as wlroots |
+
+In practice this covers the overwhelming majority of Linux desktop users.
+The uncovered tier is power-user wlroots compositors and emerging
+desktops; see [Known Gaps](#known-gaps).
+
+---
+
+## Backend Probe Order (Linux)
+
+`LinuxIdleQuery._initialize()` in `taskcoachlib/powermgt/idle.py` runs
+lazily on the first `getIdleSeconds()` call. It probes:
+
+1. `dbus_mutter` - attempts a real `GetIdletime()` call. Caches the
+   interface on success.
+2. `dbus_screensaver` - attempts a real `GetSessionIdleTime()` call.
+   Caches the interface on success.
+3. `x11_mit_screensaver` - opens `DISPLAY`, checks for the
+   `MIT-SCREEN-SAVER` extension via `XQueryExtension`, then allocates
+   the screensaver info struct.
+
+Each attempt records `(method_name, success, detail)` in
+`self._probe_log`. The first success wins; later methods are not
+probed. The selected method is exposed via `get_backend_name()`.
+
+The probe is triggered explicitly at startup by `IdleController`
+when the feature is enabled, so subsequent runtime calls hit the
+already-selected backend with no extra cost.
+
+---
+
+## Setting
+
+| Setting | Section | Default | Units | Effect |
+|---------|---------|---------|-------|--------|
+| `minidletime` | `feature` | `0` | minutes | Threshold for going idle. `0` disables the feature. |
+
+Defined in `taskcoachlib/config/defaults.py` (section `feature`).
+Editable in Preferences > Features as "Idle time notice".
+
+`IdleController.get_min_idle_time()` returns the value times 60
+(seconds) and is consulted on every state-machine tick.
+
+---
+
+## Wake-From-Idle Dialog
+
+When the user returns from an idle period during effort tracking, a
+`WakeFromIdleFrame` notification is shown for each tracked effort.
+It carries three buttons:
+
+| Button | Action |
+|--------|--------|
+| Do nothing | Keep the effort running across the idle gap. |
+| Stop it at *idle-time* | Back-date the effort's stop time to when the user went idle. |
+| Stop it at *idle-time* and resume now | Same as above, plus start a fresh effort on the same task starting now. |
+
+The dialog is rendered via `NotificationCenter().notify_frame(...)`.
+Multiple tracked efforts each get their own dialog; a `_displayed`
+set on the controller prevents duplicate dialogs for the same effort.
+
+---
+
+## State Machine
+
+`IdleNotifier` in `taskcoachlib/powermgt/idle.py` runs on `wx.EVT_IDLE`.
+
+```
+       (no efforts tracked)
+              |
+              v
+        +-----------+   tracking starts    +-----------+
+        | unbound   | -------------------> | AWAKE     |
+        +-----------+                      +-----------+
+              ^                              |       ^
+              | tracking stops               |       |
+              |                              v       |
+              |                          (idle >= threshold)
+              |                              |       |
+              |                              v       |
+              |                          +-----------+
+              |                          | SLEEPING  |
+              |                          +-----------+
+                                             |
+                                  (user returns: idle < threshold)
+                                  -> wake(goneToSleep) fires
+```
+
+- The handler is **bound only while at least one effort is tracked**.
+  `IdleController.__onTrackedChanged` calls `resume()` / `pause()` on
+  the underlying `IdleNotifier`.
+- `lastActivity` is recomputed on every EVT_IDLE tick as
+  `time.time() - getIdleSeconds()`.
+- `goneToSleep` is captured when the threshold is first crossed and
+  passed to `wake()` so the dialog shows when the user actually
+  stopped being active.
+
+---
+
+## Startup Logging
+
+When the feature is enabled (`minidletime > 0`), `IdleController` logs a
+one-shot summary at startup using the standard `log_step` utility with
+prefix `[IDLE]`. The log proves which backend was selected and that a
+real query returned a sensible value. No additional logging is emitted
+during normal operation (state transitions, dialog button choices),
+since the startup probe has already verified the path works.
+
+Example output on a Debian LXDE/X11 box:
+
+```
+[22:50:43.277] [IDLE] Idle time notice enabled; threshold=4 min (240s)
+[22:50:43.277] [IDLE] Probing idle backend on linux...
+[22:50:43.287] [IDLE]   dbus_mutter: unavailable (DBusException: org.freedesktop.DBus.Error.ServiceUnknown: The name org.gnome.Mutter.IdleMonitor was not provided by any .service files)
+[22:50:43.287] [IDLE]   dbus_screensaver: unavailable (DBusException: org.freedesktop.DBus.Error.UnknownMethod: Unknown method GetSessionIdleTime or interface org.freedesktop.ScreenSaver.)
+[22:50:43.287] [IDLE]   x11_mit_screensaver: OK
+[22:50:43.287] [IDLE] Selected backend: x11_mit_screensaver
+[22:50:43.287] [IDLE] Test query returned idle=0.01s
+```
+
+Example output when the feature is disabled:
+
+```
+(no [IDLE] lines)
+```
+
+Example output when no backend is available (e.g. a wlroots Wayland
+session today):
+
+```
+[HH:MM:SS.xxx] [IDLE] Idle time notice enabled; threshold=4 min (240s)
+[HH:MM:SS.xxx] [IDLE] Probing idle backend on linux...
+[HH:MM:SS.xxx] [IDLE]   dbus_mutter: unavailable (...)
+[HH:MM:SS.xxx] [IDLE]   dbus_screensaver: unavailable (...)
+[HH:MM:SS.xxx] [IDLE]   x11_mit_screensaver: unavailable (MIT-SCREEN-SAVER extension not present)
+[HH:MM:SS.xxx] [IDLE] WARNING: no backend available; idle-time notice will not function
+```
+
+The block appears during `MainWindow` construction, near the `[TRAY]`
+block (it currently logs just before `[TRAY]` because the controller
+is instantiated before the taskbar icon).
+
+---
+
+## Known Gaps
+
+### Wayland compositors without DBus idle services
+
+wlroots-based compositors (Sway, Hyprland, niri, river, Wayfire) and
+COSMIC do not implement `org.gnome.Mutter.IdleMonitor` or
+`org.freedesktop.ScreenSaver.GetSessionIdleTime`, and there is no
+X11 MIT-SCREEN-SAVER on a pure Wayland session. On these compositors
+the feature silently disables itself.
+
+The modern cross-compositor solution is the
+[`ext-idle-notify-v1`](https://wayland.app/protocols/ext-idle-notify-v1)
+Wayland staging protocol. KDE KWin supports it (Plasma 5.27+), as do
+most recent wlroots versions and COSMIC. GNOME Mutter does not, as of
+early 2026, but Mutter users are already covered by `dbus_mutter`.
+
+Adding an `ext_idle_notification_v1` probe between `dbus_screensaver`
+and `x11_mit_screensaver` (likely via `pywayland`) would close this
+gap. Not yet implemented.
+
+### Setting changes during a session
+
+The startup probe runs once at `IdleController.__init__`. If the user
+toggles `minidletime` from `0` to non-zero (or vice versa) at runtime
+via Preferences, the probe is not re-run. The feature still functions
+because `get_min_idle_time()` is consulted on every tick; only the
+startup log is missing. Not currently considered a bug; a restart
+re-runs the probe.
+
+---
+
+## File Reference
+
+| File | Role |
+|------|------|
+| `taskcoachlib/powermgt/idle.py` | `IdleQuery` per platform (`LinuxIdleQuery`, `WindowsIdleQuery`, `MacIdleQuery`), plus the cross-platform `IdleNotifier` state machine. |
+| `taskcoachlib/powermgt/__init__.py` | Imports the right `IdleNotifier` per platform. |
+| `taskcoachlib/gui/idlecontroller.py` | `IdleController` (subscribes to the effort tracker, forwards wake events to the dialog) and `WakeFromIdleFrame` (the notification UI). |
+| `taskcoachlib/gui/mainwindow.py` | Instantiates `IdleController` during `MainWindow.__init__`. |
+| `taskcoachlib/gui/dialog/preferences.py` | Adds the "Idle time notice" integer field to the Features tab. |
+| `taskcoachlib/config/defaults.py` | Declares `feature.minidletime = 0`. |
+| `taskcoachlib/meta/debug.py` | `log_step(*args, prefix="IDLE")` writer used for startup output. |
+
+---
+
+## See Also
+
+- [LOGGING_GUIDE.md](LOGGING_GUIDE.md) - general logging conventions and prefix list.
+- [AUI_WAYLAND_ISSUES.md](AUI_WAYLAND_ISSUES.md) - other Wayland-related platform notes.

--- a/taskcoachlib/gui/idlecontroller.py
+++ b/taskcoachlib/gui/idlecontroller.py
@@ -16,12 +16,15 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+import sys
+
 from taskcoachlib.command import (
     NewEffortCommand,
     EditEffortStopDateTimeCommand,
 )
 from taskcoachlib.domain import effort, date
 from taskcoachlib.i18n import _
+from taskcoachlib.meta.debug import log_step
 from taskcoachlib.notify import NotificationFrameBase, NotificationCenter
 from taskcoachlib.patterns import Observer
 from taskcoachlib.powermgt import IdleNotifier
@@ -32,15 +35,15 @@ import wx
 
 
 class WakeFromIdleFrame(NotificationFrameBase):
-    def __init__(self, idleTime, effort, displayedEfforts, *args, **kwargs):
-        self._idleTime = idleTime
+    def __init__(self, idle_time, effort, displayed_efforts, *args, **kwargs):
+        self._idle_time = idle_time
         self._effort = effort
-        self._displayed = displayedEfforts
-        self._lastActivity = 0
+        self._displayed = displayed_efforts
+        self._last_activity = 0
         super().__init__(*args, **kwargs)
 
     def add_inner_content(self, sizer, panel):
-        idleTimeFormatted = render.dateTime(self._idleTime)
+        idle_time_formatted = render.dateTime(self._idle_time)
         sizer.Add(
             wx.StaticText(
                 panel,
@@ -48,70 +51,115 @@ class WakeFromIdleFrame(NotificationFrameBase):
                 _(
                     "No user input since %s. The following task was\nbeing tracked:"
                 )
-                % idleTimeFormatted,
+                % idle_time_formatted,
             )
         )
         sizer.Add(
             wx.StaticText(panel, wx.ID_ANY, self._effort.task().subject())
         )
 
-        btnNothing = wx.Button(panel, wx.ID_ANY, _("Do nothing"))
-        btnStopAt = wx.Button(
-            panel, wx.ID_ANY, _("Stop it at %s") % idleTimeFormatted
+        btn_nothing = wx.Button(panel, wx.ID_ANY, _("Do nothing"))
+        btn_stop_at = wx.Button(
+            panel, wx.ID_ANY, _("Stop it at %s") % idle_time_formatted
         )
-        btnStopResume = wx.Button(
+        btn_stop_resume = wx.Button(
             panel,
             wx.ID_ANY,
-            _("Stop it at %s and resume now") % idleTimeFormatted,
+            _("Stop it at %s and resume now") % idle_time_formatted,
         )
 
-        sizer.Add(btnNothing, 0, wx.EXPAND | wx.ALL, 1)
-        sizer.Add(btnStopAt, 0, wx.EXPAND | wx.ALL, 1)
-        sizer.Add(btnStopResume, 0, wx.EXPAND | wx.ALL, 1)
+        sizer.Add(btn_nothing, 0, wx.EXPAND | wx.ALL, 1)
+        sizer.Add(btn_stop_at, 0, wx.EXPAND | wx.ALL, 1)
+        sizer.Add(btn_stop_resume, 0, wx.EXPAND | wx.ALL, 1)
 
-        btnNothing.Bind(wx.EVT_BUTTON, self.DoNothing)
-        btnStopAt.Bind(wx.EVT_BUTTON, self.DoStopAt)
-        btnStopResume.Bind(wx.EVT_BUTTON, self.DoStopResume)
+        btn_nothing.Bind(wx.EVT_BUTTON, self.do_nothing)
+        btn_stop_at.Bind(wx.EVT_BUTTON, self.do_stop_at)
+        btn_stop_resume.Bind(wx.EVT_BUTTON, self.do_stop_resume)
 
     def close_button(self, panel):
         return None
 
-    def DoNothing(self, event):
+    def do_nothing(self, event):
         self._displayed.remove(self._effort)
         self.do_close()
 
-    def DoStopAt(self, event):
+    def do_stop_at(self, event):
         self._displayed.remove(self._effort)
         EditEffortStopDateTimeCommand(
-            newValue=self._idleTime, items=[self._effort]
+            newValue=self._idle_time, items=[self._effort]
         ).do()
         self.do_close()
 
-    def DoStopResume(self, event):
+    def do_stop_resume(self, event):
         self._displayed.remove(self._effort)
         EditEffortStopDateTimeCommand(
-            newValue=self._idleTime, items=[self._effort]
+            newValue=self._idle_time, items=[self._effort]
         ).do()
         NewEffortCommand(items=[self._effort.task()]).do()
         self.do_close()
 
 
 class IdleController(Observer, IdleNotifier):
-    def __init__(self, mainWindow, settings, effortList):
-        self._mainWindow = mainWindow
+    def __init__(self, main_window, settings, effort_list):
+        self._main_window = main_window
         self._settings = settings
-        self._effortList = effortList
+        self._effort_list = effort_list
         self._displayed = set()
 
         super().__init__()
 
-        self.__tracker = effort.EffortListTracker(self._effortList)
-        self.__tracker.subscribe(self.__onTrackedChanged, "effortlisttracker")
+        self._tracker = effort.EffortListTracker(self._effort_list)
+        self._tracker.subscribe(self._on_tracked_changed, "effortlisttracker")
 
         pub.subscribe(self.poweroff, "powermgt.off")
         pub.subscribe(self.poweron, "powermgt.on")
 
-    def __onTrackedChanged(self, efforts):
+        self._log_backend_if_enabled()
+
+    def _log_backend_if_enabled(self):
+        """Probe and report the idle-detection backend at startup.
+
+        Runs only when the feature is enabled (minidletime > 0). Calling
+        get_idle_seconds() also forces lazy backend selection on Linux, so
+        no separate runtime logging is needed when the dialog later fires.
+        """
+        min_time_sec = self.get_min_idle_time()
+        if min_time_sec <= 0:
+            return
+
+        log_step(
+            "Idle time notice enabled; threshold=%d min (%ds)"
+            % (min_time_sec // 60, min_time_sec),
+            prefix="IDLE",
+        )
+        log_step("Probing idle backend on %s..." % sys.platform, prefix="IDLE")
+
+        try:
+            idle_seconds = self.get_idle_seconds()
+        except Exception as e:
+            log_step("ERROR: probe raised %r" % e, prefix="IDLE")
+            return
+
+        for name, ok, detail in self.get_probe_log():
+            status = "OK" if ok else "unavailable"
+            suffix = " (%s)" % detail if detail else ""
+            log_step("  %s: %s%s" % (name, status, suffix), prefix="IDLE")
+
+        backend = self.get_backend_name()
+        if backend:
+            log_step("Selected backend: %s" % backend, prefix="IDLE")
+            log_step(
+                "Test query returned idle=%.2fs" % idle_seconds,
+                prefix="IDLE",
+            )
+        else:
+            log_step(
+                "WARNING: no backend available; "
+                "idle-time notice will not function",
+                prefix="IDLE",
+            )
+
+    def _on_tracked_changed(self, efforts):
         if len(efforts):
             self.resume()
         else:
@@ -121,15 +169,15 @@ class IdleController(Observer, IdleNotifier):
         return self._settings.getint("feature", "minidletime") * 60
 
     def wake(self, timestamp):
-        self._lastActivity = timestamp
-        self.OnWake()
+        self._last_activity = timestamp
+        self._on_wake()
 
-    def OnWake(self):
-        for effort in self.__tracker.trackedEfforts():
+    def _on_wake(self):
+        for effort in self._tracker.trackedEfforts():
             if effort not in self._displayed:
                 self._displayed.add(effort)
                 frm = WakeFromIdleFrame(
-                    date.DateTime.fromtimestamp(self._lastActivity),
+                    date.DateTime.fromtimestamp(self._last_activity),
                     effort,
                     self._displayed,
                     _("Notification"),

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -41,11 +41,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # =============================================================================
 
 version = "2.0.2"  # Major.Minor.Milestone
-patch = "11"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.2.11
+patch = "12"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.2.12
 
 release_day = "13"  # Day of the release (1-31)
-release_month = "April"  # Month of the release
+release_month = "May"  # Month of the release
 release_year = "2026"  # Year of the release
 
 # =============================================================================

--- a/taskcoachlib/powermgt/idle.py
+++ b/taskcoachlib/powermgt/idle.py
@@ -38,6 +38,20 @@ from taskcoachlib import operating_system
 
 
 # ==============================================================================
+
+
+def _summarize_exception(exc):
+    """Compact one-line description of an exception for probe logs."""
+    try:
+        msg = str(exc)
+    except Exception:
+        msg = ""
+    if msg:
+        return "%s: %s" % (type(exc).__name__, msg.splitlines()[0][:160])
+    return type(exc).__name__
+
+
+# ==============================================================================
 # Linux/BSD
 
 if operating_system.isGTK():
@@ -67,14 +81,16 @@ if operating_system.isGTK():
 
         def __init__(self):
             self._initialized = False
-            self._method = None  # 'dbus_mutter', 'dbus_screensaver', 'x11', or None
+            # 'dbus_mutter', 'dbus_screensaver', 'x11_mit_screensaver', or None
+            self._method = None
             self._warned = False
+            self._probe_log = []  # list of (name, ok, detail)
             self.dpy = None
             self._dbus_proxy = None
             self._dbus_iface = None
 
         def _try_dbus_mutter(self):
-            """Try GNOME Mutter IdleMonitor via DBus."""
+            """Try GNOME Mutter IdleMonitor via DBus. Returns (ok, detail)."""
             try:
                 import dbus
                 bus = dbus.SessionBus()
@@ -87,12 +103,15 @@ if operating_system.isGTK():
                 iface.GetIdletime()
                 self._dbus_proxy = proxy
                 self._dbus_iface = iface
-                return True
-            except Exception:
-                return False
+                return True, None
+            except Exception as e:
+                return False, _summarize_exception(e)
 
         def _try_dbus_screensaver(self):
-            """Try freedesktop ScreenSaver via DBus (KDE)."""
+            """Try freedesktop ScreenSaver via DBus (KDE).
+
+            Returns (ok, detail).
+            """
             try:
                 import dbus
                 bus = dbus.SessionBus()
@@ -105,12 +124,12 @@ if operating_system.isGTK():
                 iface.GetSessionIdleTime()
                 self._dbus_proxy = proxy
                 self._dbus_iface = iface
-                return True
-            except Exception:
-                return False
+                return True, None
+            except Exception as e:
+                return False, _summarize_exception(e)
 
         def _try_x11_screensaver(self):
-            """Try X11 MIT-SCREEN-SAVER extension."""
+            """Try X11 MIT-SCREEN-SAVER extension. Returns (ok, detail)."""
             try:
                 _x11 = CDLL("libX11.so.6")
 
@@ -131,7 +150,7 @@ if operating_system.isGTK():
 
                 self.dpy = self.XOpenDisplay(None)
                 if not self.dpy:
-                    return False
+                    return False, "XOpenDisplay failed (no DISPLAY?)"
 
                 # Check if MIT-SCREEN-SAVER extension is available
                 major_opcode = c_int()
@@ -146,7 +165,7 @@ if operating_system.isGTK():
                 )
 
                 if not has_extension:
-                    return False
+                    return False, "MIT-SCREEN-SAVER extension not present"
 
                 _xss = CDLL("libXss.so.1")
 
@@ -158,10 +177,10 @@ if operating_system.isGTK():
                 )(("XScreenSaverQueryInfo", _xss))
 
                 self.info = self.XScreenSaverAllocInfo()
-                return True
+                return True, None
 
-            except OSError:
-                return False
+            except OSError as e:
+                return False, _summarize_exception(e)
 
         def _initialize(self):
             """Lazy initialization - try available methods in order."""
@@ -169,21 +188,38 @@ if operating_system.isGTK():
                 return
             self._initialized = True
 
-            # Try methods in order of preference
-            if self._try_dbus_mutter():
+            # Try methods in order of preference; record outcome of each.
+            ok, detail = self._try_dbus_mutter()
+            self._probe_log.append(('dbus_mutter', ok, detail))
+            if ok:
                 self._method = 'dbus_mutter'
-            elif self._try_dbus_screensaver():
+                return
+
+            ok, detail = self._try_dbus_screensaver()
+            self._probe_log.append(('dbus_screensaver', ok, detail))
+            if ok:
                 self._method = 'dbus_screensaver'
-            elif self._try_x11_screensaver():
-                self._method = 'x11'
-            else:
-                self._method = None
+                return
+
+            ok, detail = self._try_x11_screensaver()
+            self._probe_log.append(('x11_mit_screensaver', ok, detail))
+            if ok:
+                self._method = 'x11_mit_screensaver'
+                return
+
+            self._method = None
+
+        def get_backend_name(self):
+            return self._method
+
+        def get_probe_log(self):
+            return list(self._probe_log)
 
         def __del__(self):
             if self.dpy and hasattr(self, 'XCloseDisplay'):
                 self.XCloseDisplay(self.dpy)
 
-        def getIdleSeconds(self):
+        def get_idle_seconds(self):
             self._initialize()
 
             if self._method == 'dbus_mutter':
@@ -198,7 +234,7 @@ if operating_system.isGTK():
                     return self._dbus_iface.GetSessionIdleTime()
                 except Exception:
                     pass
-            elif self._method == 'x11':
+            elif self._method == 'x11_mit_screensaver':
                 self.XScreenSaverQueryInfo(
                     self.dpy, self.XRootWindow(self.dpy, 0), self.info
                 )
@@ -229,9 +265,15 @@ elif operating_system.isWindows():
             self.lastInputInfo = LASTINPUTINFO()
             self.lastInputInfo.cbSize = sizeof(self.lastInputInfo)
 
-        def getIdleSeconds(self):
+        def get_idle_seconds(self):
             self.GetLastInputInfo(byref(self.lastInputInfo))
             return (self.GetTickCount() - self.lastInputInfo.dwTime) / 1000
+
+        def get_backend_name(self):
+            return 'win32_GetLastInputInfo'
+
+        def get_probe_log(self):
+            return [('win32_GetLastInputInfo', True, None)]
 
     IdleQuery = WindowsIdleQuery
 
@@ -250,6 +292,7 @@ elif operating_system.isMac():
 
         def __init__(self):
             self._warned = False
+            self._init_error = None
             try:
                 # Load IOKit and CoreFoundation frameworks
                 self._iokit = cdll.LoadLibrary(
@@ -291,8 +334,9 @@ elif operating_system.isMac():
 
                 self._available = True
 
-            except OSError:
+            except OSError as e:
                 self._available = False
+                self._init_error = _summarize_exception(e)
 
         def __del__(self):
             if hasattr(self, '_idle_key') and self._idle_key:
@@ -301,7 +345,7 @@ elif operating_system.isMac():
                 except Exception:
                     pass
 
-        def getIdleSeconds(self):
+        def get_idle_seconds(self):
             if not self._available:
                 if not self._warned:
                     self._warned = True
@@ -347,6 +391,12 @@ elif operating_system.isMac():
             except Exception:
                 return 0
 
+        def get_backend_name(self):
+            return 'iokit_HIDIdleTime' if self._available else None
+
+        def get_probe_log(self):
+            return [('iokit_HIDIdleTime', self._available, self._init_error)]
+
     IdleQuery = MacIdleQuery
 
 
@@ -363,44 +413,44 @@ class IdleNotifier(wx.EvtHandler, IdleQuery):
         IdleQuery.__init__(self)
 
         self.state = self.STATE_AWAKE
-        self.lastActivity = time.time()
-        self.goneToSleep = None
+        self._last_activity = time.time()
+        self._gone_to_sleep = None
 
         self._bound = True
-        wx.GetApp().Bind(wx.EVT_IDLE, self._OnIdle)
+        wx.GetApp().Bind(wx.EVT_IDLE, self._on_idle)
 
     def stop(self):
         self.pause()
 
     def pause(self):
         if self._bound:
-            wx.GetApp().Unbind(wx.EVT_IDLE, handler=self._OnIdle)
+            wx.GetApp().Unbind(wx.EVT_IDLE, handler=self._on_idle)
             self._bound = False
 
     def resume(self):
         self.state = self.STATE_AWAKE
-        self.lastActivity = time.time()
+        self._last_activity = time.time()
         if not self._bound:
-            wx.GetApp().Bind(wx.EVT_IDLE, self._OnIdle)
+            wx.GetApp().Bind(wx.EVT_IDLE, self._on_idle)
 
     def _check(self):
         if (
             self.state == self.STATE_AWAKE
-            and time.time() - self.lastActivity >= self.get_min_idle_time()
+            and time.time() - self._last_activity >= self.get_min_idle_time()
         ):
-            self.goneToSleep = self.lastActivity
+            self._gone_to_sleep = self._last_activity
             self.state = self.STATE_SLEEPING
             self.sleep()
         elif (
             self.state == self.STATE_SLEEPING
-            and time.time() - self.lastActivity < self.get_min_idle_time()
+            and time.time() - self._last_activity < self.get_min_idle_time()
         ):
             self.state = self.STATE_AWAKE
-            self.wake(self.goneToSleep)
+            self.wake(self._gone_to_sleep)
 
-    def _OnIdle(self, event):
+    def _on_idle(self, event):
         self._check()
-        self.lastActivity = time.time() - self.getIdleSeconds()
+        self._last_activity = time.time() - self.get_idle_seconds()
         self._check()
         event.Skip()
 
@@ -409,7 +459,7 @@ class IdleNotifier(wx.EvtHandler, IdleQuery):
         Call this when the computer goes to sleep.
         """
         if self._bound:
-            wx.GetApp().Unbind(wx.EVT_IDLE, handler=self._OnIdle)
+            wx.GetApp().Unbind(wx.EVT_IDLE, handler=self._on_idle)
             self._bound = False
 
     def poweron(self):
@@ -417,10 +467,10 @@ class IdleNotifier(wx.EvtHandler, IdleQuery):
         Call this when the computer resumes from sleep.
         """
         if not self._bound:
-            wx.GetApp().Bind(wx.EVT_IDLE, self._OnIdle)
+            wx.GetApp().Bind(wx.EVT_IDLE, self._on_idle)
             self._bound = True
         self._check()
-        self.lastActivity = time.time() - self.getIdleSeconds()
+        self._last_activity = time.time() - self.get_idle_seconds()
         self._check()
 
     def get_min_idle_time(self):


### PR DESCRIPTION
- Add [IDLE] startup log block in IdleController when minidletime > 0: probes the platform backend, lists per-method outcomes (Linux), and prints the selected backend plus a test idle-seconds value. No runtime state-transition logging, since the startup probe pretests the path.
- New docs/IDLE.md covering platform support matrix, probe order, the setting, the wake-from-idle dialog, state machine, startup-log examples, and known gaps (wlroots/COSMIC need ext-idle-notify-v1).
- PEP 8 renames in taskcoachlib/powermgt/idle.py and taskcoachlib/gui/idlecontroller.py: getIdleSeconds -> get_idle_seconds, _OnIdle -> _on_idle, lastActivity -> _last_activity, goneToSleep -> _gone_to_sleep, mainWindow/effortList/__tracker/__onTrackedChanged/ OnWake/DoNothing/DoStopAt/DoStopResume/idleTime/displayedEfforts and related locals/attrs all converted. No dead camelCase overrides (base class methods are already snake_case). ctypes function pointers and C struct fields keep their vendor names by convention.
- Bump version to 2.0.2.12 (May 13, 2026) in meta/data.py and README.md.
- Update VERSION reference: debian/changelog and the fedora spec Version: line are rewritten by CI (build-deb.yml, build-rpm.yml), so they no longer need manual bumps for a release.

Idle time detection unavailable on this system. The idle time notification feature will be disabled. #26