### PR TITLE
Restore decimal effort time display option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.12-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.12-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.12_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.12_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.12_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.12-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.15-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.15-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.15_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.15_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.15_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.15-fedora43.rpm` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.12-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.12-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.12_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.12_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.2.12-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.2.12-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.15-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.15-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.15_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.15_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.2.15-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.2.15-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +42,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.12_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.2.12_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.15_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.2.15_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +56,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.12-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.2.12-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.15-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.2.15-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +70,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.12-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.2.12-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.15-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.2.15-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,13 +86,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.12-x86_64.AppImage
-chmod +x TaskCoach-2.0.2.12-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.15-x86_64.AppImage
+chmod +x TaskCoach-2.0.2.15-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.2.12-x86_64.AppImage
+./TaskCoach-2.0.2.15-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.

--- a/README_INSTALL_MACOS.md
+++ b/README_INSTALL_MACOS.md
@@ -17,7 +17,7 @@ Download the DMG for your Mac from the [latest release](https://github.com/taskc
 - **Apple Silicon** (M1/M2/M3/M4): `TaskCoach-<version>-macos-arm64.dmg`
 - **Intel**: `TaskCoach-<version>-macos-intel.dmg`
 
-Where `<version>` is the release version (e.g., `2.0.2.11`).
+Where `<version>` is the release version (e.g., `2.0.2.15`).
 
 Not sure which Mac you have? Click the Apple menu → "About This Mac". Look for "Chip" (Apple Silicon) or "Processor" (Intel).
 

--- a/README_INSTALL_WINDOWS.md
+++ b/README_INSTALL_WINDOWS.md
@@ -19,7 +19,7 @@ Download the installer from the [latest release](https://github.com/taskcoach/ta
 - **Installer**: `TaskCoach-<version>-windows-x64-setup.exe` - Standard installation
 - **Portable**: `TaskCoach-<version>-windows-x64-portable.zip` - No installation required
 
-Where `<version>` is the release version (e.g., `2.0.2.11`).
+Where `<version>` is the release version (e.g., `2.0.2.15`).
 
 ## <a id="security-warning"></a>Security Warning
 

--- a/taskcoachlib/config/defaults.py
+++ b/taskcoachlib/config/defaults.py
@@ -628,6 +628,7 @@ defaults = {
         "task_duration_presets": "60,120,1440,2880",  # Minutes: 1h, 2h, 1 day, 2 days
         "effort_duration_presets": "300,900,1800,3600,7200",  # Seconds: 5m, 15m, 30m, 1h, 2h
         # New settings should use snake_case naming convention (PEP 8)
+        "decimal_time": "False",  # Render effort as decimal hours (1.25) instead of 1:15
     },
     "printer": {
         "margin_left": "0",

--- a/taskcoachlib/config/settings2.py
+++ b/taskcoachlib/config/settings2.py
@@ -29,6 +29,7 @@ _LEGACY_DEBOUNCE_MS = 1000
 
 # Sections monitored by the shim — add entries as code is migrated.
 _SETTING_SECTIONS = {
+    "feature",
     "icon",
     "iconpicker",
     "view",
@@ -38,6 +39,7 @@ _SETTING_SECTIONS = {
 # Explicit type map — add entries as code is migrated to use this shim.
 # Settings not listed here are returned as raw strings.
 _TYPES_MAP = {
+    ("feature", "decimal_time"): bool,
     ("view", "descriptionpopups"): bool,
     ("window", "hoverlinewidth"): int,
     ("icon", "legacystatusicons"): bool,

--- a/taskcoachlib/gui/dialog/preferences.py
+++ b/taskcoachlib/gui/dialog/preferences.py
@@ -2236,6 +2236,15 @@ class FeaturesPage(SettingsPage):
             % meta.data.metaDict,
         )
         self.addBooleanSetting(
+            "feature",
+            "decimal_time",
+            _("Use decimal times for effort entries"),
+            _(
+                "Display one hour, fifteen minutes as 1.25 instead of 1:15. "
+                "This is useful when creating invoices."
+            ),
+        )
+        self.addBooleanSetting(
             "view",
             "descriptionpopups",
             _("Hoverover popups"),

--- a/taskcoachlib/gui/viewer/effort.py
+++ b/taskcoachlib/gui/viewer/effort.py
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from taskcoachlib import command, patterns, widgets, domain, render
+from taskcoachlib.config import settings2
 from taskcoachlib.domain import effort, date
 from taskcoachlib.domain.base import filter  # pylint: disable=W0622
 from taskcoachlib.gui import uicommand, dialog
@@ -666,13 +667,16 @@ class EffortViewer(
         for effort in efforts:
             td = td + effort.timeSpent()
 
-        sumTimeSpent = render.timeSpent(
+        sumTimeSpent = render.time_spent(
             td,
-            showSeconds=self.__show_seconds(),
+            show_seconds=self.__show_seconds(),
+            decimal=settings2.feature.decimal_time,
         )
 
         if sumTimeSpent == "":
-            if self.__show_seconds():
+            if settings2.feature.decimal_time:
+                sumTimeSpent = "0.0"
+            elif self.__show_seconds():
                 sumTimeSpent = "0:00:00"
             else:
                 sumTimeSpent = "0:00"
@@ -781,9 +785,10 @@ class EffortViewer(
             showSeconds = self.__show_seconds()
         else:
             showSeconds = True
-        return render.timeSpent(
+        return render.time_spent(
             timeSpent,
-            showSeconds=showSeconds,
+            show_seconds=showSeconds,
+            decimal=settings2.feature.decimal_time,
         )
 
     def __renderTotalTimeSpent(self, anEffort):
@@ -794,9 +799,10 @@ class EffortViewer(
             roundUp=self.__always_round_up(),
             consolidate=self.__consolidate_efforts_per_task(),
         )
-        return render.timeSpent(
+        return render.time_spent(
             totalTimeSpent,
-            showSeconds=self.__show_seconds(),
+            show_seconds=self.__show_seconds(),
+            decimal=settings2.feature.decimal_time,
         )
 
     def __renderTimeSpentOnDay(self, anEffort, dayOffset):
@@ -812,9 +818,10 @@ class EffortViewer(
             )
         else:
             timeSpent = anEffort.timeSpent()
-        return render.timeSpent(
+        return render.time_spent(
             self.__roundTimeSpent(timeSpent),
-            showSeconds=self.__show_seconds(),
+            show_seconds=self.__show_seconds(),
+            decimal=settings2.feature.decimal_time,
         )
 
     def getItemTooltipData(self, item):

--- a/taskcoachlib/gui/viewer/task.py
+++ b/taskcoachlib/gui/viewer/task.py
@@ -172,7 +172,7 @@ class BaseTaskViewer(
         self.statusMessages = None  # Break cycle
 
     def _renderTimeSpent(self, *args, **kwargs):
-        return render.timeSpent(*args, **kwargs)
+        return render.time_spent(*args, **kwargs)
 
     def onAppearanceSettingChange(self, value):  # pylint: disable=W0613
         if self:

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -44,10 +44,10 @@ import re
 # =============================================================================
 
 version = "2.0.2"  # Major.Minor.Milestone
-patch = "14"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.2.14
+patch = "15"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.2.15
 
-release_day = "16"  # Day of the release (1-31)
+release_day = "17"  # Day of the release (1-31)
 release_month = "May"  # Month of the release
 release_year = "2026"  # Year of the release
 

--- a/taskcoachlib/render.py
+++ b/taskcoachlib/render.py
@@ -58,21 +58,25 @@ def timeLeft(time_left, completed_task):
     return sign + days + hours_and_minutes
 
 
-def timeSpent(
-    timeSpent: datemodule.TimeDelta, showSeconds=True
+def time_spent(
+    time_spent: datemodule.TimeDelta, show_seconds=True, decimal=False
 ):
     """Render time spent (of type date.TimeDelta) as
-    "<hours>:<minutes>:<seconds>" or "<hours>:<minutes>" """
+    "<hours>:<minutes>:<seconds>" or "<hours>:<minutes>", or as
+    "<hours>.<fractional hours>" when decimal is True (e.g. one hour
+    fifteen minutes as "1.25" instead of "1:15", useful for invoices)."""
     zero = datemodule.TimeDelta()
-    if timeSpent == zero:
+    if time_spent == zero:
         return ""
     else:
-        sign = "-" if timeSpent < zero else ""
-        hours, minutes, seconds = timeSpent.hoursMinutesSeconds()
+        sign = "-" if time_spent < zero else ""
+        hours, minutes, seconds = time_spent.hoursMinutesSeconds()
+        if decimal:
+            return sign + "%.2f" % (hours + minutes / 60.0 + seconds / 3600.0)
         return (
             sign
             + "%d:%02d" % (hours, minutes)
-            + (":%02d" % seconds if showSeconds else "")
+            + (":%02d" % seconds if show_seconds else "")
         )
 
 
@@ -119,7 +123,7 @@ def recurrence(recurrence):
 def budget(aBudget):
     """Render budget (of type date.TimeDelta) as
     "<hours>:<minutes>:<seconds>"."""
-    return timeSpent(aBudget)
+    return time_spent(aBudget)
 
 
 # Date/time format constants - computed once at startup.

--- a/tests/unittests/RenderTest.py
+++ b/tests/unittests/RenderTest.py
@@ -142,24 +142,43 @@ class RenderTimeLeftTest(test.TestCase):
 
 class RenderTimeSpentTest(test.TestCase):
     def testZeroTime(self):
-        self.assertEqual("", render.timeSpent(date.TimeDelta()))
+        self.assertEqual("", render.time_spent(date.TimeDelta()))
 
     def testOneSecond(self):
-        self.assertEqual("0:00:01", render.timeSpent(date.ONE_SECOND))
+        self.assertEqual("0:00:01", render.time_spent(date.ONE_SECOND))
 
     def testTenHours(self):
         self.assertEqual(
-            "10:00:00", render.timeSpent(date.TimeDelta(hours=10))
+            "10:00:00", render.time_spent(date.TimeDelta(hours=10))
         )
 
     def testNegativeHours(self):
         self.assertEqual(
-            "-1:00:00", render.timeSpent(date.TimeDelta(hours=-1))
+            "-1:00:00", render.time_spent(date.TimeDelta(hours=-1))
         )
 
     def testNegativeSeconds(self):
         self.assertEqual(
-            "-0:00:01", render.timeSpent(date.TimeDelta(seconds=-1))
+            "-0:00:01", render.time_spent(date.TimeDelta(seconds=-1))
+        )
+
+    def testDecimal(self):
+        self.assertEqual(
+            "0.50",
+            render.time_spent(date.TimeDelta(minutes=30), decimal=True),
+        )
+
+    def testDecimalNul(self):
+        self.assertEqual(
+            "", render.time_spent(date.TimeDelta(hours=0), decimal=True)
+        )
+
+    def testDecimalNegative(self):
+        self.assertEqual(
+            "-1.25",
+            render.time_spent(
+                date.TimeDelta(hours=-1, minutes=-15), decimal=True
+            ),
         )
 
 


### PR DESCRIPTION
Re-add the option to render effort durations as decimal hours (for example 1.25) instead of h:mm:ss (1:15), which is useful when creating invoices. The option existed historically and was removed inadvertently in commit d13db6d6 as part of unrelated UI polish.

The setting is reintroduced using the current configuration strategy documented in docs/SETTINGS.md, not the deprecated pubsub pattern:

- defaults.py defines feature.decimal_time (snake_case, per the PEP 8 naming note in that section).
- settings2.py monitors the feature section and maps feature.decimal_time to bool, so the read-only shim returns a real boolean rather than a truthy string.
- effort.py reads settings2.feature.decimal_time at its four render call sites. No pubsub subscription and no onHourDisplayChanged callback are restored.
- preferences.py adds the checkbox to the Features tab, which is restart-required by that tab's own contract; this replaces the old live-update behaviour.

While touching the render time-spent function for the decimal branch, it is migrated to PEP 8: render.timeSpent becomes render.time_spent and showSeconds becomes show_seconds, with call sites updated in effort.py, task.py and RenderTest.py. Unrelated render code (timeLeft, budget, the module level format constants) is intentionally left unchanged.

Bump version to 2.0.2.15 (release date 17 May 2026): patch and release date in taskcoachlib/meta/data.py (version SSOT), and the hardcoded version strings in README.md, README_INSTALL_MACOS.md and README_INSTALL_WINDOWS.md. The historical "Removed in v2.0.2.10" note in docs/LIST_MANAGEMENT.md is left unchanged. changes.in is stale and not maintained for the 2.0.2.x line.

Tests: RenderTest.py decimal cases restored and updated to the new API. Manually verified in the running app: enabling the option and restarting renders effort durations as decimal hours.