### PR TITLE
Add Flatpak packaging and stop tray-icon log spam

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -184,6 +184,9 @@ jobs:
           # Copy TaskCoach source
           cp -r ${{ github.workspace }}/taskcoachlib usr/share/taskcoach/
           cp ${{ github.workspace }}/taskcoach.py usr/share/taskcoach/
+          # Default "Welcome" document, opened on first run
+          # (settings.pathToSystemWelcomeFile finds it next to taskcoach.py).
+          cp ${{ github.workspace }}/Welcome.tsk usr/share/taskcoach/
 
           # Copy icons
           mkdir -p usr/share/icons/hicolor/256x256/apps

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -1,0 +1,78 @@
+name: Build Flatpak
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - 'claude/**'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-flatpak:
+    name: Build Flatpak
+    runs-on: ubuntu-22.04
+    # The flatpak-github-actions image ships flatpak, flatpak-builder and the
+    # GNOME SDK/runtime, so the multi-GB runtime is not re-downloaded each run.
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50
+      options: --privileged
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          # build.in/flatpak/shared-modules (libappindicator chain) is a submodule.
+          submodules: recursive
+
+      - name: Get version info
+        id: version
+        run: |
+          VERSION=$(python3 -c "import sys; sys.path.insert(0, '.'); from taskcoachlib.meta import data; print(data.version_full)")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+
+      # No source-generation step: the manifest's python modules use
+      # --share=network and pip3 directly, so flatpak-builder fetches wxPython,
+      # wxWidgets and the pure-Python deps itself during the build. (The
+      # offline flatpak-pip-generator path is only needed for a Flathub
+      # submission; see docs/FLATPAK.md.)
+      - name: Build Flatpak bundle
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          # The action appends "-<arch>" to the bundle name itself, so do not
+          # add it here (otherwise the file ends up "...-x86_64-x86_64.flatpak").
+          bundle: TaskCoach-${{ steps.version.outputs.version }}.flatpak
+          manifest-path: build.in/flatpak/org.taskcoach.TaskCoach.yaml
+          cache-key: flatpak-builder-${{ github.sha }}
+          # x86_64 only here; Flathub builds aarch64 separately.
+          arch: x86_64
+          # Upload via our own step below (one artifact, named like the others).
+          upload-artifact: false
+
+      - name: Upload Flatpak artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: TaskCoach-Flatpak-${{ steps.version.outputs.version }}
+          path: TaskCoach-*.flatpak
+          retention-days: 30
+
+      - name: Create Release (on tag)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: TaskCoach-*.flatpak
+          draft: false
+          prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ __pycache__
 venv
 Welcome.tsk.lock
 test screenshots/
