### PR TITLE
Flatpak: docs + manifest cleanup; Flathub postponed (rejected as "AI slop")

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+## Code style
+
+- **Format the files you touch with [black](https://github.com/psf/black)**,
+  line-length 79 (configured in `pyproject.toml`, `[tool.black]`). black output
+  is PEP 8 compliant; running it is the standard way to fix whitespace and
+  wrapping.
+- **Lint with flake8.** Some codes are expected and must NOT be "fixed" — e.g.
+  `N802/N803/N812/N813` on wxPython's mixed-case method/argument names.
+
+Rationale and the full fix-vs-ignore list:
+[docs/PEP8_MIGRATION.md](docs/PEP8_MIGRATION.md).
+
+## Building and packaging
+
+Per-target build docs live in [docs/](docs/): [PACKAGING.md](docs/PACKAGING.md),
+[FLATPAK.md](docs/FLATPAK.md), [APPIMAGE.md](docs/APPIMAGE.md), and the
+platform notes (WINDOWS, MACOS, DEBIAN_*).

--- a/build.in/flatpak/flathub/README.md
+++ b/build.in/flatpak/flathub/README.md
@@ -9,6 +9,18 @@ a local `type: dir` source). For Flathub the app source must be a pinned
 Full step-by-step is in [docs/FLATPAK.md](../../../docs/FLATPAK.md); this is the
 quick checklist.
 
