### PR TITLE
Fix/windows scrollbar adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,20 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.18-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.18-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.18_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.18_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.18_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.18-fedora43.rpm` |
-| [Flatpak (any Linux)](#flatpak) | `TaskCoach-2.0.2.18-x86_64.flatpak` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.19-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.19-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.19_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.19_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.19_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.19-fedora43.rpm` |
+| [Flatpak (any Linux)](#flatpak) | `TaskCoach-2.0.2.19-x86_64.flatpak` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.18-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.18-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.18_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.18_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.2.18-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.2.18-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.19-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.19-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.19_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.19_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.2.19-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.2.19-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -43,8 +43,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.18_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.2.18_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.19_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.2.19_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -57,8 +57,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.18-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.2.18-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.19-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.2.19-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -71,8 +71,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.18-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.2.18-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.19-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.2.19-fedora43.rpm
 ```
 
 To uninstall:
@@ -87,13 +87,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.18-x86_64.AppImage
-chmod +x TaskCoach-2.0.2.18-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.19-x86_64.AppImage
+chmod +x TaskCoach-2.0.2.19-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.2.18-x86_64.AppImage
+./TaskCoach-2.0.2.19-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.
@@ -105,8 +105,8 @@ the first install pulls the GNOME runtime from Flathub.
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.18-x86_64.flatpak
-flatpak install ./TaskCoach-2.0.2.18-x86_64.flatpak
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.19-x86_64.flatpak
+flatpak install ./TaskCoach-2.0.2.19-x86_64.flatpak
 flatpak run io.github.taskcoach.TaskCoach
 ```
 

--- a/docs/LIST_MANAGEMENT.md
+++ b/docs/LIST_MANAGEMENT.md
@@ -11,7 +11,8 @@
 7. [Selection-Driven Button Enable/Disable](#selection-driven-button-enabledisable)
 8. [Tree Mode Button Enable/Disable](#tree-mode-button-enabledisable)
 9. [Scroll After Rebuild (Tree Views)](#scroll-after-rebuild-tree-views)
-9. [Row Hover Outline](#row-hover-outline)
+10. [Windows: Scrollbar Adjustment on Content Changes](#windows-scrollbar-adjustment-on-content-changes)
+11. [Row Hover Outline](#row-hover-outline)
 10. [Mouse-Move Handler Inventory (Tree Views)](#mouse-move-handler-inventory-tree-views)
 11. [Vampire CPU Usage](#vampire-cpu-usage)
 12. [AUI Sash Resize Throttle](#aui-sash-resize-throttle)
@@ -282,45 +283,48 @@ This is an upstream design limitation (same in wxPython 4.2.0 and current master
 
 Both methods live on the tree control subclass in `treectrl.py`. Both call `AdjustMyScrollbars()` before scrolling to fix the stale range.
 
-**`scrollToSelection()`** — Minimal scroll to make first selected item visible.
-- Called from: `treectrl.py:RefreshAllItems()` — fires for ALL callers (init, file load, expand/collapse, sort, etc.)
-- Reference: `treectrl.py:TreeListCtrl.scrollToSelection`
+**`scroll_to_selection()`** - Minimal scroll to make first selected item visible.
+- Called from: `treectrl.py:RefreshAllItems()` - fires for ALL callers (init, file load, expand/collapse, sort, etc.)
+- Reference: `treectrl.py:TreeListCtrl.scroll_to_selection`
 
-**`scrollToSelectionCentered()`** — Centers viewport on first selected item.
-- Called from: `base.py:onPresentationChanged()` — fires only on add/remove events (filter toggle, search, category filter), batched by `@eventSource`
-- Overrides the position set by `scrollToSelection()` in the same flow
-- Reference: `treectrl.py:TreeListCtrl.scrollToSelectionCentered`
+**`scroll_to_selection_centered()`** - Centers viewport on first selected item.
+- Called from: `base.py:on_presentation_changed()` - fires only on add/remove events (filter toggle, search, category filter)
+- Overrides the position set by `scroll_to_selection()` in the same flow
+- Reference: `treectrl.py:TreeListCtrl.scroll_to_selection_centered`
 
 ### Flow
 
 **Filter toggle / search / category filter / add / delete** — fires add/remove events:
 ```
-onPresentationChanged (base.py)
-  → refresh()
-    → widget.RefreshAllItems() (treectrl.py)
-      → Freeze → DeleteAll → Add → Thaw → restore selection
-      → scrollToSelection()                    ← ensure-visible
-  → scrollToSelectionCentered()                ← center on selected
+on_presentation_changed (base.py)
+  -> refresh()
+    -> widget.RefreshAllItems() (treectrl.py)
+      -> Freeze -> DeleteAll -> Add -> Thaw -> restore selection
+      -> scroll_to_selection()                 (ensure-visible)
+  -> scroll_to_selection_centered()            (center on selected)
 ```
 
-**Mode switch (list ↔ tree)** — fires sort event, NOT add/remove:
+**Mode switch (list <-> tree)** - fires sort event, NOT add/remove:
 ```
 viewer.set_tree_mode(value) (task.py)
-  → settings.setboolean(...)                 ← persistence
-  → presentation().set_tree_mode(value)
-    → Sorter.reset() → fires sortEventType (NOT add/remove)
-      → onSortOrderChanged (mixin.py) → refresh()
-        → widget.RefreshAllItems()
-          → scrollToSelection()              ← ensure-visible
-  → scrollToSelectionCentered()              ← center on selected (explicit)
-  → patterns.Event(...).send()               ← Publisher event
-    → dropdown: set_choice(value)
-    → buttons: EnableTool(id, value)
+  -> settings.setboolean(...)                (persistence)
+  -> presentation().set_tree_mode(value)
+    -> Sorter.reset() -> fires sort_event_type (NOT add/remove)
+      -> on_sort_order_changed (mixin.py) -> refresh()
+        -> widget.RefreshAllItems()
+          -> scroll_to_selection()           (ensure-visible, selection-gated)
+  -> widget._schedule_scrollbar_adjustment() (recompute range, deferred on Windows)
+  -> scroll_to_selection_centered()          (center on selected, selection-gated)
+  -> patterns.Event(...).send()              (Publisher event)
+    -> dropdown: set_choice(value)
+    -> buttons: EnableTool(id, value)
 ```
-Note: `Sorter.reset()` fires `pub.sendMessage(self.sortEventType())`, not add/remove
-events, so `onPresentationChanged` does NOT fire. The centering call is explicit in
-`set_tree_mode`. The Publisher event syncs the toolbar dropdown and expand/collapse
-buttons — see [PUBLISHER_OBSERVER.md — Case Study: Tree Mode Toggle](PUBLISHER_OBSERVER.md#case-study-tree-mode-toggle)
+Note: `Sorter.reset()` fires `pub.sendMessage(self.sort_event_type())`, not add/remove
+events, so `on_presentation_changed` does NOT fire. Because the rebuild's own recompute
+(`scroll_to_selection`) is synchronous and gated on a non-empty selection, `set_tree_mode`
+also calls `_schedule_scrollbar_adjustment()` to recompute the scrollbar range
+unconditionally (deferred on Windows). The Publisher event syncs the toolbar dropdown and
+expand/collapse buttons, see [PUBLISHER_OBSERVER.md - Case Study: Tree Mode Toggle](PUBLISHER_OBSERVER.md#case-study-tree-mode-toggle)
 for the full signal flow.
 
 ### Scroll Behavior by User Action
@@ -330,22 +334,71 @@ List-only viewers (effort, attachments) always use `ensureSelectionVisible` (nat
 
 | User Action                     | Scroll Behavior | Path                                     |
 |---------------------------------|-----------------|------------------------------------------|
-| Toggle status filter            | Center          | `onPresentationChanged` → centered       |
-| Toggle category filter          | Center          | `onPresentationChanged` → centered       |
-| Clear/change search text        | Center          | `onPresentationChanged` → centered       |
-| Switch list ↔ tree mode         | Center          | `set_tree_mode` → explicit centered |
-| Delete selected item            | Center          | `onPresentationChanged` → centered       |
-| Add new item                    | Center          | `onPresentationChanged` → centered       |
-| Window resize                   | Center          | `EVT_SIZE` → `CallAfter` → centered     |
-| Sort change                     | Ensure-visible  | `refresh()` only, no `onPresentationChanged` |
-| Expand all / Collapse all       | Ensure-visible  | `refresh()` only, no `onPresentationChanged` |
+| Toggle status filter            | Center          | `on_presentation_changed` -> centered    |
+| Toggle category filter          | Center          | `on_presentation_changed` -> centered    |
+| Clear/change search text        | Center          | `on_presentation_changed` -> centered    |
+| Switch list <-> tree mode       | Center          | `set_tree_mode` -> `_schedule_scrollbar_adjustment` (range) + centered |
+| Delete selected item            | Center          | `on_presentation_changed` -> centered    |
+| Add new item                    | Center          | `on_presentation_changed` -> centered    |
+| Window resize                   | Center          | `EVT_SIZE` -> `CallAfter` -> centered    |
+| Sort change                     | Ensure-visible  | `refresh()` only, no `on_presentation_changed` |
+| Expand all / Collapse all       | Ensure-visible  | `refresh()` only, no `on_presentation_changed` |
 | Item edit (attribute change)    | No scroll       | `RefreshItems()`, not `RefreshAllItems`  |
 | File load                       | Ensure-visible  | `onEndIO` → `refresh()` only             |
 | Initial startup                 | Ensure-visible  | `__init__` → `refresh()` only            |
 
-**Center** = `scrollToSelectionCentered()` — viewport centers on first selected item
-**Ensure-visible** = `scrollToSelection()` — minimal scroll, just makes item visible
+**Center** = `scroll_to_selection_centered()` - viewport centers on first selected item
+**Ensure-visible** = `scroll_to_selection()` - minimal scroll, just makes item visible
 **No scroll** = individual rows refreshed in place, no scroll change
+
+---
+
+## Windows: Scrollbar Adjustment on Content Changes
+
+### Problem
+
+On Windows, tree/list viewer scrollbars do not update when expanding/collapsing/adding/deleting tasks, or switching between tree and list views. Scrollbars only update on window resize. This does not occur on Linux/GTK or macOS.
+
+### Root Cause
+
+The scrollbar range is only ever recomputed by `AdjustMyScrollbars()`, and that recompute is gated. On the expand path it runs only through the upstream `RefreshSubtree()`, which returns early when the tree is marked dirty or frozen. `AdjustMyScrollbars()` itself becomes a no-op (it just sets the dirty flag) while frozen, and the dirty flag is cleared only by the upstream `OnInternalIdle()`. On a settled GTK tree the recompute fires synchronously, which is why Linux is unaffected. On Windows the recompute is missed when content changes while the tree is dirty or frozen, or before idle runs, and a synchronous `AdjustMyScrollbars()` does not reliably take effect until after the layout cycle. Deferring the call (see below) lets it run after that dirty/frozen state has cleared.
+
+### Fix: Deferred Scrollbar Adjustment
+
+A new method `_schedule_scrollbar_adjustment()` on `TreeListCtrl` (`treectrl.py`) handles the platform difference:
+
+- **Windows**: Uses `wx.CallAfter()` to defer scrollbar adjustment until after the event queue empties and the layout/idle cycle has cleared the dirty/frozen state
+- **Other platforms**: Adjusts immediately (the deferral is harmless and ensures consistency)
+
+Called from:
+- `_expandDropTarget()` — after explicit expand on drag-drop
+- `on_item_expanding()` — after lazy-loading children when item expands
+- `TreeViewer.on_item_expanded()` / `on_item_collapsed()` — after individual expand/collapse events
+- `TreeViewer.expand_all()` / `collapse_all()` — after bulk expand/collapse operations
+- `_refresh_all_items_in_place()` — after in-place content refresh without tree rebuild
+- `TaskViewer.set_tree_mode()` — after a tree<->list switch (see note below)
+
+#### Why the tree<->list switch needs its own call
+
+Switching mode rebuilds the widget through `_do_full_rebuild()`, whose only scrollbar recompute is `scroll_to_selection()` / `scroll_to_selection_centered()`. Both are **synchronous** and **gated on `if selections:`** (`treectrl.py`), so on Windows the range is not recomputed reliably (synchronous adjustment misses the post-layout cycle, and an empty selection skips it entirely). Unlike add/delete, the switch fires a sort event rather than an add/remove event, so `on_presentation_changed()` never runs and never supplies its own adjustment. `set_tree_mode()` therefore calls `_schedule_scrollbar_adjustment()` explicitly — the deferred, unconditional adjustment that already fixes the other cases. This was the one path that remained broken on Windows after the initial fix; confirmed fixed by Windows testing.
+
+### Scroll Behavior (Updated Table)
+
+All tree-based viewers now adjust scrollbars consistently on all platforms:
+
+| User Action                     | Scroll Behavior | Windows | Other Platforms |
+|---------------------------------|-----------------|---------|-----------------|
+| Expand single item              | Ensure-visible  | Deferred via `CallAfter` | Immediate |
+| Collapse single item            | Ensure-visible  | Deferred via `CallAfter` | Immediate |
+| Expand all                      | Ensure-visible  | Deferred via `CallAfter` | Immediate |
+| Collapse all                    | Ensure-visible  | Deferred via `CallAfter` | Immediate |
+| Switch tree <-> list            | Center          | Deferred via `CallAfter` | Immediate |
+
+(Other scroll behaviors unchanged — see previous table above)
+
+### Related Issues
+
+See [Scroll After Rebuild (Tree Views)](#scroll-after-rebuild-tree-views) for scrollbar stale-range issues after freeze/thaw rebuild cycles.
 
 ---
 

--- a/taskcoachlib/gui/viewer/base.py
+++ b/taskcoachlib/gui/viewer/base.py
@@ -77,8 +77,9 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         self.widget.SetBackgroundColour(
             wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOW)
         )
-        self.toolbar = toolbar.ToolBar(self, settings,
-                                       (toolbar.TOOLBAR_ICON_SIZE,) * 2)
+        self.toolbar = toolbar.ToolBar(
+            self, settings, (toolbar.TOOLBAR_ICON_SIZE,) * 2
+        )
         self.init_layout()
         self.register_presentation_observers()
         self.refresh()
@@ -88,7 +89,9 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         pub.subscribe(self.on_end_io, "taskfile.justRead")
         pub.subscribe(self.on_end_io, "taskfile.justCleared")
         # Subscribe to bulk operation signals to freeze/thaw during batch updates
-        pub.subscribe(self.on_begin_bulk_operation, "command.aboutToBulkModify")
+        pub.subscribe(
+            self.on_begin_bulk_operation, "command.aboutToBulkModify"
+        )
         pub.subscribe(self.on_end_bulk_operation, "command.justBulkModified")
 
         wx.CallAfter(self.__DisplayBalloon)
@@ -140,8 +143,11 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         self.__presentation.thaw()
         if self.__freezeCount == 0 and self.__pendingRefreshItems:
             # Refresh only items that changed during the bulk operation
-            items = [item for item in self.__pendingRefreshItems
-                     if item in self.presentation()]
+            items = [
+                item
+                for item in self.__pendingRefreshItems
+                if item in self.presentation()
+            ]
             self.__pendingRefreshItems.clear()
             if items:
                 self.widget.RefreshItems(*items)
@@ -205,7 +211,7 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
             else:
                 observers.append(observable)
         for observer in observers:
-            if hasattr(observer, 'removeInstance'):
+            if hasattr(observer, "removeInstance"):
                 observer.removeInstance()
 
         for popup_menu in self._popupMenus:
@@ -213,14 +219,19 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
                 popup_menu.clearMenu()
                 popup_menu.Destroy()
             except RuntimeError:
-                log_step("detach: popup menu already dead %x" %
-                         id(popup_menu), prefix="DEAD-OBJ", exc=True)
+                log_step(
+                    "detach: popup menu already dead %x" % id(popup_menu),
+                    prefix="DEAD-OBJ",
+                    exc=True,
+                )
 
         pub.unsubscribe(self.on_begin_io, "taskfile.aboutToRead")
         pub.unsubscribe(self.on_begin_io, "taskfile.aboutToClear")
         pub.unsubscribe(self.on_end_io, "taskfile.justRead")
         pub.unsubscribe(self.on_end_io, "taskfile.justCleared")
-        pub.unsubscribe(self.on_begin_bulk_operation, "command.aboutToBulkModify")
+        pub.unsubscribe(
+            self.on_begin_bulk_operation, "command.aboutToBulkModify"
+        )
         pub.unsubscribe(self.on_end_bulk_operation, "command.justBulkModified")
 
         self.presentation().detach()
@@ -238,14 +249,14 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
     @property
     def has_selection(self):
         w = self.widget
-        if hasattr(w, 'has_selection'):
+        if hasattr(w, "has_selection"):
             return w.has_selection
         return bool(w.curselection())
 
     @property
     def has_single_selection(self):
         w = self.widget
-        if hasattr(w, 'has_single_selection'):
+        if hasattr(w, "has_single_selection"):
             return w.has_single_selection
         return len(w.curselection()) == 1
 
@@ -299,7 +310,9 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         self._sizer = wx.BoxSizer(wx.VERTICAL)  # pylint: disable=W0201
         self._sizer.Add(self.toolbar, flag=wx.EXPAND)
         self._sizer.Add(self.widget, proportion=1, flag=wx.EXPAND)
-        self.SetSizer(self._sizer)  # Changed from SetSizerAndFit to prevent locking MinSize
+        self.SetSizer(
+            self._sizer
+        )  # Changed from SetSizerAndFit to prevent locking MinSize
         # Prevent GetEffectiveMinSize() from returning child's BestSize
         self.SetMinSize((100, 50))
         # Bind click events to activate pane when clicking on toolbar/empty space
@@ -318,9 +331,12 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         try:
             self.widget.SetFocus(*args, **kwargs)
         except RuntimeError as e:
-            log_step("SetFocus on dead widget %s: %s" %
-                     (self.__class__.__name__, e), prefix="DEAD-OBJ",
-                     exc=True)
+            log_step(
+                "SetFocus on dead widget %s: %s"
+                % (self.__class__.__name__, e),
+                prefix="DEAD-OBJ",
+                exc=True,
+            )
 
     def create_sorter(self, collection):
         """This method can be overridden to decorate the presentation with a
@@ -371,13 +387,18 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         self.refresh()
 
         # AFTER refresh - select next if selection became empty
-        if items_removed() and hasattr(self.widget, 'curselection') and not self.widget.curselection() and selection_info:
+        if (
+            items_removed()
+            and hasattr(self.widget, "curselection")
+            and not self.widget.curselection()
+            and selection_info
+        ):
             self.selectNextItemsAfterRemoval(selection_info)
         # Center on selected item — tree views use scroll_to_selection_centered,
         # list views use ensureSelectionVisible (native wx scrollbar management)
-        if hasattr(self.widget, 'scroll_to_selection_centered'):
+        if hasattr(self.widget, "scroll_to_selection_centered"):
             self.widget.scroll_to_selection_centered()
-        elif hasattr(self.widget, 'ensureSelectionVisible'):
+        elif hasattr(self.widget, "ensureSelectionVisible"):
             self.widget.ensureSelectionVisible()
         self.send_viewer_status_event()
 
@@ -412,17 +433,18 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
                 return
 
             # Fire selection signal — toolbar buttons subscribe via _SelectionSync
-            patterns.Event(
-                self.selection_changed_event_type(), self
-            ).send()
+            patterns.Event(self.selection_changed_event_type(), self).send()
 
             # Fire status event - StatusBar has its own 500ms debounce
             # No need to query selection here; status bar queries fresh when displaying
             wx.CallAfter(self.send_viewer_status_event)
         except RuntimeError as e:
-            log_step("onSelect on dead viewer %s: %s" %
-                     (self.__class__.__name__, e), prefix="DEAD-OBJ",
-                     exc=True)
+            log_step(
+                "onSelect on dead viewer %s: %s"
+                % (self.__class__.__name__, e),
+                prefix="DEAD-OBJ",
+                exc=True,
+            )
 
     def updateSelection(self, send_status_event=True):
         """Legacy method - kept for subclass compatibility.
@@ -617,7 +639,11 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         modeToolBarUICommands = self.createModeToolBarUICommands()
 
         def separator(uiCommands, *otherUICommands):
-            return (uicommand.Separator(),) if (uiCommands and any(otherUICommands)) else ()
+            return (
+                (uicommand.Separator(),)
+                if (uiCommands and any(otherUICommands))
+                else ()
+            )
 
         clipboardSeparator = separator(
             clipboardToolBarUICommands,
@@ -768,9 +794,7 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         return command.CutCommand
 
     def pasteItemCommand(self):
-        return self.pasteItemCommandClass()(
-            self.presentation()
-        )
+        return self.pasteItemCommandClass()(self.presentation())
 
     def pasteItemCommandClass(self):
         return command.PasteCommand
@@ -854,9 +878,11 @@ class TreeViewer(Viewer):  # pylint: disable=W0223
 
     def on_item_expanded(self, event):
         self.__handleExpandedOrCollapsedItem(event, expanded=True)
+        self.widget._schedule_scrollbar_adjustment()
 
     def on_item_collapsed(self, event):
         self.__handleExpandedOrCollapsedItem(event, expanded=False)
+        self.widget._schedule_scrollbar_adjustment()
 
     def __handleExpandedOrCollapsedItem(self, event, expanded):
         event.Skip()
@@ -874,6 +900,7 @@ class TreeViewer(Viewer):  # pylint: disable=W0223
         for item in self.visibleItems():
             item.expand(True, context=self.settingsSection(), notify=False)
         self.refresh()
+        self.widget._schedule_scrollbar_adjustment()
 
     def collapse_all(self):
         """Collapse all items, recursively."""
@@ -882,7 +909,7 @@ class TreeViewer(Viewer):  # pylint: disable=W0223
         for item in self.visibleItems():
             item.expand(False, context=self.settingsSection(), notify=False)
         self.refresh()
-
+        self.widget._schedule_scrollbar_adjustment()
 
     def createModeToolBarUICommands(self):
         return super().createModeToolBarUICommands() + (
@@ -907,31 +934,31 @@ class TreeViewer(Viewer):  # pylint: disable=W0223
 
     def _captureSelectionInfo(self):
         """Capture selection position before refresh."""
-        if not hasattr(self.widget, 'curselection'):
+        if not hasattr(self.widget, "curselection"):
             return None
         curselection = self.widget.curselection()
         if curselection and curselection[0] is not None:
             selectedItem = curselection[0]
             parent = self.getItemParent(selectedItem)
             siblings = self.children(parent)
-            index = siblings.index(selectedItem) if selectedItem in siblings else 0
-            return {'parent': parent, 'index': index}
+            index = (
+                siblings.index(selectedItem) if selectedItem in siblings else 0
+            )
+            return {"parent": parent, "index": index}
         return None
 
     def selectNextItemsAfterRemoval(self, selectionInfo):
         """Select next item using position captured before refresh."""
         if not selectionInfo:
             return
-        parent = selectionInfo['parent']
-        index = selectionInfo['index']
+        parent = selectionInfo["parent"]
+        index = selectionInfo["index"]
         # Parent might have been deleted too - check if still in presentation
         if parent is not None and parent not in self.presentation():
             parent = None
         siblings = self.children(parent)
         newSelection = (
-            siblings[min(len(siblings) - 1, index)]
-            if siblings
-            else parent
+            siblings[min(len(siblings) - 1, index)] if siblings else parent
         )
         if newSelection:
             self.select([newSelection])
@@ -1191,10 +1218,18 @@ class ViewerWithColumns(Viewer):  # pylint: disable=W0223
 
     def subjectImageIndices(self, item):
         normal_icon_id = item.icon_id(recursive=True)
-        selected_icon_id = item.selected_icon_id(recursive=True) or normal_icon_id
-        normalImageIndex = image_list_cache.get_index(normal_icon_id) if normal_icon_id else -1
+        selected_icon_id = (
+            item.selected_icon_id(recursive=True) or normal_icon_id
+        )
+        normalImageIndex = (
+            image_list_cache.get_index(normal_icon_id)
+            if normal_icon_id
+            else -1
+        )
         selectedImageIndex = (
-            image_list_cache.get_index(selected_icon_id) if selected_icon_id else -1
+            image_list_cache.get_index(selected_icon_id)
+            if selected_icon_id
+            else -1
         )
         return {
             wx.TreeItemIcon_Normal: normalImageIndex,
@@ -1296,7 +1331,9 @@ class SortableViewerWithColumns(
                 break
 
     def show_sort_order(self):
-        self.widget.show_sort_order(image_list_cache.get_index(self.get_sort_order_image()))
+        self.widget.show_sort_order(
+            image_list_cache.get_index(self.get_sort_order_image())
+        )
 
     def get_sort_order_image(self):
         # Arrow points in direction of sort: down for A→Z/old→new, up for Z→A/new→old

--- a/taskcoachlib/gui/viewer/task.py
+++ b/taskcoachlib/gui/viewer/task.py
@@ -2031,8 +2031,15 @@ class TaskViewer(
         self.settings.setboolean(self.settingsSection(), "treemode", value)
         self.presentation().set_tree_mode(value)
         # Mode switch goes through Sorter.reset() which fires a sort event
-        # (not add/remove), so onPresentationChanged doesn't fire.
-        # Center on selected item explicitly.
+        # (not add/remove), so onPresentationChanged doesn't fire. The rebuild
+        # recomputes scrollbars only through scroll_to_selection, which is
+        # gated on there being a selection and runs synchronously. On Windows
+        # the range must be recomputed unconditionally and after the layout
+        # settles, so reuse the same deferred adjustment that fixes
+        # expand/collapse/add/delete.
+        if hasattr(self.widget, "_schedule_scrollbar_adjustment"):
+            self.widget._schedule_scrollbar_adjustment()
+        # Center on selected item explicitly (no-op if nothing is selected).
         if hasattr(self.widget, 'scroll_to_selection_centered'):
             self.widget.scroll_to_selection_centered()
         patterns.Event(

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -44,8 +44,8 @@ import re
 # =============================================================================
 
 version = "2.0.2"  # Major.Minor.Milestone
-patch = "18"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.2.18
+patch = "19"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.2.19
 
 release_day = "9"  # Day of the release (1-31)
 release_month = "June"  # Month of the release

--- a/taskcoachlib/widgets/treectrl.py
+++ b/taskcoachlib/widgets/treectrl.py
@@ -21,7 +21,6 @@ from wx.lib.agw import customtreectrl as customtree, hypertreelist
 from taskcoachlib.widgets import itemctrl, draganddrop
 import wx
 
-
 # pylint: disable=E1101,E1103
 
 
@@ -37,7 +36,7 @@ class BaseHyperTreeList(hypertreelist.HyperTreeList):
         validator=wx.DefaultValidator,
         name="HyperTreeList",
         *args,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             parent, id, pos, size, style, agwStyle, validator, name
@@ -66,13 +65,43 @@ class BaseHyperTreeList(hypertreelist.HyperTreeList):
             main_win = self.GetMainWindow()
             if main_win:
                 main_win.AdjustMyScrollbars()
-                if hasattr(self, 'scroll_to_selection_centered'):
+                if hasattr(self, "scroll_to_selection_centered"):
                     self.scroll_to_selection_centered()
         except RuntimeError:
             # wrapped C/C++ object has been deleted
             from taskcoachlib.meta.debug import log_step
-            log_step('__onSize failed - widget already destroyed',
-                     prefix='DEAD-OBJ')
+
+            log_step(
+                "__onSize failed - widget already destroyed", prefix="DEAD-OBJ"
+            )
+
+    def _schedule_scrollbar_adjustment(self):
+        """Schedule scrollbar adjustment for after event processing completes.
+
+        On Windows, content changes (expand/collapse/add/delete) that don't
+        trigger window resize don't update scrollbars. Use wx.CallAfter to
+        defer adjustment until after the event cycle completes. Other platforms
+        handle this automatically through their event processing, but the
+        deferred call is harmless and ensures consistency.
+        """
+        if operating_system.isWindows():
+            wx.CallAfter(self.__safe_adjust_scrollbars_content_change)
+        else:
+            self.__safe_adjust_scrollbars_content_change()
+
+    def __safe_adjust_scrollbars_content_change(self):
+        """Safely adjust scrollbars after content changes without re-centering."""
+        try:
+            main_win = self.GetMainWindow()
+            if main_win:
+                main_win.AdjustMyScrollbars()
+        except RuntimeError:
+            from taskcoachlib.meta.debug import log_step
+
+            log_step(
+                "scrollbar adjustment failed - widget already destroyed",
+                prefix="DEAD-OBJ",
+            )
 
 
 class HyperTreeList(draganddrop.TreeCtrlDragAndDropMixin, BaseHyperTreeList):
@@ -100,8 +129,11 @@ class HyperTreeList(draganddrop.TreeCtrlDragAndDropMixin, BaseHyperTreeList):
         except RuntimeError:
             # wrapped C/C++ object has been deleted
             from taskcoachlib.meta.debug import log_step
-            log_step('__safe_refresh failed - widget already destroyed',
-                     prefix='DEAD-OBJ')
+
+            log_step(
+                "__safe_refresh failed - widget already destroyed",
+                prefix="DEAD-OBJ",
+            )
 
     def GetSelections(self):  # pylint: disable=C0103
         """If the root item is hidden, it should never be selected.
@@ -148,7 +180,8 @@ class HyperTreeList(draganddrop.TreeCtrlDragAndDropMixin, BaseHyperTreeList):
         Note: UnselectAll() is required before SelectItem() after a tree rebuild.
         This appears to be a HyperTreeList quirk/bug - SelectItem() silently fails
         without it, even though DoSelectItem has unselect_others=True by default.
-        See: https://github.com/wxWidgets/Phoenix/issues/1164 for related issues."""
+        See: https://github.com/wxWidgets/Phoenix/issues/1164 for related issues.
+        """
         first_selected_item = None
         self.UnselectAll()
         for item in self.GetItemChildren(recursively=True):
@@ -167,7 +200,6 @@ class HyperTreeList(draganddrop.TreeCtrlDragAndDropMixin, BaseHyperTreeList):
         if self.GetItemCount() > 0:
             self.SelectAll()
         self.selectCommand()
-
 
     def IsLabelBeingEdited(self):
         return bool(self.GetLabelTextCtrl())
@@ -215,7 +247,7 @@ class TreeListCtrl(
         itemPopupMenu=None,
         columnPopupMenu=None,
         *args,
-        **kwargs
+        **kwargs,
     ):
         self.__adapter = parent
         self.__selection = []
@@ -232,7 +264,7 @@ class TreeListCtrl(
             itemPopupMenu=itemPopupMenu,
             columnPopupMenu=columnPopupMenu,
             *args,
-            **kwargs
+            **kwargs,
         )
         self.bindEventHandlers(selectCommand, editCommand, dragAndDropCommand)
         self.GetMainWindow().Bind(wx.EVT_LEAVE_WINDOW, self._on_hover_leave)
@@ -286,7 +318,8 @@ class TreeListCtrl(
             # Filter out None values - GetItemPyData can return None for some items
             # (e.g., root items or items without associated PyData)
             return [
-                data for item in self.GetSelections()
+                data
+                for item in self.GetSelections()
                 if (data := self.GetItemPyData(item)) is not None
             ]
         except RuntimeError:
@@ -332,9 +365,13 @@ class TreeListCtrl(
         while child_item:
             obj = self.GetItemPyData(child_item)
             if obj is not None:
-                self._refreshObjectCompletely(child_item, obj)
+                self._refresh_object_completely(child_item, obj)
             self._refresh_all_items_in_place(child_item)
             child_item, cookie = self.GetNextChild(parent_item, cookie)
+        # After refreshing all items, ensure scrollbars reflect current content
+        # on Windows where content changes may not trigger scrollbar updates
+        if parent_item == self.GetRootItem():
+            self._schedule_scrollbar_adjustment()
 
     def _do_full_rebuild(self):
         """Full delete-and-recreate rebuild of the tree.
@@ -344,8 +381,10 @@ class TreeListCtrl(
         mouse motion events during and after rebuild.
         """
         from taskcoachlib.widgets.frame import (
-            _input_filter, _ensure_filter_installed,
+            _input_filter,
+            _ensure_filter_installed,
         )
+
         _ensure_filter_installed()
         _input_filter.acquire()
         self.__refreshing = True
@@ -361,7 +400,7 @@ class TreeListCtrl(
         root_item = self.GetRootItem()
         if not root_item:
             root_item = self.AddRoot("Hidden root")
-        self._addObjectRecursively(root_item)
+        self._add_object_recursively(root_item)
         self.Thaw()
         self.__refreshing = False
         # Restore selection AFTER Thaw - SelectItem doesn't work while Frozen
@@ -397,27 +436,27 @@ class TreeListCtrl(
 
     def RefreshItems(self, *objects):
         self.__selection = self.curselection()
-        self._refreshTargetObjects(self.GetRootItem(), *objects)
+        self._refresh_target_objects(self.GetRootItem(), *objects)
 
-    def _refreshTargetObjects(self, parent_item, *target_objects):
+    def _refresh_target_objects(self, parent_item, *target_objects):
         child_item, cookie = self.GetFirstChild(parent_item)
         while child_item:
             item_object = self.GetItemPyData(child_item)
             if item_object in target_objects:
-                self._refreshObjectCompletely(child_item, item_object)
-            self._refreshTargetObjects(child_item, *target_objects)
+                self._refresh_object_completely(child_item, item_object)
+            self._refresh_target_objects(child_item, *target_objects)
             child_item, cookie = self.GetNextChild(parent_item, cookie)
 
-    def _refreshObjectCompletely(self, item, *args):
+    def _refresh_object_completely(self, item, *args):
         self.__refresh_aspects(
-            ("ItemType", "Columns", "Font", "Colors", "Selection"),
+            ("item_type", "columns", "font", "colors", "selection"),
             item,
             check=True,
-            *args
+            *args,
         )
         self.GetMainWindow().RefreshLine(item)
 
-    def _addObjectRecursively(self, parent_item, parent_object=None):
+    def _add_object_recursively(self, parent_item, parent_object=None):
         for child_object in self.__adapter.children(parent_object):
             child_item = self.AppendItem(
                 parent_item,
@@ -425,10 +464,10 @@ class TreeListCtrl(
                 self.get_item_ct_type(child_object),
                 data=child_object,
             )
-            self._refreshObjectMinimally(child_item, child_object)
+            self._refresh_object_minimally(child_item, child_object)
             expanded = self.__adapter.getItemExpanded(child_object)
             if expanded:
-                self._addObjectRecursively(child_item, child_object)
+                self._add_object_recursively(child_item, child_object)
                 # Call Expand on the item instead of on the tree
                 # (self.Expand(childItem)) to prevent lots of events
                 # (EVT_TREE_ITEM_EXPANDING/EXPANDED) being sent
@@ -438,45 +477,49 @@ class TreeListCtrl(
                     child_item, self.__adapter.children(child_object)
                 )
 
-    def _refreshObjectMinimally(self, *args, **kwargs):
+    def _refresh_object_minimally(self, *args, **kwargs):
         self.__refresh_aspects(
-            ("Columns", "Colors", "Font", "Selection"), *args, **kwargs
+            ("columns", "colors", "font", "selection"), *args, **kwargs
         )
 
     def __refresh_aspects(self, aspects, *args, **kwargs):
         for aspect in aspects:
-            refresh_aspect = getattr(self, "_refresh%s" % aspect)
+            refresh_aspect = getattr(self, "_refresh_%s" % aspect)
             refresh_aspect(*args, **kwargs)
 
-    def _refreshItemType(self, item, domain_object, check=False):
+    def _refresh_item_type(self, item, domain_object, check=False):
         ct_type = self.get_item_ct_type(domain_object)
         if not check or (check and ct_type != self.GetItemType(item)):
             self.SetItemType(item, ct_type)
 
-    def _refreshColumns(self, item, domain_object, check=False):
+    def _refresh_columns(self, item, domain_object, check=False):
         for column_index in range(self.GetColumnCount()):
-            self._refreshColumn(item, domain_object, column_index, check=check)
+            self._refresh_column(
+                item, domain_object, column_index, check=check
+            )
 
-    def _refreshColumn(self, item, domain_object, column_index, check=False):
+    def _refresh_column(self, item, domain_object, column_index, check=False):
         aspects = (
-            ("Text", "Image")
+            ("text", "image")
             if column_index in self.__columns_with_images
-            else ("Text",)
+            else ("text",)
         )
         self.__refresh_aspects(
             aspects, item, domain_object, column_index, check=check
         )
 
-    def _refreshText(self, item, domain_object, column_index, check=False):
+    def _refresh_text(self, item, domain_object, column_index, check=False):
         text = self.__adapter.getItemText(domain_object, column_index)
         if text.count("\n") > 3:
             text = "\n".join(text.split("\n")[:4]) + " ..."
         if not check or (check and text != item.GetText(column_index)):
             item.SetText(column_index, text)
 
-    def _refreshImage(self, item, domain_object, column_index, check=False):
+    def _refresh_image(self, item, domain_object, column_index, check=False):
         if self.__adapter.hasColumnMultiImages(column_index):
-            images = self.__adapter.getItemMultiImages(domain_object, column_index)
+            images = self.__adapter.getItemMultiImages(
+                domain_object, column_index
+            )
             if not check or (check and images != item.GetImages(column_index)):
                 item.SetImages(column_index, images)
             return
@@ -488,7 +531,7 @@ class TreeListCtrl(
             ):
                 item.SetImage(column_index, image, which)
 
-    def _refreshColors(self, item, domain_object, check=False):
+    def _refresh_colors(self, item, domain_object, check=False):
         bg_color = domain_object.backgroundColor(recursive=True)
         fg_color = domain_object.foregroundColor(recursive=True)
         if bg_color is None:
@@ -505,18 +548,20 @@ class TreeListCtrl(
             self.SetItemBackgroundColour(item, bg_color)
         if fg_color is None:
             if operating_system.isWindows():
-                fg_color = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOWTEXT)
+                fg_color = wx.SystemSettings.GetColour(
+                    wx.SYS_COLOUR_WINDOWTEXT
+                )
             else:
                 fg_color = wx.NullColour
         if not check or (check and fg_color != self.GetItemTextColour(item)):
             self.SetItemTextColour(item, fg_color)
 
-    def _refreshFont(self, item, domain_object, check=False):
+    def _refresh_font(self, item, domain_object, check=False):
         font = domain_object.font(recursive=True) or self.__default_font
         if not check or (check and font != self.GetItemFont(item)):
             self.SetItemFont(item, font)
 
-    def _refreshSelection(self, item, domain_object, check=False):
+    def _refresh_selection(self, item, domain_object, check=False):
         select = domain_object in self.__selection
         if not check or (check and select != item.IsSelected()):
             # Use SetHilight for visual highlighting during tree construction.
@@ -543,8 +588,11 @@ class TreeListCtrl(
         except RuntimeError:
             # wrapped C/C++ object has been deleted
             from taskcoachlib.meta.debug import log_step
-            log_step('selectCommand() failed - widget already destroyed',
-                     prefix='DEAD-OBJ')
+
+            log_step(
+                "selectCommand() failed - widget already destroyed",
+                prefix="DEAD-OBJ",
+            )
 
     def on_key_down(self, event):
         if event.GetKeyCode() == wx.WXK_RETURN:
@@ -564,30 +612,42 @@ class TreeListCtrl(
             self.GetItemPyData(drag_item) for drag_item in drag_items
         )
         wx.CallAfter(
-            self.__safe_drag_and_drop_command, drop_item, drag_items, part, column
+            self.__safe_drag_and_drop_command,
+            drop_item,
+            drag_items,
+            part,
+            column,
         )
 
-    def __safe_drag_and_drop_command(self, drop_item, drag_items, part, column):
+    def __safe_drag_and_drop_command(
+        self, drop_item, drag_items, part, column
+    ):
         """Safely call dragAndDropCommand, guarding against deleted C++ objects."""
         try:
             if self:
                 self.dragAndDropCommand(drop_item, drag_items, part, column)
                 # Expand the drop target if items were dropped on it
                 if drop_item is not None:
-                    self._expandDropTarget(drop_item)
+                    self._expand_drop_target(drop_item)
         except RuntimeError:
             # wrapped C/C++ object has been deleted
             from taskcoachlib.meta.debug import log_step
-            log_step('dragAndDropCommand failed - widget already destroyed',
-                     prefix='DEAD-OBJ')
 
-    def _expandDropTarget(self, drop_item):
+            log_step(
+                "dragAndDropCommand failed - widget already destroyed",
+                prefix="DEAD-OBJ",
+            )
+
+    def _expand_drop_target(self, drop_item):
         """Expand the drop target item so the dropped children are visible."""
         # Find the tree item for the drop target
         for item in self.GetItemChildren(recursively=True):
             if self.GetItemPyData(item) == drop_item:
-                if self.GetChildrenCount(item, recursively=False) > 0 or self.ItemHasChildren(item):
+                if self.GetChildrenCount(
+                    item, recursively=False
+                ) > 0 or self.ItemHasChildren(item):
                     self.Expand(item)
+                    self._schedule_scrollbar_adjustment()
                 break
 
     def on_item_expanding(self, event):
@@ -595,7 +655,8 @@ class TreeListCtrl(
         item = event.GetItem()
         if self.GetChildrenCount(item, recursively=False) == 0:
             domain_object = self.GetItemPyData(item)
-            self._addObjectRecursively(item, domain_object)
+            self._add_object_recursively(item, domain_object)
+            self._schedule_scrollbar_adjustment()
 
     def on_double_click(self, event):
         self.__user_double_clicked = True
@@ -725,7 +786,7 @@ class CheckTreeCtrl(TreeListCtrl):
         dragAndDropCommand,
         itemPopupMenu=None,
         *args,
-        **kwargs
+        **kwargs,
     ):
         self.__checking = False
         super().__init__(
@@ -736,7 +797,7 @@ class CheckTreeCtrl(TreeListCtrl):
             dragAndDropCommand,
             itemPopupMenu,
             *args,
-            **kwargs
+            **kwargs,
         )
         self.checkCommand = checkCommand
         self.Bind(customtree.EVT_TREE_ITEM_CHECKED, self.on_item_checked)
@@ -818,15 +879,15 @@ class CheckTreeCtrl(TreeListCtrl):
         event.SetEventObject(self)
         self.GetEventHandler().ProcessEvent(event)
 
-    def _refreshObjectCompletely(self, item, domain_object):
-        super()._refreshObjectCompletely(item, domain_object)
-        self._refreshCheckState(item, domain_object)
+    def _refresh_object_completely(self, item, domain_object):
+        super()._refresh_object_completely(item, domain_object)
+        self._refresh_check_state(item, domain_object)
 
-    def _refreshObjectMinimally(self, item, domain_object):
-        super()._refreshObjectMinimally(item, domain_object)
-        self._refreshCheckState(item, domain_object)
+    def _refresh_object_minimally(self, item, domain_object):
+        super()._refresh_object_minimally(item, domain_object)
+        self._refresh_check_state(item, domain_object)
 
-    def _refreshCheckState(self, item, domain_object):
+    def _refresh_check_state(self, item, domain_object):
         # Use CheckItem2 so no events get sent:
         checked = self.get_is_item_checked(domain_object)
         if checked is None:
@@ -850,7 +911,7 @@ class CheckTreeCtrl(TreeListCtrl):
         for item in self.GetItemChildren(recursively=True):
             domain_object = self.GetItemPyData(item)
             if domain_object is not None:
-                self._refreshCheckState(item, domain_object)
+                self._refresh_check_state(item, domain_object)
 
     def on_item_checked(self, event):
         if self.__checking:


### PR DESCRIPTION
Fix scrollbars not updating in the task list on Windows

On Windows, the scrollbars in the task list did not resize themselves as the contents changed. Expanding or collapsing items, adding or deleting tasks, and switching between the tree and flat list views all left the scrollbars stuck at their old size; they only corrected themselves if you manually resized the window. This did not happen on Linux.

This change makes the scrollbars refresh automatically whenever the contents of the list change, so they always match what is actually on screen. The same behavior now applies consistently across the task, category, and note lists.

The version number was updated and the related developer notes were refreshed.

Expand the task's tree mask the bottom tasks #450