### PR TITLE
Fix idle-effort popup reopening after Do nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,20 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.20-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.20-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.20_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.20_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.20_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.20-fedora43.rpm` |
-| [Flatpak (any Linux)](#flatpak) | `TaskCoach-2.0.2.20-x86_64.flatpak` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.21-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.21-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.21_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.21_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.21_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.21-fedora43.rpm` |
+| [Flatpak (any Linux)](#flatpak) | `TaskCoach-2.0.2.21-x86_64.flatpak` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.20-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.20-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.20_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.20_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.2.20-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.2.20-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.21-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.21-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.21_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.21_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.2.21-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.2.21-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -43,8 +43,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.20_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.2.20_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.21_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.2.21_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -57,8 +57,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.20-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.2.20-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.21-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.2.21-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -71,8 +71,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.20-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.2.20-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.21-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.2.21-fedora43.rpm
 ```
 
 To uninstall:
@@ -87,13 +87,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.20-x86_64.AppImage
-chmod +x TaskCoach-2.0.2.20-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.21-x86_64.AppImage
+chmod +x TaskCoach-2.0.2.21-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.2.20-x86_64.AppImage
+./TaskCoach-2.0.2.21-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.
@@ -105,8 +105,8 @@ the first install pulls the GNOME runtime from Flathub.
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.20-x86_64.flatpak
-flatpak install ./TaskCoach-2.0.2.20-x86_64.flatpak
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.21-x86_64.flatpak
+flatpak install ./TaskCoach-2.0.2.21-x86_64.flatpak
 flatpak run io.github.taskcoach.TaskCoach
 ```
 

--- a/taskcoachlib/gui/idlecontroller.py
+++ b/taskcoachlib/gui/idlecontroller.py
@@ -39,7 +39,6 @@ class WakeFromIdleFrame(NotificationFrameBase):
         self._idle_time = idle_time
         self._effort = effort
         self._displayed = displayed_efforts
-        self._last_activity = 0
         super().__init__(*args, **kwargs)
 
     def add_inner_content(self, sizer, panel):
@@ -105,6 +104,7 @@ class IdleController(Observer, IdleNotifier):
         self._settings = settings
         self._effort_list = effort_list
         self._displayed = set()
+        self._went_idle_at = None
 
         super().__init__()
 
@@ -168,17 +168,30 @@ class IdleController(Observer, IdleNotifier):
     def get_min_idle_time(self):
         return self._settings.getint("feature", "minidletime") * 60
 
+    def sleep(self):
+        log_step("Idle threshold reached while tracking effort", prefix="IDLE")
+
     def wake(self, timestamp):
-        self._last_activity = timestamp
+        # Keep the went-idle timestamp in its own attribute. Storing it
+        # in _last_activity overwrote the IdleNotifier state machine's
+        # activity clock with a stale time, which made _check() cycle
+        # through sleep/wake on every wx idle event and reopen the
+        # notification endlessly after "Do nothing".
+        self._went_idle_at = timestamp
+        log_step(
+            "Wake from idle; idle since %s"
+            % date.DateTime.fromtimestamp(timestamp),
+            prefix="IDLE",
+        )
         self._on_wake()
 
     def _on_wake(self):
-        for effort in self._tracker.trackedEfforts():
-            if effort not in self._displayed:
-                self._displayed.add(effort)
+        for tracked_effort in self._tracker.trackedEfforts():
+            if tracked_effort not in self._displayed:
+                self._displayed.add(tracked_effort)
                 frm = WakeFromIdleFrame(
-                    date.DateTime.fromtimestamp(self._last_activity),
-                    effort,
+                    date.DateTime.fromtimestamp(self._went_idle_at),
+                    tracked_effort,
                     self._displayed,
                     _("Notification"),
                     wx_bitmap=icon_catalog.get_bitmap(

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -44,8 +44,8 @@ import re
 # =============================================================================
 
 version = "2.0.2"  # Major.Minor.Milestone
-patch = "20"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.2.20
+patch = "21"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.2.21
 
 release_day = "14"  # Day of the release (1-31)
 release_month = "August"  # Month of the release


### PR DESCRIPTION
IdleController.wake() stored the went-idle timestamp in _last_activity, the same attribute IdleNotifier's state machine uses as its activity clock. The stale value made _check() re-enter the sleep/wake cycle on every wx idle event, so the notification reopened endlessly once Do nothing removed the effort from the displayed set. Stopping the effort masked the loop because that pauses the notifier, which is why only Do nothing exhibited the bug. The defect is in shared code and affected all platforms equally.

Store the timestamp in its own attribute, rename the loop variable that shadowed the effort module import, drop a dead attribute in WakeFromIdleFrame, and log idle sleep/wake transitions so the notice can be diagnosed from the log (the issue reported no log entries).

Bump version to 2.0.2.21, release date August 14, 2026; update README download links.

The popup pop again and again when I want to ignore it #464