### PR TITLE
Flatpak: add x-checker-data for automated Flathub updates

### DIFF
--- a/build.in/flatpak/flathub/README.md
+++ b/build.in/flatpak/flathub/README.md
@@ -53,8 +53,32 @@ build.
    [docs/FLATPAK.md](../../../docs/FLATPAK.md) (file-centric app, wx uses its own
    dialogs, not the XDG portal).
 
+## Updates after the first submission (automated)
+
+The initial submission above is a one-time manual step (Flathub bans automated
+submission PRs). **Every release after that is automated by Flathub**, so there
+is no GitHub Action to build on our side.
+
+The `type: git` source carries an `x-checker-data` block (a `git` checker with
+`tag-pattern: '^v([\d.]+)$'`). Flathub runs
+[flatpak-external-data-checker](https://github.com/flathub-infra/flatpak-external-data-checker)
+hourly against the app repo; when it sees a newer `v*` tag here, `flathubbot`
+opens an update PR in the Flathub repo with the new tag + commit. So the release
+flow is just:
+
+1. Push a new `vX.Y.Z` tag in this repo (the existing release workflow does the
+   GitHub release + bundle).
+2. `flathubbot` opens the update PR in the Flathub repo within the hour.
+3. Merge it (or set `automerge-flathubbot-prs: true` in the Flathub repo's
+   `flathub.json` to skip the click). Flathub builds and publishes.
+
+If the **pip dependencies** changed (a new dep or version, not just app code),
+regenerate `python3-sources.json` / `python3-build-deps.json` (download them from
+the release build's `flatpak-pip-sources` artifact) and include them in that PR;
+for code-only releases the checker's app-source bump is enough.
+
 ## Keeping it in sync
 
 If the dev manifest (`../io.github.taskcoach.TaskCoach.yaml`) changes, re-copy it
-over the manifest here and re-apply the `type: git` source block, so this
-reference does not drift.
+over the manifest here and re-apply the `type: git` source block (with its
+`x-checker-data`), so this reference does not drift.

--- a/build.in/flatpak/flathub/io.github.taskcoach.TaskCoach.yaml
+++ b/build.in/flatpak/flathub/io.github.taskcoach.TaskCoach.yaml
@@ -187,3 +187,10 @@ modules:
         url: https://github.com/taskcoach/taskcoach
         tag: v2.0.2.18
         commit: REPLACE_WITH_v2.0.2.18_COMMIT_SHA
+        # Auto-update: once on Flathub, flatpak-external-data-checker (run hourly
+        # by Flathub) watches for newer v* tags here and flathubbot opens an
+        # update PR in the Flathub repo. Pushing a new vX.Y.Z tag in this repo is
+        # then all that is needed; merge the bot's PR to publish.
+        x-checker-data:
+          type: git
+          tag-pattern: '^v([\d.]+)$'


### PR DESCRIPTION
Add an x-checker-data git tag-pattern watcher to the Flathub reference manifest's app source. Once submitted, Flathub's hourly flatpak-external-data-checker opens an update PR (via flathubbot) whenever a newer v* tag is pushed here, so post-submission releases are automated with no GitHub Action on our side. Document the flow in the flathub README.