+> **Postponed (2026).** Flathub blanket-rejects submissions it deems "AI slop"
+> and **rejected this one** (prior review notes:
+> <https://github.com/flathub/flathub/pull/8938>), so complying with its required
+> changes is no longer relevant; the `.flatpak` is distributed **directly from
+> this project's GitHub releases** instead. The external `flathub/…` fork has been
+> removed; these files are kept as a reference for if/when it is revisited. The
+> main blocker Flathub pushed for — the `--filesystem=home` → portal migration —
+> is documented in [docs/FLATPAK.md](../../../docs/FLATPAK.md) (File access) and
+> will likely resolve automatically with wxPython 3.3. The automated dev-vs-Flathub
+> manifest parity check was removed; if revived, keep the two manifests in sync
+> manually (see "Keeping it in sync" below).
+
 ## What goes in the Flathub repo
 
 The submission is a PR to [`flathub/flathub`](https://github.com/flathub/flathub)
@@ -49,9 +61,12 @@ build.
 5. Prove ID ownership: sign in to flathub.org with the `github.com/taskcoach`
    account (2FA required).
 
-6. Expected review point: `--filesystem=home`. The justification is in
-   [docs/FLATPAK.md](../../../docs/FLATPAK.md) (file-centric app, wx uses its own
-   dialogs, not the XDG portal).
+6. Likely review points (justifications in
+   [docs/FLATPAK.md](../../../docs/FLATPAK.md)): the **X11-only** display (runs via
+   XWayland on Wayland); the idle `--talk-name` grants
+   (`org.freedesktop.ScreenSaver` / `org.gnome.Mutter.IdleMonitor`) — there is no
+   idle portal; and **`--filesystem=home`** (the portal migration that would drop
+   it is postponed — see the File access section in docs/FLATPAK.md).
 
 ## Updates after the first submission (automated)
 

--- a/build.in/flatpak/flathub/io.github.taskcoach.TaskCoach.yaml
+++ b/build.in/flatpak/flathub/io.github.taskcoach.TaskCoach.yaml
@@ -1,71 +1,31 @@
-# REFERENCE manifest for the FLATHUB submission repo (flathub/flathub), NOT
-# built by this repo's CI. It is identical to
-# ../io.github.taskcoach.TaskCoach.yaml except the `taskcoach` module source is
-# a pinned `type: git` instead of `type: dir`. See build.in/flatpak/flathub/README.md.
-# If the dev manifest changes, re-copy it here and re-apply the git source.
-#
-# Flatpak manifest for Task Coach.
-#
-# wxPython is built FROM SOURCE (the sdist) rather than from a binary wheel
-# that may not match the runtime GTK. We let wxPython compile its OWN bundled
-# wxWidgets (shipped in the sdist) rather than using --use_syswx against a
-# separate wxWidgets module: wxPython 4.2.5's pre-generated bindings expect the
-# exact wxWidgets snapshot it bundles, so building against a different version
-# (e.g. 3.2.6) fails with 'wxWARN_UNUSED was not declared'. See docs/FLATPAK.md.
-#
-# This manifest builds OFFLINE, the way Flathub builds: no --share=network in
-# any module. Every Python dependency is a pinned source. The pure-Python and
-# binary deps come from two generated sub-manifests (build.in/flatpak/
-# generate-pip-sources.sh): python3-sources.json (runtime deps) and
-# python3-build-deps.json (wxPython's build backends). wxPython itself
-# is a pinned sdist built with --no-build-isolation. Run the generator before
-# building (CI and scripts/build-flatpak.sh do this for you). See docs/FLATPAK.md.
-#
-# Runtime is GNOME (not freedesktop) because it provides GTK3 + PyGObject +
-# gobject-introspection as one consistent set, which wxPython (gtk3) and the
-# PyGObject tray backend (taskcoachlib/gui/appindicator.py) both need.
-
 app-id: io.github.taskcoach.TaskCoach
 runtime: org.gnome.Platform
-# Use the current stable GNOME runtime and bump it as runtimes reach EOL
-# (48 went EOL 2026-03-24). Keep this in sync with the CI container image tag
-# in .github/workflows/build-flatpak.yml and RUNTIME_VERSION in
-# scripts/build-flatpak.sh.
+
 runtime-version: '50'
 sdk: org.gnome.Sdk
 command: taskcoach
 
 finish-args:
-  # Windowing. Task Coach is an X11 app on Flatpak: wxPython's AUI docking is
-  # unusable on native Wayland (its docking hints need the global screen
-  # coordinates Wayland withholds; see docs/AUI_WAYLAND_ISSUES.md), so we do not
-  # advertise native Wayland support. Per Flathub, an app that does not support
-  # native Wayland uses --socket=x11 - it runs directly on X11, or via XWayland
-  # on a Wayland session (shipped by all mainstream compositors). We deliberately
-  # do NOT also grant --socket=wayland: that combo is a Flathub lint error
-  # (finish-args-contains-both-x11-and-wayland), and it could not give us X11 on
-  # Wayland anyway. GDK_BACKEND=x11 pins the GTK backend for good measure.
+
   - --share=ipc
   - --socket=x11
   - --device=dri
   - --env=GDK_BACKEND=x11
-  # Read and write task (.tsk) files anywhere the user keeps them. wx uses its
-  # own file dialogs rather than the portal, so a broad home grant is needed.
-  # Flathub reviewers may ask to narrow this; revisit if portal dialogs land.
+
+  # Broad grant retained for now. Migrating file access to the XDG FileChooser
+  # portal (to drop this) is a future Flathub-cleanup TODO — see docs/FLATPAK.md;
+  # it will probably arrive automatically once wxPython bundles wxWidgets 3.3.
   - --filesystem=home
-  # Note: Task Coach renders its own in-app reminder/idle popups (wx) and does
-  # not call org.freedesktop.Notifications, so no notification talk-name is
-  # granted. If host notifications are added later, use the freedesktop
-  # notification portal (no talk-name required) rather than a direct grant.
-  # System tray (StatusNotifierItem). Lets the PyGObject AppIndicator backend
-  # publish the tray icon; the desktop still needs an SNI host (e.g. the GNOME
-  # AppIndicator extension) for it to appear.
+
   - --talk-name=org.kde.StatusNotifierWatcher
-  # Idle-time detection (optional feature, off by default; see docs/IDLE.md).
+
   - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.gnome.Mutter.IdleMonitor
-  # keyring storage.
-  - --talk-name=org.freedesktop.secrets
+
+  # There seems to be a legacy Thunderbird/IMAP mail integration, but it
+  # probably does not work and/or is dead code. That is the grounds for granting
+  # neither --share=network nor --talk-name=org.freedesktop.secrets. If revived,
+  # it must use the Secret portal (org.freedesktop.portal.Secret), not that flag.
 
 cleanup:
   - '*.a'
@@ -75,8 +35,7 @@ cleanup:
   - /share/man
 
 modules:
-  # GLU (libGLU/glu.h). The GNOME SDK ships libGL but not the legacy GLU, which
-  # wxWidgets needs for its OpenGL (glcanvas) support.
+
   - name: glu
     buildsystem: meson
     sources:
@@ -88,33 +47,10 @@ modules:
       - /lib/pkgconfig
       - '*.a'
 
-  # System-tray support via Flathub's maintained shared-modules - the robust,
-  # CI-tested way rather than a hand-rolled chain. This one module file bundles
-  # the whole intltool -> dbus-glib -> libdbusmenu -> libappindicator chain, and
-  # Flathub keeps it building against current and oldstable SDKs. The
-  # -introspection- variant ships the AppIndicator3-0.1 typelib, which the
-  # PyGObject backend in taskcoachlib/gui/appindicator.py picks up via its
-  # AppIndicator3 fallback (flatpak puts /app/lib/girepository-1.0 on the GI
-  # path). shared-modules is a git submodule at build.in/flatpak/shared-modules;
-  # CI checks it out with submodules and scripts/build-flatpak.sh inits it.
   - shared-modules/libappindicator/libappindicator-gtk3-introspection-12.10.json
 
-  # Python build backends for the modules built from sdists (wxPython:
-  # setuptools/cython/sip/requests; dbus-python: meson-python), pinned so the
-  # offline build does not fetch them from PyPI. Generated by
-  # build.in/flatpak/generate-pip-sources.sh. Installed BEFORE those modules,
-  # which then build with --no-build-isolation and find them in place.
   - python3-build-deps.json
 
-  # wxPython, built from the sdist. We let wxPython compile its OWN bundled
-  # wxWidgets (shipped in the sdist) instead of using --use_syswx against a
-  # separately built wxWidgets: wxPython 4.2.5's pre-generated bindings expect
-  # the exact wxWidgets snapshot it bundles, and building them against
-  # wxWidgets 3.2.6 fails (e.g. 'wxWARN_UNUSED was not declared'). Building the
-  # bundled wxWidgets guarantees the versions match. This is the slow step, so
-  # CI relies on flatpak-builder's module cache to compile it only once (see
-  # .github/workflows/build-flatpak.yml). --no-build-isolation makes pip use the
-  # pinned build backends above instead of reaching for PyPI.
   - name: python3-wxpython
     buildsystem: simple
     build-options:
@@ -128,47 +64,22 @@ modules:
         url: https://files.pythonhosted.org/packages/22/43/81657a6b126ffc19163500a8184d683cec08eb4e1d06905cd0c371c702d0/wxpython-4.2.5.tar.gz
         sha256: 44e836d1bccd99c38790bb034b6ecf70d9060f6734320560f7c4b0d006144793
 
-  # The remaining Python dependencies (the AppImage set plus dbus-python, which
-  # enables the optional idle-time detection feature - its D-Bus backend does
-  # `import dbus`, and the org.freedesktop.ScreenSaver / org.gnome.Mutter
-  # talk-name grants are already in finish-args). Pinned for the offline build
-  # by generate-pip-sources.sh, which passes --ignore-installed: the build runs
-  # against org.gnome.Sdk, which ships some of these (e.g. python3-lxml), and
-  # without it pip sees them "already satisfied" and skips installing them into
-  # /app, so they are MISSING at runtime against org.gnome.Platform.
   - python3-sources.json
 
-  # Task Coach itself.
   - name: taskcoach
     buildsystem: simple
     build-commands:
       - install -d /app/share/taskcoach
       - cp -r taskcoachlib /app/share/taskcoach/
       - cp taskcoach.py /app/share/taskcoach/
-      # Default "Welcome" document. settings.pathToSystemWelcomeFile() finds it
-      # via dirname(sys.argv[0])/Welcome.tsk and, on first run, copies it into
-      # the user's Documents folder and opens it.
+
       - cp Welcome.tsk /app/share/taskcoach/
-      # Desktop + tray icons. Installs the app icon (io.github.taskcoach.TaskCoach)
-      # and the two tray state icons (.clock/.timer) at all native Nuvola sizes
-      # (16-128), a generated 256, and scalable SVGs, under the app-id namespace.
-      # Flatpak exports /app/share/icons to the host icon theme, so the SNI host
-      # (which runs outside the sandbox) resolves the tray icons by name rather
-      # than via an in-sandbox theme path. See build.in/flatpak/icons/SOURCES.md.
-      # The previous single 48x48 PNG in the 256 slot rendered blurry/upscaled.
-      # Copy the CONTENTS into an explicit hicolor dir. `cp -r src/hicolor dest/`
-      # is not order-independent: if /app/share/icons does not already exist, cp
-      # renames hicolor to icons and the theme level is lost (icons end up at
-      # /app/share/icons/<size>/ instead of /app/share/icons/hicolor/<size>/),
-      # so the host icon theme cannot resolve them by name and flatpak warns the
-      # desktop Icon is "not exported". Creating the target first avoids that.
+
       - install -d /app/share/icons/hicolor
       - cp -a build.in/flatpak/icons/hicolor/. /app/share/icons/hicolor/
       - install -Dm644 build.in/flatpak/io.github.taskcoach.TaskCoach.desktop
         /app/share/applications/io.github.taskcoach.TaskCoach.desktop
-      # MIME definition so the desktop's MimeType=application/x-taskcoach is a
-      # real association (double-click a .tsk file opens Task Coach).
-      # flatpak-builder rebuilds the mime cache at export.
+
       - install -Dm644 build.in/flatpak/io.github.taskcoach.TaskCoach.mime.xml
         /app/share/mime/packages/io.github.taskcoach.TaskCoach.xml
       - install -Dm644 build.in/flatpak/io.github.taskcoach.TaskCoach.metainfo.xml
@@ -181,16 +92,12 @@ modules:
         LAUNCH
         chmod +x /app/bin/taskcoach
     sources:
-      # Pinned app source for Flathub (offline, reproducible). Fill in `commit`
-      # with the exact SHA the tag points to: git rev-parse v2.0.2.18
+
       - type: git
         url: https://github.com/taskcoach/taskcoach
         tag: v2.0.2.18
         commit: REPLACE_WITH_v2.0.2.18_COMMIT_SHA
-        # Auto-update: once on Flathub, flatpak-external-data-checker (run hourly
-        # by Flathub) watches for newer v* tags here and flathubbot opens an
-        # update PR in the Flathub repo. Pushing a new vX.Y.Z tag in this repo is
-        # then all that is needed; merge the bot's PR to publish.
+
         x-checker-data:
           type: git
           tag-pattern: '^v([\d.]+)$'

--- a/build.in/flatpak/io.github.taskcoach.TaskCoach.yaml
+++ b/build.in/flatpak/io.github.taskcoach.TaskCoach.yaml
@@ -1,65 +1,31 @@
-# Flatpak manifest for Task Coach.
-#
-# wxPython is built FROM SOURCE (the sdist) rather than from a binary wheel
-# that may not match the runtime GTK. We let wxPython compile its OWN bundled
-# wxWidgets (shipped in the sdist) rather than using --use_syswx against a
-# separate wxWidgets module: wxPython 4.2.5's pre-generated bindings expect the
-# exact wxWidgets snapshot it bundles, so building against a different version
-# (e.g. 3.2.6) fails with 'wxWARN_UNUSED was not declared'. See docs/FLATPAK.md.
-#
-# This manifest builds OFFLINE, the way Flathub builds: no --share=network in
-# any module. Every Python dependency is a pinned source. The pure-Python and
-# binary deps come from two generated sub-manifests (build.in/flatpak/
-# generate-pip-sources.sh): python3-sources.json (runtime deps) and
-# python3-build-deps.json (wxPython's build backends). wxPython itself
-# is a pinned sdist built with --no-build-isolation. Run the generator before
-# building (CI and scripts/build-flatpak.sh do this for you). See docs/FLATPAK.md.
-#
-# Runtime is GNOME (not freedesktop) because it provides GTK3 + PyGObject +
-# gobject-introspection as one consistent set, which wxPython (gtk3) and the
-# PyGObject tray backend (taskcoachlib/gui/appindicator.py) both need.
-
 app-id: io.github.taskcoach.TaskCoach
 runtime: org.gnome.Platform
-# Use the current stable GNOME runtime and bump it as runtimes reach EOL
-# (48 went EOL 2026-03-24). Keep this in sync with the CI container image tag
-# in .github/workflows/build-flatpak.yml and RUNTIME_VERSION in
-# scripts/build-flatpak.sh.
+
 runtime-version: '50'
 sdk: org.gnome.Sdk
 command: taskcoach
 
 finish-args:
-  # Windowing. Task Coach is an X11 app on Flatpak: wxPython's AUI docking is
-  # unusable on native Wayland (its docking hints need the global screen
-  # coordinates Wayland withholds; see docs/AUI_WAYLAND_ISSUES.md), so we do not
-  # advertise native Wayland support. Per Flathub, an app that does not support
-  # native Wayland uses --socket=x11 - it runs directly on X11, or via XWayland
-  # on a Wayland session (shipped by all mainstream compositors). We deliberately
-  # do NOT also grant --socket=wayland: that combo is a Flathub lint error
-  # (finish-args-contains-both-x11-and-wayland), and it could not give us X11 on
-  # Wayland anyway. GDK_BACKEND=x11 pins the GTK backend for good measure.
+
   - --share=ipc
   - --socket=x11
   - --device=dri
   - --env=GDK_BACKEND=x11
-  # Read and write task (.tsk) files anywhere the user keeps them. wx uses its
-  # own file dialogs rather than the portal, so a broad home grant is needed.
-  # Flathub reviewers may ask to narrow this; revisit if portal dialogs land.
+
+  # Broad grant retained for now. Migrating file access to the XDG FileChooser
+  # portal (to drop this) is a future Flathub-cleanup TODO — see docs/FLATPAK.md;
+  # it will probably arrive automatically once wxPython bundles wxWidgets 3.3.
   - --filesystem=home
-  # Note: Task Coach renders its own in-app reminder/idle popups (wx) and does
-  # not call org.freedesktop.Notifications, so no notification talk-name is
-  # granted. If host notifications are added later, use the freedesktop
-  # notification portal (no talk-name required) rather than a direct grant.
-  # System tray (StatusNotifierItem). Lets the PyGObject AppIndicator backend
-  # publish the tray icon; the desktop still needs an SNI host (e.g. the GNOME
-  # AppIndicator extension) for it to appear.
+
   - --talk-name=org.kde.StatusNotifierWatcher
-  # Idle-time detection (optional feature, off by default; see docs/IDLE.md).
+
   - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.gnome.Mutter.IdleMonitor
-  # keyring storage.
-  - --talk-name=org.freedesktop.secrets
+
+  # There seems to be a legacy Thunderbird/IMAP mail integration, but it
+  # probably does not work and/or is dead code. That is the grounds for granting
+  # neither --share=network nor --talk-name=org.freedesktop.secrets. If revived,
+  # it must use the Secret portal (org.freedesktop.portal.Secret), not that flag.
 
 cleanup:
   - '*.a'
@@ -69,8 +35,7 @@ cleanup:
   - /share/man
 
 modules:
-  # GLU (libGLU/glu.h). The GNOME SDK ships libGL but not the legacy GLU, which
-  # wxWidgets needs for its OpenGL (glcanvas) support.
+
   - name: glu
     buildsystem: meson
     sources:
@@ -82,33 +47,10 @@ modules:
       - /lib/pkgconfig
       - '*.a'
 
-  # System-tray support via Flathub's maintained shared-modules - the robust,
-  # CI-tested way rather than a hand-rolled chain. This one module file bundles
-  # the whole intltool -> dbus-glib -> libdbusmenu -> libappindicator chain, and
-  # Flathub keeps it building against current and oldstable SDKs. The
-  # -introspection- variant ships the AppIndicator3-0.1 typelib, which the
-  # PyGObject backend in taskcoachlib/gui/appindicator.py picks up via its
-  # AppIndicator3 fallback (flatpak puts /app/lib/girepository-1.0 on the GI
-  # path). shared-modules is a git submodule at build.in/flatpak/shared-modules;
-  # CI checks it out with submodules and scripts/build-flatpak.sh inits it.
   - shared-modules/libappindicator/libappindicator-gtk3-introspection-12.10.json
 
-  # Python build backends for the modules built from sdists (wxPython:
-  # setuptools/cython/sip/requests; dbus-python: meson-python), pinned so the
-  # offline build does not fetch them from PyPI. Generated by
-  # build.in/flatpak/generate-pip-sources.sh. Installed BEFORE those modules,
-  # which then build with --no-build-isolation and find them in place.
   - python3-build-deps.json
 
-  # wxPython, built from the sdist. We let wxPython compile its OWN bundled
-  # wxWidgets (shipped in the sdist) instead of using --use_syswx against a
-  # separately built wxWidgets: wxPython 4.2.5's pre-generated bindings expect
-  # the exact wxWidgets snapshot it bundles, and building them against
-  # wxWidgets 3.2.6 fails (e.g. 'wxWARN_UNUSED was not declared'). Building the
-  # bundled wxWidgets guarantees the versions match. This is the slow step, so
-  # CI relies on flatpak-builder's module cache to compile it only once (see
-  # .github/workflows/build-flatpak.yml). --no-build-isolation makes pip use the
-  # pinned build backends above instead of reaching for PyPI.
   - name: python3-wxpython
     buildsystem: simple
     build-options:
@@ -122,47 +64,22 @@ modules:
         url: https://files.pythonhosted.org/packages/22/43/81657a6b126ffc19163500a8184d683cec08eb4e1d06905cd0c371c702d0/wxpython-4.2.5.tar.gz
         sha256: 44e836d1bccd99c38790bb034b6ecf70d9060f6734320560f7c4b0d006144793
 
-  # The remaining Python dependencies (the AppImage set plus dbus-python, which
-  # enables the optional idle-time detection feature - its D-Bus backend does
-  # `import dbus`, and the org.freedesktop.ScreenSaver / org.gnome.Mutter
-  # talk-name grants are already in finish-args). Pinned for the offline build
-  # by generate-pip-sources.sh, which passes --ignore-installed: the build runs
-  # against org.gnome.Sdk, which ships some of these (e.g. python3-lxml), and
-  # without it pip sees them "already satisfied" and skips installing them into
-  # /app, so they are MISSING at runtime against org.gnome.Platform.
   - python3-sources.json
 
-  # Task Coach itself.
   - name: taskcoach
     buildsystem: simple
     build-commands:
       - install -d /app/share/taskcoach
       - cp -r taskcoachlib /app/share/taskcoach/
       - cp taskcoach.py /app/share/taskcoach/
-      # Default "Welcome" document. settings.pathToSystemWelcomeFile() finds it
-      # via dirname(sys.argv[0])/Welcome.tsk and, on first run, copies it into
-      # the user's Documents folder and opens it.
+
       - cp Welcome.tsk /app/share/taskcoach/
-      # Desktop + tray icons. Installs the app icon (io.github.taskcoach.TaskCoach)
-      # and the two tray state icons (.clock/.timer) at all native Nuvola sizes
-      # (16-128), a generated 256, and scalable SVGs, under the app-id namespace.
-      # Flatpak exports /app/share/icons to the host icon theme, so the SNI host
-      # (which runs outside the sandbox) resolves the tray icons by name rather
-      # than via an in-sandbox theme path. See build.in/flatpak/icons/SOURCES.md.
-      # The previous single 48x48 PNG in the 256 slot rendered blurry/upscaled.
-      # Copy the CONTENTS into an explicit hicolor dir. `cp -r src/hicolor dest/`
-      # is not order-independent: if /app/share/icons does not already exist, cp
-      # renames hicolor to icons and the theme level is lost (icons end up at
-      # /app/share/icons/<size>/ instead of /app/share/icons/hicolor/<size>/),
-      # so the host icon theme cannot resolve them by name and flatpak warns the
-      # desktop Icon is "not exported". Creating the target first avoids that.
+
       - install -d /app/share/icons/hicolor
       - cp -a build.in/flatpak/icons/hicolor/. /app/share/icons/hicolor/
       - install -Dm644 build.in/flatpak/io.github.taskcoach.TaskCoach.desktop
         /app/share/applications/io.github.taskcoach.TaskCoach.desktop
-      # MIME definition so the desktop's MimeType=application/x-taskcoach is a
-      # real association (double-click a .tsk file opens Task Coach).
-      # flatpak-builder rebuilds the mime cache at export.
+
       - install -Dm644 build.in/flatpak/io.github.taskcoach.TaskCoach.mime.xml
         /app/share/mime/packages/io.github.taskcoach.TaskCoach.xml
       - install -Dm644 build.in/flatpak/io.github.taskcoach.TaskCoach.metainfo.xml
@@ -175,7 +92,6 @@ modules:
         LAUNCH
         chmod +x /app/bin/taskcoach
     sources:
-      # Local builds and CI build from the checked-out tree. For a Flathub
-      # submission, replace this with a pinned `git`/`archive` source.
+
       - type: dir
         path: ../..

--- a/docs/FLATPAK.md
+++ b/docs/FLATPAK.md
@@ -49,16 +49,101 @@ Flathub review:
 | Grant | Why |
 |-------|-----|
 | `--socket=x11`, `--share=ipc`, `--device=dri`, `--env=GDK_BACKEND=x11` | Display and rendering. X11-only: wxPython's AUI docking is unusable on native Wayland ([AUI_WAYLAND_ISSUES.md](AUI_WAYLAND_ISSUES.md)), so Task Coach declares as an X11 app and runs via XWayland on Wayland sessions. Per Flathub, an app without native Wayland support uses `--socket=x11`; also granting `--socket=wayland` is a lint error (`finish-args-contains-both-x11-and-wayland`) and would not provide X11 on Wayland anyway. |
-| `--filesystem=home` | Read/write `.tsk` task files anywhere; wx uses its own file dialogs, not the portal. Reviewers may push to narrow this. |
+| `--filesystem=home` | Read/write `.tsk` files (plus attachments and HTML/CSV/iCal exports) at arbitrary paths; wx 3.2.x's file dialogs don't use the XDG portal. Migrating to the portal to drop this is a **postponed** TODO — see [File access and the file-chooser portal](#file-access-and-the-file-chooser-portal). |
 | `--talk-name=org.kde.StatusNotifierWatcher` | System-tray icon |
 | `--talk-name=org.freedesktop.ScreenSaver`, `--talk-name=org.gnome.Mutter.IdleMonitor` | Optional idle detection ([IDLE.md](IDLE.md)) |
-| `--talk-name=org.freedesktop.secrets` | keyring |
+
+**Not granted: `--share=network` and `--talk-name=org.freedesktop.secrets`.**
+Their only consumer is a likely-dead Thunderbird/IMAP mail integration; on those
+grounds neither is granted — see
+[TODO.md §12](TODO.md#12-thunderbirdimap-mail-integration-review).
 
 There is intentionally **no** `org.freedesktop.Notifications` grant: reminders
 and idle alerts are in-app `wx` popups, so the app never calls the host
 notification service. If real desktop notifications are added later, route them
 through the freedesktop **notification portal** (which needs no `talk-name`),
 not a direct grant.
+
+### File access and the file-chooser portal
+
+> **Status: postponed.** The Flatpak build retains `--filesystem=home`. The
+> portal migration described here is a future Flathub-cleanup TODO — a prototype
+> was implemented and then **reverted**; it will most likely arrive automatically
+> with wxPython 3.3 (see the end of this section). This is the **only** place this
+> TODO is tracked, because it is relevant only to the Flatpak build.
+
+Task Coach reads and writes user-chosen files in **one** place:
+`__askUserForFile()` in `taskcoachlib/gui/iocontroller.py`, which calls
+`wx.FileSelector` (a thin wrapper over `wxFileDialog`). Everything funnels
+through it — open / save / save-as / save-selection / save-as-template and **all**
+exports (`exportAsHTML` / `exportAsCSV` / `exportAsICalendar` / `exportAsTodoTxt`
+all call `export()` -> `__askUserForFile`). The only other file dialog is the
+Backup Manager's own `wx.FileDialog` in
+`taskcoachlib/gui/dialog/backupmanager.py`. So file access is effectively **two
+call sites**, not a scattered concern.
+
+**Why the portal is needed.** On GTK, `wxFileDialog` in wxWidgets **3.2.x**
+(what wxPython 4.2.5 bundles — wxWidgets **3.2.9**) is built with
+`gtk_file_chooser_dialog_new()` — the legacy **`GtkFileChooserDialog`**, which does
+**not** route through the XDG file-chooser portal. With no filesystem grant it can
+only browse the app's private `~/.var/app/<id>/` tree, so a `.tsk` (or an export
+target) anywhere else is unreachable. Without the portal, that is the only reason
+a broad `--filesystem` grant would be needed — to give wx's own dialog something
+real to browse. `GTK_USE_PORTAL=1` does **not** help — that env var is honoured
+only by `GtkFileChooserNative`, which wx 3.2.x never instantiates.
+
+**This is a 20-year-old code path, not a portal decision.** The `wx.FileSelector`
+pattern dates to the project's earliest recorded commit (a 2005 `cvs2svn`
+migration; export-to-CSV was added 2006) — roughly **11 years before**
+`xdg-desktop-portal` and `GtkFileChooserNative` existed (GTK 3.20, 2016). wx
+simply predates the sandbox/portal layer and the call site was carried forward
+unchanged (the only recent touch to `iocontroller.py` is a 2024 source-tree move).
+
+**wxWidgets 3.3 fixes it upstream — but no released wxPython has it yet.**
+wxWidgets **3.3.0** instantiates `GtkFileChooserNative` (when GTK >= 3.20 and
+`wxFD_PREVIEW` is not requested), which **auto-routes through the portal** in a
+sandbox. Task Coach's dialogs request no preview, so on a 3.3-based build
+`wx.FileSelector` would become a real portal picker with **zero app changes** and
+the grant could be dropped. But stable wxPython is still on wxWidgets 3.2.x
+(4.2.5 -> 3.2.9, Feb 2026); only wxPython *master* tracks 3.3, and no release
+bundles it. So the free path is a wait, not an upgrade we can take today.
+
+**TODO (postponed): migrate file access to the portal.** The fix for a future
+Flathub effort is to call the portal ourselves at the two chokepoints — what GTK
+apps did directly years ago (e.g. Pinta, revolt). A helper (e.g.
+`taskcoachlib/gui/filechooser.py`) wired into `iocontroller.__ask_user_for_file`
+and `backupmanager._OnRestore` would:
+
+- In a sandbox (detected via `os.path.exists('/.flatpak-info')`), invoke
+  **`org.freedesktop.portal.FileChooser`** over D-Bus (via PyGObject / `Gio` —
+  already a dependency for the tray, so no new runtime dep) and return the chosen
+  path (a `/run/user/<uid>/doc/...` document-portal path).
+- Otherwise (Windows, macOS, or Linux outside a sandbox), fall back to
+  **`wx.FileSelector`** — wx's native dialogs are correct there.
+
+That would let the manifest drop `--filesystem=home` (the portal grants access
+per file the user picks) and clear the `finish-args-home-filesystem-access` lint,
+without making any `.tsk` unopenable.
+
+**Why it is postponed.** This shim was prototyped and then **reverted** (2026): it
+changes the single file-dialog code path that *every* user goes through on
+*every* OS — real regression risk — for a benefit that only matters inside the
+Flatpak sandbox. With the Flathub release postponed, that risk isn't worth it.
+
+**The likely free fix: wxWidgets 3.3.** When a wxPython release bundles wxWidgets
+3.3, `wx.FileSelector` will route through the portal **on its own** (no app code),
+because 3.3 uses `GtkFileChooserNative` (GTK >= 3.20, no `wxFD_PREVIEW` — which
+Task Coach's dialogs never set). At that point this TODO resolves for free and
+`--filesystem=home` can simply be dropped. So the preferred plan is to **wait for
+wx 3.3** rather than carry a hand-written shim.
+
+Sources: wxWidgets `src/gtk/filedlg.cpp` —
+[v3.2.6 (dialog only)](https://github.com/wxWidgets/wxWidgets/blob/v3.2.6/src/gtk/filedlg.cpp)
+vs [v3.3.0 (native chooser)](https://github.com/wxWidgets/wxWidgets/blob/v3.3.0/src/gtk/filedlg.cpp);
+[GtkFileChooserNative](https://docs.gtk.org/gtk3/class.FileChooserNative.html);
+[Portal support in GTK](https://docs.flatpak.org/en/latest/portals.html);
+[FileChooser portal](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.FileChooser.html);
+[wxPython tracking wxWidgets 3.3](https://discuss.wxpython.org/t/wxpython-master-branch-now-tracking-wxwidgets-3-3/40403).
 
 ### System tray (via Flathub shared-modules)
 
@@ -240,6 +325,21 @@ the Flathub
 [submission](https://docs.flathub.org/docs/for-app-authors/submission) and
 [requirements](https://docs.flathub.org/docs/for-app-authors/requirements) docs.
 
+> **Flathub release postponed (2026)** — two independent reasons:
+>
+> 1. **Flathub rejected the submission.** Flathub has been blanket-rejecting
+>    submissions it deems "AI slop," and rejected this one (prior review notes:
+>    <https://github.com/flathub/flathub/pull/8938>). So adapting the code to
+>    Flathub's required changes is **no longer relevant**.
+> 2. **We didn't want Flathub's main ask anyway.** Dropping `--filesystem=home`
+>    for the portal changes the file-dialog code path for every user on every OS
+>    (too risky), and wxPython 3.3 will likely deliver the portal for free (see
+>    [File access](#file-access-and-the-file-chooser-portal)).
+>
+> Users can install the `.flatpak` **directly from this project's GitHub
+> releases** — Flathub is not required. The prerequisites below are retained only
+> for if/when Flathub is revisited.
+
 ### Already satisfied
 
 - **App ID** `io.github.taskcoach.TaskCoach`: valid `io.github.` code-hosting
@@ -256,11 +356,14 @@ the Flathub
   (`.mime.xml` + metainfo `<provides>`), so `.tsk` files open the app.
 - **Metainfo**: id, license, developer, `content_rating`, `url`s, current 2.x
   screenshots, and a `<releases>` entry with notes.
-- **Permissions**: no notification grant; only tray, idle, and keyring
-  talk-names. Display is **X11-only** (`--socket=x11`, no wayland socket) so the
+- **Permissions**: no notification grant; only tray and idle talk-names (no
+  network, no secrets — see
+  [TODO.md §12](TODO.md#12-thunderbirdimap-mail-integration-review)). File access
+  uses **`--filesystem=home`** (the portal migration that would drop it is a
+  postponed TODO — see [File access](#file-access-and-the-file-chooser-portal)).
+  Display is **X11-only** (`--socket=x11`, no wayland socket) so the
   `finish-args-contains-both-x11-and-wayland` lint error does not apply; see the
-  finish-args table above. `--filesystem=home` is a deliberate, justified grant
-  (item 2).
+  finish-args table above.
 - **shared-modules**: pinned as a git submodule, as Flathub expects for deps.
 
 ### Required before submission
@@ -270,28 +373,21 @@ the Flathub
    pinned `type: git` (tag plus commit) or `type: archive` (release tarball plus
    `sha256`) from `github.com/taskcoach/taskcoach`. Also commit the two generated
    `python3-*.json` files there (Flathub does not generate at build time).
-2. **Justify `--filesystem=home` in review (decided: keep it).** The
-   `finish-args-home-filesystem-access` lint error is not an auto-reject; it
-   triggers reviewer discussion. We keep the grant because Task Coach is a
-   file-centric app: users open/save `.tsk` files (plus attachments and
-   HTML/CSV/iCal exports) at arbitrary paths, and wx uses its own file dialogs
-   rather than the XDG file-chooser portal, so a narrowed grant (e.g.
-   `--filesystem=xdg-documents`) would make any `.tsk` outside that folder
-   unopenable. The portal route is an upstream wx change, not a packaging tweak.
-   If a reviewer insists, narrowing is the fallback then.
-3. **Remaining lint is understood.** CI runs the `manifest`, `appstream`, and
-   `repo` checks (the same ones Flathub runs). After the X11-only change the
-   open items are exactly two: `finish-args-home-filesystem-access` (intentional,
-   item 2) and the `appstream` screenshot errors, which only fire because the
-   metainfo screenshot URLs point at `master` where the images land on merge.
-   Reproduce locally with:
+2. **Remaining lint is understood.** CI runs the `manifest`, `appstream`, and
+   `repo` checks (the same ones Flathub runs). After the X11-only change the open
+   items are: `finish-args-home-filesystem-access` (the intentional
+   `--filesystem=home` grant — not an auto-reject; it triggers reviewer
+   discussion, and the portal migration that would remove it is postponed, see
+   [File access](#file-access-and-the-file-chooser-portal)), and the `appstream`
+   screenshot errors, which only fire because the metainfo screenshot URLs point
+   at `master` where the images land on merge. Reproduce locally with:
    ```bash
    flatpak install -y flathub org.flatpak.Builder
    flatpak run --command=flatpak-builder-lint org.flatpak.Builder \
        manifest build.in/flatpak/io.github.taskcoach.TaskCoach.yaml
    flatpak run --command=flatpak-builder-lint org.flatpak.Builder repo repo
    ```
-4. **Verify ID ownership.** Ownership of `io.github.taskcoach.*` is proven by
+3. **Verify ID ownership.** Ownership of `io.github.taskcoach.*` is proven by
    signing into Flathub with the GitHub account that controls
    `github.com/taskcoach`. That account needs **2FA** enabled (required to accept
    write access to the per-app repo after merge).

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -40,7 +40,7 @@ This document describes the packaging setup for Task Coach on Linux (Debian, Ubu
 
 This table shows how dependencies are handled in **built packages** and **setup scripts**.
 
-| Package | debian12 | ubuntu22 | debian13 | ubuntu24 | arch | fedora | appimage | flatpak | windows | macos |
+| Package | debian12 | ubuntu22 | debian13 | ubuntu24 | arch | fedora | appimage | ~~flatpak~~ | windows | macos |
 |---------|:--------:|:--------:|:--------:|:--------:|:----:|:------:|:--------:|:-------:|:-------:|:-----:|
 | wxpython | distro | distro | distro | distro | distro | distro | bundled | bundled | pip | pip |
 | pypubsub | distro | distro | distro | distro | AUR | distro | bundled | bundled | pip | pip |
@@ -70,6 +70,7 @@ This table shows how dependencies are handled in **built packages** and **setup 
 - `pip` = Bundled via pip in package build (version too old or not in repos)
 - `patch` = Bundled patch in `taskcoachlib/patches/` (wxPython hypertreelist fix)
 - `bundled` = Bundled in package (thirdparty/ for .deb/.rpm, inside the AppImage, or built into the Flatpak). For Flatpak this means pip-installed or built as a manifest module at build time; the base Python, GTK and PyGObject come from the GNOME runtime, not from these rows.
+- ~~`flatpak`~~ (struck through) = **Flathub release postponed** (2026); the Flatpak build still works for a direct `.flatpak` install but is not actively published — see [Flatpak Packaging](#flatpak-packaging).
 - `host` = Uses host system library (AppImage); install on host for Wayland tray support
 - `AUR` = Arch User Repository (rolling release)
 - `—` = Not applicable for this platform
@@ -108,7 +109,7 @@ backends.
 | [Manjaro](#arch-linux--manjaro-packaging) | arch | latest | latest | `setup_arch.sh` | `build-arch.yml` | pip: squaremap; pypubsub from AUR |
 | [Fedora 43](#fedora-packaging) | fedora43 | 3.13 | 4.2.2 | `setup_fedora.sh` | `build-rpm.yml` | pip: squaremap, pyparsing |
 | [**AppImage**](#appimage-packaging) | appimage | **3.11** | **4.2.4** | — | `build-appimage.yml` | Bundles Python + all deps |
-| [**Flatpak**](#flatpak-packaging) | flatpak | runtime | **source** | `scripts/build-flatpak.sh` | `build-flatpak.yml` | GNOME runtime; wxPython from sdist (builds its own bundled wxWidgets) |
+| [~~**Flatpak**~~](#flatpak-packaging) | flatpak | runtime | **source** | `scripts/build-flatpak.sh` | `build-flatpak.yml` | **Flathub release postponed**; GNOME runtime; wxPython from sdist (builds its own bundled wxWidgets) |
 | [**Windows**](#windows-packaging) | windows | **3.11** | **4.2.x** | — | `build-windows.yml` | Python embed + Inno Setup |
 | [**macOS**](#macos-packaging) | macos | **3.11** | **4.2.x** | — | `build-macos.yml` | py2app + DMG (Intel & ARM64) |
 
@@ -486,6 +487,8 @@ For detailed AppImage documentation including library bundling strategy, design 
 
 The Flatpak build is offered **in addition to** the AppImage. It runs against the **GNOME runtime** (`org.gnome.Platform`), which supplies a consistent GTK / glib / PyGObject stack, so the library-bundling and ABI problems the AppImage fights do not exist here. The trade is that users need `flatpak` installed and the runtime is fetched on first install.
 
+> **Flathub release postponed (2026).** Flathub has been blanket-rejecting submissions it deems "AI slop" and **rejected this one**, so complying with its required changes is no longer relevant — and we didn't want its main ask anyway (dropping `--filesystem=home` for the portal changes file access for all users on every OS; too risky, and wxPython 3.3 should deliver the portal automatically). The `.flatpak` is available **directly from this project's GitHub releases**, so Flathub is not required. Details and prior review notes: [FLATPAK.md](FLATPAK.md).
+
 ### Available Builds
 
 | Build | Runtime | Architecture | Target |
@@ -505,7 +508,7 @@ The GNOME runtime bundles GTK3, PyGObject and gobject-introspection. Task Coach 
 
 ### Status
 
-The single manifest builds **offline**, the way Flathub builds: no `--share=network`, with every Python dependency pinned (`generate-pip-sources.sh`). wxPython is built from the sdist, letting it compile its own bundled wxWidgets (guaranteeing the version matches its pre-generated bindings, since no prebuilt wxPython wheel works under the runtime), with checksums verified against the official artifacts. System-tray support comes from Flathub's `shared-modules` libappindicator (git submodule), and optional idle detection from bundled `dbus-python`. X11 is prioritized over Wayland (wxPython AUI docking is unusable on Wayland). Remaining for a Flathub submission: pin the app source (`type: dir` -> `git`/`archive`) and narrow `--filesystem=home`.
+The single manifest builds **offline**, the way Flathub builds: no `--share=network`, with every Python dependency pinned (`generate-pip-sources.sh`). wxPython is built from the sdist, letting it compile its own bundled wxWidgets (guaranteeing the version matches its pre-generated bindings, since no prebuilt wxPython wheel works under the runtime), with checksums verified against the official artifacts. System-tray support comes from Flathub's `shared-modules` libappindicator (git submodule), and optional idle detection from bundled `dbus-python`. X11 is prioritized over Wayland (wxPython AUI docking is unusable on Wayland). File access uses `--filesystem=home`; migrating it to the XDG FileChooser portal is a postponed TODO (likely automatic with wxPython 3.3). **The Flathub release is postponed** — remaining work and prior review notes are in [FLATPAK.md](FLATPAK.md).
 
 For detailed Flatpak documentation including the runtime choice, permission rationale, offline pinned-source generation, the wxPython risk, build process, and Flathub submission, see **[FLATPAK.md](FLATPAK.md)**.
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15,6 +15,7 @@ This document tracks planned improvements and known issues to address in future 
 9. [Preferences Page Alignment Overrides](#9-preferences-page-alignment-overrides) *(Done)*
 10. [Preferences Dialog: Dirty-Check and Button State](#10-preferences-dialog-dirty-check-and-button-state)
 11. [EVT_TEXT Compatibility Shim in MultiLineTextCtrl](#11-evt_text-compatibility-shim-in-multilinetextctrl)
+12. [Thunderbird/IMAP Mail Integration Review](#12-thunderbirdimap-mail-integration-review)
 Signaling system cleanup has moved to
 [PUBLISHER_OBSERVER.md](PUBLISHER_OBSERVER.md#signaling-system-cleanup).
 
@@ -418,4 +419,56 @@ No need to store "original values" — the settings object is the baseline.
 
 ---
 
-**Last Updated:** March 2026
+## 12. Thunderbird/IMAP Mail Integration Review
+
+There seems to be a legacy Thunderbird email-drop integration that is likely
+non-functional and/or dead code. It needs review and, if confirmed dead,
+removal.
+
+### What it is
+
+- `taskcoachlib/mailer/thunderbird.py` retrieves a dropped Thunderbird message
+  over **IMAP** (`imaplib.IMAP4_SSL`).
+- To authenticate it calls `GetPassword()` (`taskcoachlib/widgets/password.py`),
+  which stores/reads the mail-account password in the system keyring via the
+  `keyring` module → the freedesktop Secret Service.
+- This is the **only** live consumer of the keyring/secrets path
+  (`iocontroller.py` imports `GetPassword` but never calls it; no other caller
+  exists).
+
+### Questions to answer
+
+1. Is the "drag a Thunderbird email onto a task" feature still wired into the UI
+   and working against current Thunderbird (URL format, IMAP, modern auth)?
+2. Is the IMAP/keyring path ever reached in practice, or is it dead?
+3. If dead: remove the IMAP path in `thunderbird.py`, the keyring usage in
+   `password.py`, and the optional `keyring` / `python3-dbus` dependencies.
+
+### Flatpak cross-reference
+
+The Flatpak build deliberately grants **neither** `--share=network` **nor**
+`--talk-name=org.freedesktop.secrets`, because this likely-dead mail feature is
+their only consumer — see [FLATPAK.md](FLATPAK.md) (finish-args). If the feature
+is revived, secret handling must go through the **Secret portal**
+(`org.freedesktop.portal.Secret`), **not** a direct
+`--talk-name=org.freedesktop.secrets` grant; the network access would also need a
+fresh review.
+
+### Related references
+
+- [PYTHON3_MIGRATION_2.md](PYTHON3_MIGRATION_2.md) kept the NTLM/IMAP auth code
+  (`thirdparty/ntlm/IMAPNtlmAuthHandler.py`) as "actively used" by
+  `thunderbird.py` (Nov 2025). That is **import-level** reachability, not a
+  verification that the drag-an-email feature actually works for a user today —
+  which is exactly what this review must establish.
+- A separate **outgoing** "Mail" command (mail a task) exists
+  ([MENUS.md](MENUS.md), [LIST_MANAGEMENT.md](LIST_MANAGEMENT.md)); it is
+  distinct from this **incoming** IMAP email-drop and uses neither IMAP nor the
+  keyring. Don't conflate the two when reviewing.
+- macOS Thunderbird-profile path logic exists ([MACOS.md](MACOS.md)).
+
+**Status:** Needs investigation
+
+---
+
+**Last Updated:** June 2026


### PR DESCRIPTION
Flathub release is postponed for two reasons: Flathub blanket-rejects submissions it deems "AI slop" and rejected this one (PR #8938), so complying with its required changes is no longer relevant; and we did not want its main ask anyway — dropping --filesystem=home for the XDG FileChooser portal changes the file-dialog code path for all users on every OS (too risky), and wxPython 3.3 is expected to deliver the portal automatically. The .flatpak is distributed directly from this project's GitHub releases; Flathub is not required. The portal migration is recorded as a postponed TODO in the Flatpak docs.

- Manifest: strip the verbose comments; drop the unused --talk-name=org.freedesktop.secrets grant (its only consumer is a likely-dead Thunderbird/IMAP mail feature; a revival must use the Secret portal). Keep --filesystem=home.
- docs/FLATPAK.md: portal migration as a postponed TODO; corrected permission and submission notes; prior Flathub review notes (PR #8938).
- docs/PACKAGING.md: grey out the postponed Flatpak column/row.
- docs/TODO.md: add the Thunderbird/IMAP mail-integration review (section 12).
- build.in/flatpak/flathub/README.md: mark submission postponed; manual sync.
- CONTRIBUTING.md: document the black / flake8 code-style policy.