### PR TITLE
Fix Wayland system tray: missing typelib, Hide() not Iconize()

### DIFF
--- a/setup_debian12_bookworm.sh
+++ b/setup_debian12_bookworm.sh
@@ -76,7 +76,8 @@ if command -v sudo &> /dev/null; then
         python3-pyparsing \
         python3-pyxdg \
         python3-venv \
-        python3-squaremap
+        python3-squaremap \
+        gir1.2-ayatanaappindicator3-0.1
     echo -e "${GREEN}✓ System packages installed${NC}"
 else
     echo -e "${YELLOW}⚠ sudo not available, please install packages manually${NC}"

--- a/setup_debian13_trixie.sh
+++ b/setup_debian13_trixie.sh
@@ -88,7 +88,8 @@ if command -v sudo &> /dev/null; then
         python3-fasteners \
         python3-watchdog \
         python3-pubsub \
-        python3-squaremap
+        python3-squaremap \
+        gir1.2-ayatanaappindicator3-0.1
     echo -e "${GREEN}✓ System packages installed${NC}"
 else
     echo -e "${YELLOW}⚠ sudo not available, please install packages manually${NC}"

--- a/setup_ubuntu2204_jammy.sh
+++ b/setup_ubuntu2204_jammy.sh
@@ -76,7 +76,8 @@ if command -v sudo &> /dev/null; then
         python3-pyparsing \
         python3-xdg \
         python3-venv \
-        python3-squaremap
+        python3-squaremap \
+        gir1.2-ayatanaappindicator3-0.1
     echo -e "${GREEN}✓ System packages installed${NC}"
 else
     echo -e "${YELLOW}⚠ sudo not available, please install packages manually${NC}"

--- a/setup_ubuntu2404_noble.sh
+++ b/setup_ubuntu2404_noble.sh
@@ -80,7 +80,8 @@ if command -v sudo &> /dev/null; then
         python3-fasteners \
         python3-watchdog \
         python3-pubsub \
-        python3-squaremap
+        python3-squaremap \
+        gir1.2-ayatanaappindicator3-0.1
     echo -e "${GREEN}✓ System packages installed${NC}"
 else
     echo -e "${YELLOW}⚠ sudo not available, please install packages manually${NC}"

--- a/taskcoachlib/gui/mainwindow.py
+++ b/taskcoachlib/gui/mainwindow.py
@@ -328,6 +328,11 @@ If this happens again, please make a copy of your TaskCoach.ini file """
         ):
             event.Veto()
             self.Iconize()
+            if self.settings.getboolean("window", "hidewheniconized"):
+                # Wayland: GTK3 doesn't fire EVT_ICONIZE with IsIconized()==True,
+                # so the onIconify → Hide() chain never runs. Call Hide() directly
+                # so close-to-tray actually leaves no taskbar entry. Idempotent on X11.
+                self.Hide()
         else:
             if application.Application().quitApplication():
                 # UnInit AUI manager before window destruction to avoid

--- a/taskcoachlib/gui/taskbaricon.py
+++ b/taskcoachlib/gui/taskbaricon.py
@@ -428,7 +428,12 @@ class AppIndicatorTaskBarIcon(patterns.Observer):
            True because GTK3's Wayland backend never sets
            GDK_WINDOW_STATE_ICONIFIED).  restore() is all no-ops, so
            force a surface remap via Hide()+Show().
-        3. else — window is visible and active, minimize it.
+        3. else — window is visible, hide it.
+
+        We call Hide() rather than Iconize() because the menu label is
+        "Hide", and because Iconize() on Wayland only reaches the taskbar
+        (the EVT_ICONIZE → onIconify → Hide() chain in mainwindow.py is
+        broken on Wayland — GTK3 never sets IsIconized()==True).
         """
         if self.__window.IsIconized() or not self.__window.IsShown():
             # X11: wx knows the window state → normal restore
@@ -439,7 +444,7 @@ class AppIndicatorTaskBarIcon(patterns.Observer):
             self.__window.Hide()
             self.__window.Show()
         else:
-            self.__window.Iconize()
+            self.__window.Hide()
 
     # Menu:
 


### PR DESCRIPTION
Like that hidding works on wayland and plasma kde. Shouldn't have an impact on others.
If it's easier for you, i can leave the dependency for the distros away....

- Setup scripts: add gir1.2-ayatanaappindicator3-0.1. Without it, AppIndicator silently fails to load on Wayland → no tray icon.

- taskbaricon.py / mainwindow.py: call Hide() directly. GTK3 Wayland never sets IsIconized()==True, so the Iconize → EVT_ICONIZE → onIconify → Hide() chain never fires. Idempotent elsewhere.