+
+# Flatpak: generated pinned sources and build output (see docs/FLATPAK.md)
+build.in/flatpak/python3-sources.json
+build.in/flatpak/.flatpak-builder/
+*.flatpak

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "build.in/flatpak/shared-modules"]
+	path = build.in/flatpak/shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/README.md
+++ b/README.md
@@ -18,19 +18,20 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.16-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.16-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.16_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.16_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.16_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.16-fedora43.rpm` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.17-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.17-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.17_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.17_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.17_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.17-fedora43.rpm` |
+| [Flatpak (any Linux)](#flatpak) | `TaskCoach-2.0.2.17-x86_64.flatpak` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.16-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.16-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.16_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.16_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.2.16-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.2.16-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.17-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.17-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.17_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.17_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.2.17-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.2.17-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -42,8 +43,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.16_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.2.16_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.17_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.2.17_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -56,8 +57,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.16-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.2.16-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.17-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.2.17-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -70,8 +71,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.16-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.2.16-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.17-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.2.17-fedora43.rpm
 ```
 
 To uninstall:
@@ -86,16 +87,37 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.16-x86_64.AppImage
-chmod +x TaskCoach-2.0.2.16-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.17-x86_64.AppImage
+chmod +x TaskCoach-2.0.2.17-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.2.16-x86_64.AppImage
+./TaskCoach-2.0.2.17-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.
+
+#### Flatpak
+
+A single-file Flatpak bundle is also published. It needs `flatpak` installed;
+the first install pulls the GNOME runtime from Flathub.
+
+```bash
+cd ~/Downloads
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.17-x86_64.flatpak
+flatpak install ./TaskCoach-2.0.2.17-x86_64.flatpak
+flatpak run org.taskcoach.TaskCoach
+```
+
+To remove:
+```bash
+flatpak uninstall org.taskcoach.TaskCoach
+```
+
+The Flatpak bundles its own libayatana-appindicator, so the system-tray icon
+works without host packages (on GNOME you still need the AppIndicator extension,
+as noted below).
 
 #### Linux System Tray
 
@@ -188,7 +210,9 @@ Key packages:
 - [README_INSTALL_MACOS.md](README_INSTALL_MACOS.md) - macOS installation with security bypass
 - [README_INSTALL_WINDOWS.md](README_INSTALL_WINDOWS.md) - Windows installation with SmartScreen bypass
 - [DEBIAN_BOOKWORM_SETUP.md](docs/DEBIAN_BOOKWORM_SETUP.md) - Detailed installation and setup
-- [PACKAGING.md](docs/PACKAGING.md) - Building .deb packages
+- [PACKAGING.md](docs/PACKAGING.md) - Packaging across all platforms (deb, rpm, Arch, AppImage, Flatpak, Windows, macOS)
+- [APPIMAGE.md](docs/APPIMAGE.md) - AppImage build details
+- [FLATPAK.md](docs/FLATPAK.md) - Flatpak build details
 - [CRITICAL_WXPYTHON_PATCH.md](docs/CRITICAL_WXPYTHON_PATCH.md) - wxPython compatibility patch details
 
 ## Support

--- a/build.in/flatpak/README.md
+++ b/build.in/flatpak/README.md
@@ -1,0 +1,45 @@
+# Flatpak packaging for Task Coach
+
+Files here build Task Coach as a Flatpak, alongside the AppImage. Full
+documentation is in [docs/FLATPAK.md](../../docs/FLATPAK.md).
+
+| File | Purpose |
+|------|---------|
+| `org.taskcoach.TaskCoach.yaml` | Flatpak manifest (GNOME runtime) |
+| `org.taskcoach.TaskCoach.metainfo.xml` | AppStream metadata (required by Flathub) |
+| `org.taskcoach.TaskCoach.desktop` | Desktop entry (named by app ID) |
+| `generate-pip-sources.sh` | Generates pinned offline sources (Flathub path only) |
+| `python3-sources.json` | Generated, git-ignored; only needed for the offline Flathub variant |
+| `shared-modules/` | Git submodule: Flathub's maintained libappindicator (tray) chain |
+
+## Quick local build
+
+```bash
+# 1. Fetch the shared-modules submodule (tray chain) and the runtime + SDK.
+git submodule update --init build.in/flatpak/shared-modules
+flatpak install -y flathub org.gnome.Platform//50 org.gnome.Sdk//50
+
+# 2. Build and install for the current user. The python modules fetch wxPython,
+#    wxWidgets and deps over the network (--share=network in the manifest).
+flatpak-builder --user --install --force-clean \
+    build/flatpak build.in/flatpak/org.taskcoach.TaskCoach.yaml
+
+# 3. Run.
+flatpak run org.taskcoach.TaskCoach
+```
+
+Or use `scripts/build-flatpak.sh`, which wraps these steps and also produces a
+single-file `.flatpak` bundle.
+
+## Known open items
+
+- **wxPython** is built from the sdist, letting it compile its own bundled
+  wxWidgets (so the version matches its bindings). It compiles, but slowly; the
+  first CI build is where to confirm it. See [docs/FLATPAK.md](../../docs/FLATPAK.md).
+- **System tray** uses Flathub's maintained `shared-modules` libappindicator
+  (git submodule at `shared-modules/`); run `git submodule update --init` before
+  building locally. See [docs/FLATPAK.md](../../docs/FLATPAK.md).
+- **Idle detection** is enabled via bundled `dbus-python`.
+- **Screenshots** in the metainfo are placeholders; replace with real URLs.
+- For **Flathub**: drop `--share=network`, generate offline sources, and swap
+  the `taskcoach` module's `type: dir` for a pinned `git`/`archive` source.

--- a/build.in/flatpak/generate-pip-sources.sh
+++ b/build.in/flatpak/generate-pip-sources.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Generate python3-sources.json for the Flatpak manifest.
+#
+# This is ONLY needed for an offline Flathub submission. The default manifest
+# (and our own CI/local builds) fetch deps over the network with --share=network
+# and do not need this file.
+#
+# wxPython is already offline-ready in the manifest: it is a pinned sdist that
+# builds its own bundled wxWidgets. So this generator only needs to cover the
+# remaining PURE-PYTHON deps (the python3-deps module). Run it, commit
+# python3-sources.json, switch the manifest to include it instead of the network
+# python3-deps module, and drop --share=network. See docs/FLATPAK.md.
+#
+# Usage: build.in/flatpak/generate-pip-sources.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GENERATOR_URL="https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/pip/flatpak-pip-generator"
+OUT="$SCRIPT_DIR/python3-sources.json"
+
+# Pure-Python deps only (wxPython/wxWidgets are pinned source modules already).
+REQUIREMENTS=(
+    "six>=1.16.0"
+    "pypubsub"
+    "watchdog>=3.0.0"
+    "chardet>=5.2.0"
+    "python-dateutil>=2.9.0"
+    "pyparsing>=3.1.3"
+    "lxml"
+    "pyxdg"
+    "keyring"
+    "numpy>=1.26,<2"
+    "fasteners>=0.19"
+    "squaremap>=1.0.5"
+    "pyenchant>=3.2.0"
+    "distro"
+)
+
+echo "Fetching flatpak-pip-generator..."
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+wget -q "$GENERATOR_URL" -O "$TMP/flatpak-pip-generator"
+python3 -m pip install --quiet --user requirements-parser || true
+
+echo "Generating $OUT ..."
+python3 "$TMP/flatpak-pip-generator" \
+    --output "$SCRIPT_DIR/python3-sources" \
+    "${REQUIREMENTS[@]}"
+
+# flatpak-pip-generator writes python3-sources.json next to --output.
+echo "Wrote $OUT"
+echo "Review it, then build with build.in/flatpak or scripts/build-flatpak.sh"

--- a/build.in/flatpak/org.taskcoach.TaskCoach.desktop
+++ b/build.in/flatpak/org.taskcoach.TaskCoach.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Name=Task Coach
+GenericName=Task Manager
+Comment=Your friendly task manager
+Exec=taskcoach %f
+Icon=org.taskcoach.TaskCoach
+Terminal=false
+Type=Application
+Categories=Office;Calendar;ProjectManagement;
+Keywords=task;todo;reminder;project;gtd;
+MimeType=application/x-taskcoach;
+StartupNotify=true
+StartupWMClass=TaskCoach

--- a/build.in/flatpak/org.taskcoach.TaskCoach.metainfo.xml
+++ b/build.in/flatpak/org.taskcoach.TaskCoach.metainfo.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2013-2026 Task Coach developers -->
+<component type="desktop-application">
+  <id>org.taskcoach.TaskCoach</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Task Coach</name>
+  <summary>Your friendly task manager</summary>
+  <developer id="org.taskcoach">
+    <name>Task Coach developers</name>
+  </developer>
+
+  <description>
+    <p>
+      Task Coach is a free open source todo manager to manage personal tasks
+      and todo lists. It grew out of frustration about other programs not
+      handling composite tasks well.
+    </p>
+    <p>
+      In addition to flexible composite tasks, Task Coach has grown to include
+      prerequisites, prioritizing, effort tracking against a budget per task,
+      category tags, notes, and many other features. Users are not forced to
+      use all of them; Task Coach can be as simple or as complex as needed.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">org.taskcoach.TaskCoach.desktop</launchable>
+
+  <!-- Flathub requires at least one screenshot with a resolvable image URL.
+       Replace this placeholder with real hosted screenshots before submitting. -->
+  <screenshots>
+    <screenshot type="default">
+      <caption>The Task Coach main window</caption>
+      <image>https://raw.githubusercontent.com/taskcoach/taskcoach/master/website.in/screenshots/main.png</image>
+    </screenshot>
+  </screenshots>
+
+  <url type="homepage">https://github.com/taskcoach/taskcoach</url>
+  <url type="bugtracker">https://github.com/taskcoach/taskcoach/issues</url>
+  <url type="faq">https://answers.launchpad.net/taskcoach/+faqs</url>
+
+  <content_rating type="oars-1.1" />
+
+  <!-- CI rewrites the <releases> version/date from meta/data.py at build time. -->
+  <releases>
+    <release version="2.0.2.17" date="2026-06-07"/>
+  </releases>
+</component>

--- a/build.in/flatpak/org.taskcoach.TaskCoach.yaml
+++ b/build.in/flatpak/org.taskcoach.TaskCoach.yaml
@@ -1,0 +1,152 @@
+# Flatpak manifest for Task Coach.
+#
+# wxPython is built FROM SOURCE (the sdist) rather than from a binary wheel
+# that may not match the runtime GTK. We let wxPython compile its OWN bundled
+# wxWidgets (shipped in the sdist) rather than using --use_syswx against a
+# separate wxWidgets module: wxPython 4.2.5's pre-generated bindings expect the
+# exact wxWidgets snapshot it bundles, so building against a different version
+# (e.g. 3.2.6) fails with 'wxWARN_UNUSED was not declared'. See docs/FLATPAK.md.
+#
+# Network during build: the python modules use --share=network so pip can
+# fetch build backends (setuptools/sip) and pure-Python deps. This is fine for
+# our own CI/local bundles. For a FLATHUB submission, builds must be offline:
+# drop --share=network and provide pinned sources via flatpak-pip-generator
+# (build.in/flatpak/generate-pip-sources.sh). See docs/FLATPAK.md.
+#
+# Runtime is GNOME (not freedesktop) because it provides GTK3 + PyGObject +
+# gobject-introspection as one consistent set, which wxPython (gtk3) and the
+# PyGObject tray backend (taskcoachlib/gui/appindicator.py) both need.
+
+app-id: org.taskcoach.TaskCoach
+runtime: org.gnome.Platform
+# Use the current stable GNOME runtime and bump it as runtimes reach EOL
+# (48 went EOL 2026-03-24). Keep this in sync with the CI container image tag
+# in .github/workflows/build-flatpak.yml and RUNTIME_VERSION in
+# scripts/build-flatpak.sh.
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: taskcoach
+
+finish-args:
+  # Windowing.
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  # Read and write task (.tsk) files anywhere the user keeps them. wx uses its
+  # own file dialogs rather than the portal, so a broad home grant is needed.
+  # Flathub reviewers may ask to narrow this; revisit if portal dialogs land.
+  - --filesystem=home
+  # Reminders / desktop notifications.
+  - --talk-name=org.freedesktop.Notifications
+  # System tray (StatusNotifierItem). Lets the PyGObject AppIndicator backend
+  # publish the tray icon; the desktop still needs an SNI host (e.g. the GNOME
+  # AppIndicator extension) for it to appear.
+  - --talk-name=org.kde.StatusNotifierWatcher
+  # Idle-time detection (optional feature, off by default; see docs/IDLE.md).
+  - --talk-name=org.freedesktop.ScreenSaver
+  - --talk-name=org.gnome.Mutter.IdleMonitor
+  # keyring storage.
+  - --talk-name=org.freedesktop.secrets
+
+cleanup:
+  - '*.a'
+  - '*.la'
+  - /include
+  - /lib/pkgconfig
+  - /share/man
+
+modules:
+  # GLU (libGLU/glu.h). The GNOME SDK ships libGL but not the legacy GLU, which
+  # wxWidgets needs for its OpenGL (glcanvas) support.
+  - name: glu
+    buildsystem: meson
+    sources:
+      - type: archive
+        url: https://archive.mesa3d.org/glu/glu-9.0.3.tar.xz
+        sha256: bd43fe12f374b1192eb15fe20e45ff456b9bc26ab57f0eee919f96ca0f8a330f
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - '*.a'
+
+  # System-tray support via Flathub's maintained shared-modules - the robust,
+  # CI-tested way rather than a hand-rolled chain. This one module file bundles
+  # the whole intltool -> dbus-glib -> libdbusmenu -> libappindicator chain, and
+  # Flathub keeps it building against current and oldstable SDKs. The
+  # -introspection- variant ships the AppIndicator3-0.1 typelib, which the
+  # PyGObject backend in taskcoachlib/gui/appindicator.py picks up via its
+  # AppIndicator3 fallback (flatpak puts /app/lib/girepository-1.0 on the GI
+  # path). shared-modules is a git submodule at build.in/flatpak/shared-modules;
+  # CI checks it out with submodules and scripts/build-flatpak.sh inits it.
+  - shared-modules/libappindicator/libappindicator-gtk3-introspection-12.10.json
+
+  # wxPython, built from the sdist. We let wxPython compile its OWN bundled
+  # wxWidgets (shipped in the sdist) instead of using --use_syswx against a
+  # separately built wxWidgets: wxPython 4.2.5's pre-generated bindings expect
+  # the exact wxWidgets snapshot it bundles, and building them against
+  # wxWidgets 3.2.6 fails (e.g. 'wxWARN_UNUSED was not declared'). Building the
+  # bundled wxWidgets guarantees the versions match. This is the slow step.
+  - name: python3-wxpython
+    buildsystem: simple
+    build-options:
+      build-args:
+        - --share=network
+      env:
+        WXPYTHON_BUILD_ARGS: '--nodoc'
+    build-commands:
+      - pip3 install --prefix=${FLATPAK_DEST} --verbose wxpython-4.2.5.tar.gz
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/22/43/81657a6b126ffc19163500a8184d683cec08eb4e1d06905cd0c371c702d0/wxpython-4.2.5.tar.gz
+        sha256: 44e836d1bccd99c38790bb034b6ecf70d9060f6734320560f7c4b0d006144793
+
+  # The remaining Python dependencies (the AppImage set plus dbus-python, which
+  # enables the optional idle-time detection feature - its D-Bus backend does
+  # `import dbus`, and the org.freedesktop.ScreenSaver / org.gnome.Mutter
+  # talk-name grants are already in finish-args).
+  # --ignore-installed is required: the build runs against org.gnome.Sdk, which
+  # ships some of these (e.g. python3-lxml). Without it, pip sees them "already
+  # satisfied" from the SDK and skips installing them into /app, so they are
+  # MISSING at runtime against org.gnome.Platform (which lacks them).
+  - name: python3-deps
+    buildsystem: simple
+    build-options:
+      build-args:
+        - --share=network
+    build-commands:
+      - pip3 install --prefix=${FLATPAK_DEST} --ignore-installed
+        "six>=1.16.0" pypubsub "watchdog>=3.0.0" "chardet>=5.2.0"
+        "python-dateutil>=2.9.0" "pyparsing>=3.1.3" lxml pyxdg keyring
+        "numpy>=1.26,<2" "fasteners>=0.19" "squaremap>=1.0.5"
+        "pyenchant>=3.2.0" "dbus-python>=1.3.2" distro
+
+  # Task Coach itself.
+  - name: taskcoach
+    buildsystem: simple
+    build-commands:
+      - install -d /app/share/taskcoach
+      - cp -r taskcoachlib /app/share/taskcoach/
+      - cp taskcoach.py /app/share/taskcoach/
+      # Default "Welcome" document. settings.pathToSystemWelcomeFile() finds it
+      # via dirname(sys.argv[0])/Welcome.tsk and, on first run, copies it into
+      # the user's Documents folder and opens it.
+      - cp Welcome.tsk /app/share/taskcoach/
+      - install -Dm644 icons.in/taskcoach.png
+        /app/share/icons/hicolor/256x256/apps/org.taskcoach.TaskCoach.png
+      - install -Dm644 build.in/flatpak/org.taskcoach.TaskCoach.desktop
+        /app/share/applications/org.taskcoach.TaskCoach.desktop
+      - install -Dm644 build.in/flatpak/org.taskcoach.TaskCoach.metainfo.xml
+        /app/share/metainfo/org.taskcoach.TaskCoach.metainfo.xml
+      - |
+        cat > /app/bin/taskcoach <<'LAUNCH'
+        #!/bin/bash
+        export PYTHONPATH="/app/share/taskcoach:${PYTHONPATH}"
+        exec python3 /app/share/taskcoach/taskcoach.py "$@"
+        LAUNCH
+        chmod +x /app/bin/taskcoach
+    sources:
+      # Local builds and CI build from the checked-out tree. For a Flathub
+      # submission, replace this with a pinned `git`/`archive` source.
+      - type: dir
+        path: ../..

--- a/docs/FLATPAK.md
+++ b/docs/FLATPAK.md
@@ -1,0 +1,216 @@
+# Flatpak Packaging
+
+This document covers the Flatpak build for Task Coach: the design decisions,
+how to build locally, the CI workflow, distribution options, and the known
+open items. It complements the high-level entry in [PACKAGING.md](PACKAGING.md).
+
+Flatpak is offered **in addition to** the AppImage, not as a replacement. The
+two solve different problems:
+
+- **AppImage**: one self-contained file, no install, no prerequisites; you own
+  the library-bundling fragility (see [APPIMAGE.md](APPIMAGE.md)).
+- **Flatpak**: runs against a shared, versioned **runtime**, so the GTK / glib /
+  PyGObject / gobject-introspection stack is one consistent set provided by the
+  platform. The AppImage's ABI/bundling problems do not exist here, at the cost
+  of needing `flatpak` installed and (on first install) fetching the runtime.
+
+## Project files
+
+| File | Purpose |
+|------|---------|
+| [`build.in/flatpak/org.taskcoach.TaskCoach.yaml`](../build.in/flatpak/org.taskcoach.TaskCoach.yaml) | Manifest |
+| [`build.in/flatpak/org.taskcoach.TaskCoach.metainfo.xml`](../build.in/flatpak/org.taskcoach.TaskCoach.metainfo.xml) | AppStream metadata (required by Flathub) |
+| [`build.in/flatpak/org.taskcoach.TaskCoach.desktop`](../build.in/flatpak/org.taskcoach.TaskCoach.desktop) | Desktop entry, named by app ID |
+| [`build.in/flatpak/generate-pip-sources.sh`](../build.in/flatpak/generate-pip-sources.sh) | Generates pinned Python sources |
+| `build.in/flatpak/shared-modules/` | Git submodule: Flathub's maintained libappindicator (tray) chain |
+| [`scripts/build-flatpak.sh`](../scripts/build-flatpak.sh) | Local build + bundle |
+| [`.github/workflows/build-flatpak.yml`](../.github/workflows/build-flatpak.yml) | CI build + release upload |
+
+## Design decisions
+
+### Runtime: GNOME, not freedesktop
+
+The manifest uses `org.gnome.Platform` rather than `org.freedesktop.Platform`
+because the GNOME runtime bundles **GTK3, PyGObject, and gobject-introspection**.
+Task Coach needs all three: wxPython is the gtk3 build, and the system-tray
+backend in `taskcoachlib/gui/appindicator.py` is written against PyGObject. With
+the GNOME runtime everything in the process shares a single GTK/glib/GObject
+type system, which is exactly the property the AppImage cannot guarantee.
+
+Bump `runtime-version` as runtimes reach end of life; Flathub will flag an EOL
+runtime.
+
+### Permissions (finish-args)
+
+Each grant in the manifest is there for a reason; keep the set minimal for
+Flathub review:
+
+| Grant | Why |
+|-------|-----|
+| `--socket=wayland`, `--socket=fallback-x11`, `--share=ipc`, `--device=dri` | Display and rendering |
+| `--filesystem=home` | Read/write `.tsk` task files anywhere; wx uses its own file dialogs, not the portal. Reviewers may push to narrow this. |
+| `--talk-name=org.freedesktop.Notifications` | Reminders |
+| `--talk-name=org.kde.StatusNotifierWatcher` | System-tray icon |
+| `--talk-name=org.freedesktop.ScreenSaver`, `--talk-name=org.gnome.Mutter.IdleMonitor` | Optional idle detection ([IDLE.md](IDLE.md)) |
+| `--talk-name=org.freedesktop.secrets` | keyring |
+
+### System tray (via Flathub shared-modules)
+
+System-tray support comes from **Flathub's maintained
+[`shared-modules`](https://github.com/flathub/shared-modules)**, referenced as a
+git submodule at `build.in/flatpak/shared-modules`. The manifest pulls in one
+file:
+
+```
+- shared-modules/libappindicator/libappindicator-gtk3-introspection-12.10.json
+```
+
+That single file bundles the whole `intltool` -> `dbus-glib` -> `libdbusmenu` ->
+`libindicator` -> `libappindicator` chain, **with Flathub's patches** for the
+exact build breakages a hand-rolled chain hits (e.g. libdbusmenu's
+`HAVE_VALGRIND`/automake and `-Werror` issues). Flathub CI guarantees it builds
+against current and oldstable Freedesktop/GNOME SDKs, so this is the robust,
+maintained path rather than pinning fragile upstream tarballs ourselves.
+
+The `-introspection-` variant ships the `AppIndicator3-0.1` typelib. The
+PyGObject backend in `taskcoachlib/gui/appindicator.py` tries
+`AyatanaAppIndicator3` first and then falls back to `AppIndicator3`, so it picks
+this up with no app-code change (Flatpak puts `/app/lib/girepository-1.0` on the
+GI path; PyGObject itself comes from the GNOME runtime).
+
+CI checks out the submodule (`submodules: recursive`) and
+`scripts/build-flatpak.sh` runs `git submodule update --init`. To update the
+chain later, bump the submodule: `git -C build.in/flatpak/shared-modules pull`.
+
+The desktop still needs an SNI host (e.g. the GNOME AppIndicator extension) for
+the icon to actually appear; that is outside any package's control. Per the
+[Flatpak docs](https://docs.flatpak.org/en/latest/desktop-integration.html) the
+`--talk-name=org.kde.StatusNotifierWatcher` grant (present in `finish-args`) is
+required, and libappindicator also provides an XEmbed fallback for shells
+without SNI.
+
+### wxPython: build from source, let it build its own wxWidgets
+
+The first instinct is to install the binary wheel, but it may not match the
+runtime GTK, so we build wxPython from the sdist instead. The second instinct
+(used by some Flathub apps like KiCad) is `--use_syswx`: build wxWidgets as a
+separate module and link it. That only works when the system wxWidgets is the
+**exact** version wxPython's pre-generated bindings expect; building wxPython
+4.2.5 against wxWidgets 3.2.6 fails with errors like `wxWARN_UNUSED was not
+declared`, and pinning the precise snapshot per wxPython release is fragile.
+
+So we do **not** use `--use_syswx`. The wxPython sdist ships the matching
+wxWidgets source (it is ~56MB for this reason), and we let `build.py` compile
+that bundled wxWidgets and then Phoenix against it. The versions are guaranteed
+to match. The cost is a long build (wxWidgets + wxPython compile, several
+minutes); the flatpak-builder cache makes reruns fast.
+
+A small **`glu`** module is built first because the GNOME SDK ships `libGL` but
+not the legacy `GLU` (`glu.h`) that wxWidgets' OpenGL (glcanvas) support needs.
+Checksums in the manifest are real (verified against the GLU and PyPI artifacts).
+
+### `--ignore-installed` for the Python deps
+
+The `python3-deps` module installs with `pip3 ... --ignore-installed`. The build
+runs against `org.gnome.Sdk`, which ships some of these modules (notably
+`python3-lxml`). Without `--ignore-installed`, pip treats them as already
+satisfied (from the SDK) and skips installing them into `/app`, so they are
+**missing at runtime** against `org.gnome.Platform` (which does not include
+them). This manifested as `ModuleNotFoundError: No module named 'lxml'` on first
+launch even though the build succeeded.
+
+The set also includes **`dbus-python`**, which enables the optional idle-time
+detection feature (its D-Bus backend does `import dbus`); the matching
+`org.freedesktop.ScreenSaver` / `org.gnome.Mutter.IdleMonitor` talk-name grants
+are in `finish-args`.
+
+### Network during build vs Flathub offline
+
+Our own CI/local builds let the python modules use `--share=network` so pip can
+fetch the wxPython/wxWidgets sources, build backends, and the pure-Python deps.
+A **Flathub** submission must build fully offline: remove `--share=network` and
+provide pinned sources with `generate-pip-sources.sh` (which uses
+`flatpak-pip-generator` to produce a git-ignored `python3-sources.json`). The
+helper is kept for exactly that path.
+
+## Building locally
+
+```bash
+# 1. Runtime + SDK.
+flatpak remote-add --user --if-not-exists flathub \
+    https://flathub.org/repo/flathub.flatpakrepo
+flatpak install --user -y flathub org.gnome.Platform//50 org.gnome.Sdk//50
+
+# 2. Build, install, run. The python modules fetch their own sources over the
+#    network (--share=network in the manifest); nothing to pre-generate.
+flatpak-builder --user --install --force-clean \
+    build/flatpak build.in/flatpak/org.taskcoach.TaskCoach.yaml
+flatpak run org.taskcoach.TaskCoach
+```
+
+`scripts/build-flatpak.sh` wraps all of this and also exports a single-file
+`.flatpak` bundle.
+
+## CI
+
+`.github/workflows/build-flatpak.yml` runs inside the
+`flathub-infra/flatpak-github-actions:gnome-50` container (flatpak +
+flatpak-builder + SDK preinstalled), builds with the official
+`flatpak/flatpak-github-actions/flatpak-builder` action (the manifest's python
+modules fetch their own sources via `--share=network`), uploads the `.flatpak`
+bundle as an artifact, and attaches it to the GitHub Release on a `v*` tag.
+This matches the AppImage workflow's trigger and release pattern.
+
+## Distribution
+
+### Direct bundle (from a GitHub release)
+
+The `.flatpak` bundle can be installed directly, no Flathub needed:
+
+```bash
+flatpak install ./TaskCoach-X.Y.Z.W-x86_64.flatpak
+flatpak run org.taskcoach.TaskCoach
+```
+
+Caveats: the user needs `flatpak` installed; the bundle contains the app but
+not the runtime, so the first install fetches `org.gnome.Platform` from Flathub
+(the bundle records this via `--runtime-repo`); and a directly-installed bundle
+does not auto-update (re-download to update).
+
+### Flathub (managed, auto-updating)
+
+To publish on Flathub:
+
+1. Pin everything: replace the `taskcoach` module's `type: dir` source with a
+   pinned `git`/`archive`, and commit a generated `python3-sources.json` (plus
+   pin any tray modules to commits if tray support has been added by then).
+2. Replace the placeholder screenshots in the metainfo with real hosted images
+   and validate with `appstreamcli validate`.
+3. Open a PR adding the manifest to the
+   [`flathub/flathub`](https://github.com/flathub/flathub) repo (`new-pr`
+   branch). A bot builds it; reviewers check the build, permissions, metadata,
+   and licensing.
+4. After merge, Flathub's own buildbot builds and publishes; updates are pushed
+   to the per-app Flathub repo.
+
+### Self-hosted remote
+
+Because Flatpak is decentralized, you can instead host your own OSTree repo
+(static, or via `flat-manager`) and have users `flatpak remote-add` it. This
+keeps auto-updates without Flathub.
+
+## Known open items
+
+This needs a real `flatpak-builder` pass to confirm, ideally in CI:
+
+- **wxPython** uses the proven source-build pattern, so it should work, but the
+  wxWidgets + wxPython compile is slow (several minutes) and is the most likely
+  place for a first-build failure. The flatpak-builder cache makes reruns fast.
+- **System tray** uses Flathub `shared-modules` (git submodule), so the
+  appindicator build is the CI-maintained upstream one. If the app reports a
+  missing `AppIndicator3` typelib at runtime, confirm the submodule was checked
+  out and that the `-introspection-` variant is the one referenced.
+- **Screenshots** in the metainfo are placeholders.
+- For **Flathub**: drop `--share=network`, generate offline sources, and replace
+  the `taskcoach` module's `type: dir` with a pinned source. (shared-modules is
+  already submodule-pinned, which Flathub expects.)

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -1,6 +1,6 @@
 # Packaging Guide for Task Coach
 
-This document describes the packaging setup for Task Coach on Linux (Debian, Ubuntu, Linux Mint, Arch Linux, Manjaro, Fedora, AppImage), Windows, and macOS.
+This document describes the packaging setup for Task Coach on Linux (Debian, Ubuntu, Linux Mint, Arch Linux, Manjaro, Fedora, AppImage, Flatpak), Windows, and macOS.
 
 ## Table of Contents
 
@@ -14,6 +14,7 @@ This document describes the packaging setup for Task Coach on Linux (Debian, Ubu
 - [Arch Linux / Manjaro Packaging](#arch-linux--manjaro-packaging)
 - [Fedora Packaging](#fedora-packaging)
 - [AppImage Packaging](#appimage-packaging)
+- [Flatpak Packaging](#flatpak-packaging)
 - [Windows Packaging](#windows-packaging)
 - [macOS Packaging](#macos-packaging)
 
@@ -39,36 +40,36 @@ This document describes the packaging setup for Task Coach on Linux (Debian, Ubu
 
 This table shows how dependencies are handled in **built packages** and **setup scripts**.
 
-| Package | debian12 | ubuntu22 | debian13 | ubuntu24 | arch | fedora | appimage | windows | macos |
-|---------|:--------:|:--------:|:--------:|:--------:|:----:|:------:|:--------:|:-------:|:-----:|
-| wxpython | distro | distro | distro | distro | distro | distro | bundled | pip | pip |
-| pypubsub | distro | distro | distro | distro | AUR | distro | bundled | pip | pip |
-| pyparsing | **pip** | **pip** | distro | distro | distro | **pip** | bundled | pip | pip |
-| watchdog | **pip** | **pip** | distro | distro | distro | distro | bundled | pip | pip |
-| squaremap | distro | distro | distro | distro | **pip** | **pip** | bundled | pip | pip |
-| six | distro | distro | distro | distro | distro | distro | bundled | pip | pip |
-| lxml | distro | distro | distro | distro | distro | distro | bundled | pip | pip |
-| numpy (<2) | distro | distro | distro | distro | distro | distro | bundled | pip | pip |
-| ↳ version | 1.24.2 | 1.21.5 | 2.2.4 | 1.26.4 | 2.4.0 | 2.3.3 | 1.26.4 | 1.26.4 | 1.26.4 |
-| chardet (<5.2) | distro | distro | distro | distro | distro | distro | bundled | pip | pip |
-| python-dateutil | distro | distro | distro | distro | distro | distro | bundled | pip | pip |
-| keyring | distro | distro | distro | distro | distro | distro | bundled | pip | pip |
-| pyxdg | distro | distro | distro | distro | distro | distro | bundled | — | — |
-| fasteners | distro | distro | distro | distro | distro | distro | bundled | pip | pip |
-| pyenchant | distro | distro | distro | distro | distro | distro | bundled | pip | pip |
-| hunspell-en-us | optional | optional | optional | optional | optional | optional | optional | — | — |
-| ayatana-appindicator | distro | distro | distro | distro | distro | distro | host | — | — |
-| hypertreelist | **patch** | **patch** | **patch** | **patch** | **patch** | **patch** | bundled | **patch** | **patch** |
-| WMI | — | — | — | — | — | — | — | pip | — |
-| python3-dbus | optional | optional | optional | optional | optional | optional | — | — | — |
-| python3-pywayland | — | — | optional | — | optional | optional | — | — | — |
+| Package | debian12 | ubuntu22 | debian13 | ubuntu24 | arch | fedora | appimage | flatpak | windows | macos |
+|---------|:--------:|:--------:|:--------:|:--------:|:----:|:------:|:--------:|:-------:|:-------:|:-----:|
+| wxpython | distro | distro | distro | distro | distro | distro | bundled | bundled | pip | pip |
+| pypubsub | distro | distro | distro | distro | AUR | distro | bundled | bundled | pip | pip |
+| pyparsing | **pip** | **pip** | distro | distro | distro | **pip** | bundled | bundled | pip | pip |
+| watchdog | **pip** | **pip** | distro | distro | distro | distro | bundled | bundled | pip | pip |
+| squaremap | distro | distro | distro | distro | **pip** | **pip** | bundled | bundled | pip | pip |
+| six | distro | distro | distro | distro | distro | distro | bundled | bundled | pip | pip |
+| lxml | distro | distro | distro | distro | distro | distro | bundled | bundled | pip | pip |
+| numpy (<2) | distro | distro | distro | distro | distro | distro | bundled | bundled | pip | pip |
+| ↳ version | 1.24.2 | 1.21.5 | 2.2.4 | 1.26.4 | 2.4.0 | 2.3.3 | 1.26.4 | 1.26.4 | 1.26.4 | 1.26.4 |
+| chardet (<5.2) | distro | distro | distro | distro | distro | distro | bundled | bundled | pip | pip |
+| python-dateutil | distro | distro | distro | distro | distro | distro | bundled | bundled | pip | pip |
+| keyring | distro | distro | distro | distro | distro | distro | bundled | bundled | pip | pip |
+| pyxdg | distro | distro | distro | distro | distro | distro | bundled | bundled | — | — |
+| fasteners | distro | distro | distro | distro | distro | distro | bundled | bundled | pip | pip |
+| pyenchant | distro | distro | distro | distro | distro | distro | bundled | bundled | pip | pip |
+| hunspell-en-us | optional | optional | optional | optional | optional | optional | optional | optional | — | — |
+| ayatana-appindicator | distro | distro | distro | distro | distro | distro | host | bundled | — | — |
+| hypertreelist | **patch** | **patch** | **patch** | **patch** | **patch** | **patch** | bundled | bundled | **patch** | **patch** |
+| WMI | — | — | — | — | — | — | — | — | pip | — |
+| python3-dbus | optional | optional | optional | optional | optional | optional | — | bundled | — | — |
+| python3-pywayland | — | — | optional | — | optional | optional | — | — | — | — |
 
 **Key:**
 - `distro` = Installed from distribution repos (required dependency)
 - `optional` = Optional feature support, exactly like the spell-check dictionaries: `Recommends:` on deb/rpm, `optdepends` on Arch. Never a hard dependency, never bundled, never pip-installed. Pulled in where the distro packages it, silently skipped (install still succeeds) where it does not.
 - `pip` = Bundled via pip in package build (version too old or not in repos)
 - `patch` = Bundled patch in `taskcoachlib/patches/` (wxPython hypertreelist fix)
-- `bundled` = Bundled in package (thirdparty/ for .deb/.rpm, or inside AppImage)
+- `bundled` = Bundled in package (thirdparty/ for .deb/.rpm, inside the AppImage, or built into the Flatpak). For Flatpak this means pip-installed or built as a manifest module at build time; the base Python, GTK and PyGObject come from the GNOME runtime, not from these rows.
 - `host` = Uses host system library (AppImage); install on host for Wayland tray support
 - `AUR` = Arch User Repository (rolling release)
 - `—` = Not applicable for this platform
@@ -107,6 +108,7 @@ backends.
 | [Manjaro](#arch-linux--manjaro-packaging) | arch | latest | latest | `setup_arch.sh` | `build-arch.yml` | pip: squaremap; pypubsub from AUR |
 | [Fedora 43](#fedora-packaging) | fedora43 | 3.13 | 4.2.2 | `setup_fedora.sh` | `build-rpm.yml` | pip: squaremap, pyparsing |
 | [**AppImage**](#appimage-packaging) | appimage | **3.11** | **4.2.4** | — | `build-appimage.yml` | Bundles Python + all deps |
+| [**Flatpak**](#flatpak-packaging) | flatpak | runtime | **source** | `scripts/build-flatpak.sh` | `build-flatpak.yml` | GNOME runtime; wxPython from sdist (builds its own bundled wxWidgets) |
 | [**Windows**](#windows-packaging) | windows | **3.11** | **4.2.x** | — | `build-windows.yml` | Python embed + Inno Setup |
 | [**macOS**](#macos-packaging) | macos | **3.11** | **4.2.x** | — | `build-macos.yml` | py2app + DMG (Intel & ARM64) |
 
@@ -474,6 +476,38 @@ The AppImage build creates a portable, self-contained Linux executable that bund
 **Minimum requirements:** glibc 2.28+ (Debian Bookworm, Ubuntu 22.04+, Fedora 40+)
 
 For detailed AppImage documentation including library bundling strategy, design decisions, build process, and troubleshooting, see **[APPIMAGE.md](APPIMAGE.md)**.
+
+---
+
+## Flatpak Packaging
+
+- **Flatpak:** [docs](https://docs.flatpak.org/) | [flatpak-builder](https://docs.flatpak.org/en/latest/flatpak-builder.html) | [Flathub submission](https://docs.flathub.org/docs/for-app-authors/submission) | [flatpak-builder-tools](https://github.com/flatpak/flatpak-builder-tools)
+- **Project files:** [FLATPAK.md](FLATPAK.md) | [`build.in/flatpak/`](../build.in/flatpak/) | [`build-flatpak.sh`](../scripts/build-flatpak.sh) | [`build-flatpak.yml`](../.github/workflows/build-flatpak.yml)
+
+The Flatpak build is offered **in addition to** the AppImage. It runs against the **GNOME runtime** (`org.gnome.Platform`), which supplies a consistent GTK / glib / PyGObject stack, so the library-bundling and ABI problems the AppImage fights do not exist here. The trade is that users need `flatpak` installed and the runtime is fetched on first install.
+
+### Available Builds
+
+| Build | Runtime | Architecture | Target |
+|-------|---------|--------------|--------|
+| `TaskCoach-X.Y.Z.W-x86_64.flatpak` | `org.gnome.Platform//50` | x86_64 | Direct install or Flathub |
+
+**Requirements:** `flatpak` installed; first install pulls the GNOME runtime from Flathub.
+
+### Why the GNOME runtime
+
+The GNOME runtime bundles GTK3, PyGObject and gobject-introspection. Task Coach needs all three (wxPython gtk3 plus the PyGObject backend), and inside the runtime they are one consistent set, which is exactly the property the AppImage cannot guarantee. System-tray support comes from Flathub's maintained `shared-modules` (referenced as a git submodule), so the appindicator chain is the CI-tested upstream one rather than a hand-rolled set of tarballs. See [FLATPAK.md](FLATPAK.md).
+
+### Distribution
+
+- **Direct bundle:** attach the `.flatpak` to a GitHub Release; users run `flatpak install ./TaskCoach-*.flatpak`. Self-contained for the app, but the runtime is fetched on first install and the bundle does not auto-update.
+- **Flathub:** submit the manifest via a PR to [`flathub/flathub`](https://github.com/flathub/flathub); Flathub's own buildbot then builds and publishes with managed auto-updates.
+
+### Status
+
+wxPython is built from the sdist, letting it compile its own bundled wxWidgets (guaranteeing the version matches its pre-generated bindings), with checksums verified against the official artifacts. System-tray support comes from Flathub's `shared-modules` libappindicator (git submodule), and optional idle detection from bundled `dbus-python`. For a Flathub submission, builds must additionally be made offline (drop `--share=network`, generate pinned sources) and the placeholder screenshots replaced.
+
+For detailed Flatpak documentation including the runtime choice, permission rationale, offline pinned-source generation, the wxPython risk, build process, and Flathub submission, see **[FLATPAK.md](FLATPAK.md)**.
 
 ---
 

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -150,6 +150,9 @@ copy_application() {
     # Copy TaskCoach source
     cp -r "$PROJECT_ROOT/taskcoachlib" "$APPDIR/usr/share/taskcoach/"
     cp "$PROJECT_ROOT/taskcoach.py" "$APPDIR/usr/share/taskcoach/"
+    # Default "Welcome" document. settings.pathToSystemWelcomeFile() finds it
+    # via dirname(sys.argv[0])/Welcome.tsk and opens it on first run.
+    cp "$PROJECT_ROOT/Welcome.tsk" "$APPDIR/usr/share/taskcoach/"
 
     # Copy icons
     mkdir -p "$APPDIR/usr/share/icons/hicolor/256x256/apps"

--- a/scripts/build-flatpak.sh
+++ b/scripts/build-flatpak.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Build Task Coach as a Flatpak locally, alongside the AppImage build.
+# Produces an installed app and a single-file .flatpak bundle that can be
+# distributed directly (flatpak install ./TaskCoach-*.flatpak).
+#
+# Requires: flatpak, flatpak-builder, network access (first run pulls the
+# GNOME runtime/SDK and the pinned Python sources).
+#
+# Usage: ./scripts/build-flatpak.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+FLATPAK_DIR="$PROJECT_ROOT/build.in/flatpak"
+MANIFEST="$FLATPAK_DIR/org.taskcoach.TaskCoach.yaml"
+BUILD_DIR="$PROJECT_ROOT/build/flatpak"
+APP_ID="org.taskcoach.TaskCoach"
+RUNTIME_VERSION="50"
+
+echo "=========================================="
+echo "Task Coach Flatpak Builder"
+echo "=========================================="
+
+for cmd in flatpak flatpak-builder; do
+    if ! command -v "$cmd" &> /dev/null; then
+        echo "Missing dependency: $cmd"
+        echo "Install with: sudo apt install flatpak flatpak-builder"
+        echo "  (or: sudo dnf install flatpak flatpak-builder)"
+        exit 1
+    fi
+done
+
+# Ensure the shared-modules submodule (libappindicator chain) is present.
+git -C "$PROJECT_ROOT" submodule update --init build.in/flatpak/shared-modules
+
+# Version from the single source of truth.
+VERSION="$(python3 -c "from taskcoachlib.meta import data; print(data.version_full)")"
+echo "Version: $VERSION"
+
+# Ensure the GNOME runtime and SDK are present.
+flatpak remote-add --user --if-not-exists flathub \
+    https://flathub.org/repo/flathub.flatpakrepo
+flatpak install --user -y flathub \
+    "org.gnome.Platform//$RUNTIME_VERSION" \
+    "org.gnome.Sdk//$RUNTIME_VERSION"
+
+# The manifest's python modules fetch wxPython/wxWidgets/deps themselves via
+# pip with --share=network, so there is nothing to pre-generate here. (The
+# offline flatpak-pip-generator path is only for a Flathub submission.)
+
+# Build, install for the current user, and export a repo.
+rm -rf "$BUILD_DIR"
+flatpak-builder --user --install --force-clean \
+    --repo="$BUILD_DIR/repo" \
+    "$BUILD_DIR/build" "$MANIFEST"
+
+# Produce a single-file bundle that references Flathub for the runtime.
+flatpak build-bundle \
+    --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo \
+    "$BUILD_DIR/repo" \
+    "$PROJECT_ROOT/TaskCoach-${VERSION}-x86_64.flatpak" \
+    "$APP_ID"
+
+echo ""
+echo "=========================================="
+echo "Flatpak built successfully!"
+echo "=========================================="
+echo "Bundle: $PROJECT_ROOT/TaskCoach-${VERSION}-x86_64.flatpak"
+echo ""
+echo "Run the installed app:"
+echo "  flatpak run $APP_ID"
+echo ""
+echo "Install the bundle elsewhere:"
+echo "  flatpak install ./TaskCoach-${VERSION}-x86_64.flatpak"
+echo ""

--- a/taskcoachlib/application/application.py
+++ b/taskcoachlib/application/application.py
@@ -837,12 +837,17 @@ Break the lock?"""
             from taskcoachlib.gui import taskbaricon, menu
 
             # Use factory function to get the appropriate icon type
-            # (AppIndicator on Wayland, wx.adv.TaskBarIcon otherwise)
-            self.taskBarIcon = taskbaricon.create_taskbar_icon(
-                self.mainwindow,  # pylint: disable=W0201
+            # (AppIndicator on Wayland, wx.adv.TaskBarIcon otherwise). Returns
+            # None when no tray backend can work on this system; in that case
+            # we run without a tray icon rather than create a broken one.
+            task_bar_icon = taskbaricon.create_taskbar_icon(
+                self.mainwindow,
                 self.taskFile.tasks(),
                 self.settings,
             )
+            if task_bar_icon is None:
+                return
+            self.taskBarIcon = task_bar_icon  # pylint: disable=W0201
             self.taskBarIcon.setPopupMenu(
                 menu.TaskBarMenu(
                     self.taskBarIcon,
@@ -891,7 +896,8 @@ Break the lock?"""
         self.quitApplication(force=True)
 
     def on_reopen_app(self):
-        self.taskBarIcon.onTaskbarClick(None)
+        if hasattr(self, "taskBarIcon"):
+            self.taskBarIcon.onTaskbarClick(None)
 
     def save_all_settings(self):
         """Save all settings to disk. Called on normal exit and signal handlers.

--- a/taskcoachlib/gui/taskbaricon.py
+++ b/taskcoachlib/gui/taskbaricon.py
@@ -940,6 +940,15 @@ def create_taskbar_icon(mainwindow, taskList, settings):
         log_step("Using AppIndicator (fallback)", prefix="TRAY")
         return AppIndicatorTaskBarIcon(mainwindow, taskList, settings)
 
-    # No AppIndicator available, try wx.adv.TaskBarIcon anyway (may not work)
-    log_step("WARNING: No good tray option available, trying wx.adv.TaskBarIcon", prefix="TRAY")
-    return TaskBarIcon(mainwindow, taskList, settings)
+    # No working tray backend: the native tray is unavailable (e.g. GNOME on
+    # Wayland, which has no XEmbed system tray) and the AppIndicator bindings
+    # are not present. Creating a wx.adv.TaskBarIcon here produces a
+    # non-functional icon whose every SetIcon() trips GTK 'GTK_IS_WIDGET'
+    # assertions, spamming the log once per second while tracking effort.
+    # Run without a tray icon instead.
+    log_step(
+        "No working tray backend available (native tray unavailable and "
+        "AppIndicator missing); running without a tray icon",
+        prefix="TRAY",
+    )
+    return None

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -44,10 +44,10 @@ import re
 # =============================================================================
 
 version = "2.0.2"  # Major.Minor.Milestone
-patch = "16"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.2.16
+patch = "17"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.2.17
 
-release_day = "5"  # Day of the release (1-31)
+release_day = "7"  # Day of the release (1-31)
 release_month = "June"  # Month of the release
 release_year = "2026"  # Year of the release
 


### PR DESCRIPTION
Flatpak release alongside the AppImage: GNOME-runtime manifest (wxWidgets built as a module, wxPython from sdist with --use_syswx), AppStream metainfo, desktop file, local build script, and a CI workflow following the existing build-* pattern. Docs updated: PACKAGING.md, new FLATPAK.md, README.md.

Tray: create_taskbar_icon now returns None when no backend works (GNOME Wayland without AppIndicator) instead of a non-functional wx.adv.TaskBarIcon whose per-second SetIcon spammed gtk_widget_get_scale_factor while tracking.

bug: "assertion 'GTK_IS_WIDGET (widget)' failed" (Fedora 44 Workstation) #448
[suggestion] provide TaskCoach as flatpak #434