### PR TITLE
Fix focus and scroll position after deleting a task

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -3,13 +3,17 @@ name: Build AppImage
 on:
   push:
     branches:
-      - main
       - master
     tags:
-      - 'v*'
+      # Release tags only: Major.Minor.Milestone.Patch (see meta/data.py).
+      # '+' means one or more of the preceding class, so this excludes
+      # stray tags such as v1.5.0-starofrainnight.
+      - 'v[0-9]+.[0-9]+.[0-9]+.[0-9]+'
   pull_request:
+    # Defaults are opened/synchronize/reopened; ready_for_review is added
+    # so leaving draft rebuilds rather than relying on the draft's runs.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
-      - main
       - master
   workflow_dispatch:
 

--- a/.github/workflows/build-arch.yml
+++ b/.github/workflows/build-arch.yml
@@ -3,13 +3,17 @@ name: Build Arch/Manjaro Package
 on:
   push:
     branches:
-      - main
       - master
     tags:
-      - 'v*'
+      # Release tags only: Major.Minor.Milestone.Patch (see meta/data.py).
+      # '+' means one or more of the preceding class, so this excludes
+      # stray tags such as v1.5.0-starofrainnight.
+      - 'v[0-9]+.[0-9]+.[0-9]+.[0-9]+'
   pull_request:
+    # Defaults are opened/synchronize/reopened; ready_for_review is added
+    # so leaving draft rebuilds rather than relying on the draft's runs.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
-      - main
       - master
   workflow_dispatch:
 

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -3,13 +3,17 @@ name: Build Debian Package
 on:
   push:
     branches:
-      - main
       - master
     tags:
-      - 'v*'
+      # Release tags only: Major.Minor.Milestone.Patch (see meta/data.py).
+      # '+' means one or more of the preceding class, so this excludes
+      # stray tags such as v1.5.0-starofrainnight.
+      - 'v[0-9]+.[0-9]+.[0-9]+.[0-9]+'
   pull_request:
+    # Defaults are opened/synchronize/reopened; ready_for_review is added
+    # so leaving draft rebuilds rather than relying on the draft's runs.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
-      - main
       - master
   workflow_dispatch:
 

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -16,15 +16,17 @@ name: Build Flatpak
 on:
   push:
     branches:
-      - main
       - master
-      - 'fix/**'
-      - 'feat/**'
     tags:
-      - 'v*'
+      # Release tags only: Major.Minor.Milestone.Patch (see meta/data.py).
+      # '+' means one or more of the preceding class, so this excludes
+      # stray tags such as v1.5.0-starofrainnight.
+      - 'v[0-9]+.[0-9]+.[0-9]+.[0-9]+'
   pull_request:
+    # Defaults are opened/synchronize/reopened; ready_for_review is added
+    # so leaving draft rebuilds rather than relying on the draft's runs.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
-      - main
       - master
   schedule:
     # Weekly build to keep the flatpak-builder cache warm. GitHub evicts

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -3,13 +3,17 @@ name: Build macOS Package
 on:
   push:
     branches:
-      - main
       - master
     tags:
-      - 'v*'
+      # Release tags only: Major.Minor.Milestone.Patch (see meta/data.py).
+      # '+' means one or more of the preceding class, so this excludes
+      # stray tags such as v1.5.0-starofrainnight.
+      - 'v[0-9]+.[0-9]+.[0-9]+.[0-9]+'
   pull_request:
+    # Defaults are opened/synchronize/reopened; ready_for_review is added
+    # so leaving draft rebuilds rather than relying on the draft's runs.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
-      - main
       - master
   workflow_dispatch:
 

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -3,13 +3,17 @@ name: Build RPM Package
 on:
   push:
     branches:
-      - main
       - master
     tags:
-      - 'v*'
+      # Release tags only: Major.Minor.Milestone.Patch (see meta/data.py).
+      # '+' means one or more of the preceding class, so this excludes
+      # stray tags such as v1.5.0-starofrainnight.
+      - 'v[0-9]+.[0-9]+.[0-9]+.[0-9]+'
   pull_request:
+    # Defaults are opened/synchronize/reopened; ready_for_review is added
+    # so leaving draft rebuilds rather than relying on the draft's runs.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
-      - main
       - master
   workflow_dispatch:
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -3,13 +3,17 @@ name: Build Windows Package
 on:
   push:
     branches:
-      - main
       - master
     tags:
-      - 'v*'
+      # Release tags only: Major.Minor.Milestone.Patch (see meta/data.py).
+      # '+' means one or more of the preceding class, so this excludes
+      # stray tags such as v1.5.0-starofrainnight.
+      - 'v[0-9]+.[0-9]+.[0-9]+.[0-9]+'
   pull_request:
+    # Defaults are opened/synchronize/reopened; ready_for_review is added
+    # so leaving draft rebuilds rather than relying on the draft's runs.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
-      - main
       - master
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -18,20 +18,20 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.21-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.21-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.21_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.21_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.21_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.21-fedora43.rpm` |
-| [Flatpak (any Linux)](#flatpak) | `TaskCoach-2.0.2.21-x86_64.flatpak` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.22-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.22-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.22_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.22_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.22_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.22-fedora43.rpm` |
+| [Flatpak (any Linux)](#flatpak) | `TaskCoach-2.0.2.22-x86_64.flatpak` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.21-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.21-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.21_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.21_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.2.21-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.2.21-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.22-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.22-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.22_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.22_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.2.22-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.2.22-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -43,8 +43,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.21_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.2.21_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.22_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.2.22_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -57,8 +57,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.21-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.2.21-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.22-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.2.22-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -71,8 +71,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.21-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.2.21-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.22-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.2.22-fedora43.rpm
 ```
 
 To uninstall:
@@ -87,13 +87,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.21-x86_64.AppImage
-chmod +x TaskCoach-2.0.2.21-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.22-x86_64.AppImage
+chmod +x TaskCoach-2.0.2.22-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.2.21-x86_64.AppImage
+./TaskCoach-2.0.2.22-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.
@@ -105,8 +105,8 @@ the first install pulls the GNOME runtime from Flathub.
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.21-x86_64.flatpak
-flatpak install ./TaskCoach-2.0.2.21-x86_64.flatpak
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.22-x86_64.flatpak
+flatpak install ./TaskCoach-2.0.2.22-x86_64.flatpak
 flatpak run io.github.taskcoach.TaskCoach
 ```
 

--- a/docs/LIST_MANAGEMENT.md
+++ b/docs/LIST_MANAGEMENT.md
@@ -11,7 +11,8 @@
 7. [Selection-Driven Button Enable/Disable](#selection-driven-button-enabledisable)
 8. [Tree Mode Button Enable/Disable](#tree-mode-button-enabledisable)
 9. [Scroll After Rebuild (Tree Views)](#scroll-after-rebuild-tree-views)
-10. [Windows: Scrollbar Adjustment on Content Changes](#windows-scrollbar-adjustment-on-content-changes)
+10. [Stale Item Positions After Rebuild](#stale-item-positions-after-rebuild)
+11. [Windows: Scrollbar Adjustment on Content Changes](#windows-scrollbar-adjustment-on-content-changes)
 11. [Row Hover Outline](#row-hover-outline)
 10. [Mouse-Move Handler Inventory (Tree Views)](#mouse-move-handler-inventory-tree-views)
 11. [Vampire CPU Usage](#vampire-cpu-usage)
@@ -89,10 +90,10 @@ When items are deleted and the selection becomes empty, select the "next" item f
 ### The Timing Problem
 
 ```
-onPresentationChanged(event):
+on_presentation_changed(event):
     │
     ├── BEFORE refresh(): Widget has old state (deleted items still visible)
-    │   └── Can query: selected items, their positions
+    │   └── Can query: selected items, the rows around them
     │
     ├── refresh(): Widget updates
     │
@@ -100,30 +101,82 @@ onPresentationChanged(event):
         └── Cannot determine where deleted items were
 ```
 
-### Solution: Capture State Before Refresh
+### Which Row Gets Selected
 
-**Reference:** `base.py:onPresentationChanged()`, `_captureSelectionInfo()`, `selectNextItemsAfterRemoval()`
+The row **above** the deleted one, so that repeated deletes keep walking
+up the list. Only when the deleted row was the topmost one does the
+selection move **down** to the row that took its place.
+
+"Above" and "below" mean adjacent *rows*, not adjacent siblings: the row
+above a top-level task is the last open descendant of the previous
+top-level task, and the row above a first child is its parent.
+
+### Solution: Capture Neighbouring Rows Before Refresh
+
+**Reference:** `base.py:on_presentation_changed()`, `_capture_selection_info()`, `select_next_items_after_removal()`, `treectrl.py:selection_neighbours()`
+
+The index of the deleted row cannot be recovered from the presentation:
+by the time `on_presentation_changed` fires, the domain layer has
+already removed the item, so `children(parent)` no longer contains it.
+Only the widget still holds the old order. `selection_neighbours()`
+therefore walks the widget's tree and returns the two chains of objects
+around the selection, nearest row first.
 
 Flow:
-1. BEFORE refresh: call `_captureSelectionInfo()` to get parent and index
+1. BEFORE refresh: `_capture_selection_info()` calls
+   `widget.selection_neighbours()` -> `{"above": [...], "below": [...]}`
 2. Call `refresh()` - widget updates, deleted items gone
-3. AFTER refresh: if selection empty, call `selectNextItemsAfterRemoval(selectionInfo)`
+3. AFTER refresh: if selection empty, `select_next_items_after_removal()`
+   selects the first entry of `above` that is still in the presentation,
+   falling back to the first surviving entry of `below`
+
+Walking chains rather than picking a single neighbour handles
+multi-select deletes: the rows between the survivors are skipped because
+they are no longer in the presentation.
+
+`selection_neighbours()` does its own tree walk instead of calling
+upstream `GetPrevVisible`/`GetNextVisible`, because those also test
+whether the row is scrolled on screen and would skip off-screen rows.
 
 ### Edge Cases
 
-**Deleted from bottom of list:**
-- Selected item was at index N
-- After deletion, list only has M items where M < N
-- Select last item: `min(len(siblings) - 1, index)` = last item
+**Deleted from top of list:**
+- Nothing above, so the first surviving row below is selected
+
+**Deleted the only row / whole list emptied:**
+- Both chains are empty, nothing is selected
 
 **Parent also deleted:**
-- Check if parent still in presentation
-- If not, look for siblings at root level
+- The parent is not in the presentation, so it is skipped like any other
+  removed row and the walk continues outward
+
+**Widgets without a row order** (timeline, calendar, square map):
+- These have no `selection_neighbours()`; they keep the older
+  parent-plus-index capture, where "next" means `min(len(siblings) - 1,
+  index)`
 
 **Benefits:**
 - No cache maintained on every selection change
 - State captured only when needed (before refresh on removal)
 - Each window captures its own state independently
+
+### Scrolling
+
+The new selection is adjacent to the deleted row, so
+`on_presentation_changed` then runs the usual
+`scroll_to_selection_centered()` for the "Delete selected item" row of
+the [scroll behavior table](#scroll-behavior-by-user-action), gated by
+`view.autoscrollselection` like every other path.
+
+Restoring the viewport needs one extra step, though. See
+[Stale Item Positions After Rebuild](#stale-item-positions-after-rebuild).
+
+### List Viewers
+
+`ListViewer.select_next_items_after_removal` is still a no-op: native list
+controls keep the selection at the same *index*, which lands on the row
+**below** the deleted one. Effort and attachment viewers therefore do
+not follow the rule above.
 
 ---
 
@@ -382,6 +435,51 @@ with the settings object as source), not pypubsub; see
 PUBLISHER_OBSERVER.md for why new signals must not use pubsub.
 
 ---
+
+## Stale Item Positions After Rebuild
+
+### Problem
+
+With auto-scroll off, deleting a task sent the view back to the top even
+though `_do_full_rebuild()` saves `GetViewStart()` and restores it.
+
+### Root Cause
+
+`AdjustMyScrollbars()` (upstream, in `hypertreelist.py`) derives the
+scrollbar range from `self._anchor.GetSize(...)`, that is from the item
+positions, but it never recalculates them. `ScrollTo()` does guard on
+`self._dirty` and call `CalculatePositions()`; `AdjustMyScrollbars()`
+has no such guard.
+
+Both `CalculatePositions()` and `AdjustMyScrollbars()` also return early
+while the window is frozen, only setting `_dirty`. A rebuild runs inside
+Freeze/Thaw, so when the restore executes the positions are still dirty,
+the computed range is stale, and the following `Scroll()` is clamped -
+usually to 0, which reads as "the list jumped to the top".
+
+### Fix
+
+`HyperTreeList._recalculated_main_window()` calls `CalculatePositions()`
+when `_dirty` and returns the main window. Used by the viewport restore
+in `_do_full_rebuild()` and by `stable_viewport()`, both of which call
+`AdjustMyScrollbars()` + `Scroll()` on a freshly rebuilt tree, and by
+`selection_neighbours()`, which orders the selected rows by `GetY()`.
+
+It deliberately leaves `_dirty` set, exactly as upstream `ScrollTo()`
+does. `customtreectrl` only ever *sets* that flag - nothing but
+`__init__` clears it - so clearing it here would suppress
+recalculations upstream still expects to perform.
+
+### Known Implicit Dependency
+
+`scroll_to_selection_centered()` reads `item.GetY()` and
+`GetLineHeight(item)` without recalculating first. It is correct today
+only because something upstream in the same flow already recalculated:
+selecting an item triggers `EnsureVisible()` -> `ScrollTo()` ->
+`CalculatePositions()` in upstream `customtreectrl`. If that chain ever
+stops firing before the centering call, centering will compute from
+stale positions. Route it through `_recalculated_main_window()` if that
+happens.
 
 ## Windows: Scrollbar Adjustment on Content Changes
 

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -8,6 +8,7 @@ This document describes the packaging setup for Task Coach on Linux (Debian, Ubu
 - [Minimum Version Requirements](#minimum-version-requirements)
 - [Install Overview by Build Target](#install-overview-by-build-target)
 - [Build Scripts and Workflows](#build-scripts-and-workflows)
+  - [Workflow Triggers](#workflow-triggers)
 
 **Packaging by Platform**
 - [Debian/Ubuntu Packaging](#debianubuntu-packaging)
@@ -115,7 +116,50 @@ backends.
 
 **AppImage note:** Uses Python 3.11 (not 3.12) for wxPython wheel availability. See [AppImage Packaging](#appimage-packaging) section for details.
 
-**pip packages are bundled at build time** - users just install the package, no pip runs at install.
+### Workflow Triggers
+
+Every build workflow above uses the same triggers. Keep them identical
+when adding a target or editing one.
+
+| Trigger | Refs | Purpose |
+|---------|------|---------|
+| `pull_request` | targeting `master` | Every PR, every push to it, and leaving draft |
+| `push` | `master` | Merge to the default branch, and any direct push |
+| `push` (tags) | `v[0-9]+.[0-9]+.[0-9]+.[0-9]+` | Release; the only refs that attach artifacts to a GitHub Release |
+| `workflow_dispatch` | any ref | Manual run |
+
+Nothing triggers on branch-name patterns. Work in progress is verified
+by its pull request, so a build never depends on how a branch happens to
+be named, and pushing a branch with no PR costs nothing. `master` is the
+only long-lived branch; there is no `main`.
+
+The `pull_request` types are `opened`, `synchronize`, `reopened`,
+`ready_for_review`. The first three are the GitHub default; the fourth is
+added so that marking a draft ready rebuilds instead of relying on runs
+from while it was a draft.
+
+The tag pattern matches the four-part version scheme in
+[`meta/data.py`](../taskcoachlib/meta/data.py) and nothing else. In this
+filter syntax `+` means "one or more of the preceding character class",
+so the pattern accepts `v2.0.2.21` and rejects unrelated tags that merely
+start with `v` (the repository carries one, `v1.5.0-starofrainnight`).
+A plain `v*` would match those and fire a full release build. **Release
+candidate and three-part tags do not build.** Widen the pattern first if
+that scheme ever changes.
+
+Two consequences worth knowing: a release must start from a *pushed tag*,
+since creating a Release in the web UI from a tag that already exists
+raises no `push` event; and deleting a branch or tag builds nothing,
+because deletions raise `delete`, not `push`.
+
+All seven also share a `concurrency` group that cancels superseded runs
+on a branch or PR but never on a tag.
+
+`build-flatpak.yml` additionally runs on a weekly `schedule`. That adds
+no build ref of its own: it exists solely because GitHub evicts the
+Flatpak cache after 7 days of disuse and a cold cache recompiles
+wxWidgets from source, which takes hours. See
+[FLATPAK.md](FLATPAK.md#wxpython-build-from-source-let-it-build-its-own-wxwidgets).
 
 ### Estimated Desktop User Base
 

--- a/taskcoachlib/gui/viewer/base.py
+++ b/taskcoachlib/gui/viewer/base.py
@@ -20,6 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+import contextlib
 import wx
 from taskcoachlib import patterns, widgets, command, render
 from taskcoachlib.i18n import _
@@ -389,7 +390,7 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         # BEFORE refresh - capture selection info while widget has old state
         selection_info = None
         if items_removed():
-            selection_info = self._captureSelectionInfo()
+            selection_info = self._capture_selection_info()
 
         self.refresh()
 
@@ -400,7 +401,12 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
             and not self.widget.curselection()
             and selection_info
         ):
-            self.selectNextItemsAfterRemoval(selection_info)
+            # Selecting scrolls the widget, which "stable" mode must not
+            keep_viewport = getattr(
+                self.widget, "stable_viewport", contextlib.nullcontext
+            )
+            with keep_viewport():
+                self.select_next_items_after_removal(selection_info)
         # Center on selected item — tree views use scroll_to_selection_centered,
         # list views use ensureSelectionVisible (native wx scrollbar management)
         if hasattr(self.widget, "scroll_to_selection_centered"):
@@ -422,15 +428,16 @@ class Viewer(wx.Panel, patterns.Observer, metaclass=ViewerMeta):
         except RuntimeError:
             pass  # wrapped C/C++ object has been deleted
 
-    def _captureSelectionInfo(self):
+    def _capture_selection_info(self):
         """Capture selection info before refresh. Override in subclasses."""
         return None
 
-    def selectNextItemsAfterRemoval(self, selectionInfo):
+    def select_next_items_after_removal(self, selection_info):
         """Select the next item after items were removed.
 
         Args:
-            selectionInfo: Selection state captured before refresh (parent + index)
+            selection_info: Selection state captured before the
+                refresh, while the widget still showed the old rows.
         """
         raise NotImplementedError
 
@@ -872,21 +879,21 @@ class ListViewer(Viewer):  # pylint: disable=W0223
     def is_tree_viewer(self):
         return False
 
-    def visibleItems(self):
+    def visible_items(self):
         """Iterate over the items in the presentation."""
         for item in self.presentation():
             yield item
 
-    def getItemWithIndex(self, index):
+    def get_item_with_index(self, index):
         try:
             return self.presentation()[index]
         except IndexError:
             return None
 
-    def getIndexOfItem(self, item):
+    def get_index_of_item(self, item):
         return self.presentation().index(item)
 
-    def selectNextItemsAfterRemoval(self, selectionInfo):
+    def select_next_items_after_removal(self, selection_info):
         pass  # Done automatically by list controls
 
 
@@ -917,7 +924,7 @@ class TreeViewer(Viewer):  # pylint: disable=W0223
         """Expand all items, recursively."""
         # Since the widget does not send EVT_TREE_ITEM_EXPANDED when expanding
         # all items, we have to do the bookkeeping ourselves:
-        for item in self.visibleItems():
+        for item in self.visible_items():
             item.expand(True, context=self.settingsSection(), notify=False)
         self.refresh()
         self.widget._schedule_scrollbar_adjustment()
@@ -926,7 +933,7 @@ class TreeViewer(Viewer):  # pylint: disable=W0223
         """Collapse all items, recursively."""
         # Since the widget does not send EVT_TREE_ITEM_COLLAPSED when collapsing
         # all items, we have to do the bookkeeping ourselves:
-        for item in self.visibleItems():
+        for item in self.visible_items():
             item.expand(False, context=self.settingsSection(), notify=False)
         self.refresh()
         self.widget._schedule_scrollbar_adjustment()
@@ -942,73 +949,106 @@ class TreeViewer(Viewer):  # pylint: disable=W0223
 
     def select(self, items):
         for item in items:
-            self.__expandItemRecursively(item)
+            self.__expand_item_recursively(item)
         self.refresh()
         super().select(items)
 
-    def __expandItemRecursively(self, item):
-        parent = self.getItemParent(item)
+    def __expand_item_recursively(self, item):
+        parent = self.get_item_parent(item)
         if parent:
             parent.expand(True, context=self.settingsSection(), notify=False)
-            self.__expandItemRecursively(parent)
+            self.__expand_item_recursively(parent)
 
-    def _captureSelectionInfo(self):
-        """Capture selection position before refresh."""
+    def _capture_selection_info(self):
+        """Capture the rows around the selection before refresh.
+
+        The removed items are already gone from the presentation by the
+        time this runs, so the neighbouring rows can only be read from
+        the widget, which still shows the old contents.
+        """
         if not hasattr(self.widget, "curselection"):
+            return None
+        if hasattr(self.widget, "selection_neighbours"):
+            above, below = self.widget.selection_neighbours()
+            if above or below:
+                return {"above": above, "below": below}
             return None
         curselection = self.widget.curselection()
         if curselection and curselection[0] is not None:
-            selectedItem = curselection[0]
-            parent = self.getItemParent(selectedItem)
+            selected_item = curselection[0]
+            parent = self.get_item_parent(selected_item)
             siblings = self.children(parent)
             index = (
-                siblings.index(selectedItem) if selectedItem in siblings else 0
+                siblings.index(selected_item)
+                if selected_item in siblings
+                else 0
             )
             return {"parent": parent, "index": index}
         return None
 
-    def selectNextItemsAfterRemoval(self, selectionInfo):
-        """Select next item using position captured before refresh."""
-        if not selectionInfo:
+    def select_next_items_after_removal(self, selection_info):
+        """Select the row that took the place of the removed rows.
+
+        The row above the removed ones is preferred, so that deleting
+        several items in a row keeps walking up the list. Only when the
+        removed row was the topmost one does the selection move down
+        instead.
+        """
+        if not selection_info:
             return
-        parent = selectionInfo["parent"]
-        index = selectionInfo["index"]
+        if "above" in selection_info:
+            new_selection = self.__first_survivor(
+                selection_info["above"]
+            ) or self.__first_survivor(selection_info["below"])
+            if new_selection:
+                self.select([new_selection])
+            return
+        parent = selection_info["parent"]
+        index = selection_info["index"]
         # Parent might have been deleted too - check if still in presentation
         if parent is not None and parent not in self.presentation():
             parent = None
         siblings = self.children(parent)
-        newSelection = (
+        new_selection = (
             siblings[min(len(siblings) - 1, index)] if siblings else parent
         )
-        if newSelection:
-            self.select([newSelection])
+        if new_selection:
+            self.select([new_selection])
 
-    def visibleItems(self):
+    def __first_survivor(self, items):
+        """Return the first of items that is still in the presentation."""
+        presentation = self.presentation()
+        for item in items:
+            if item in presentation:
+                return item
+        return None
+
+    def visible_items(self):
         """Iterate over the items in the presentation."""
 
-        def yieldItemsAndChildren(items):
-            sortedItems = [
+        def yield_items_and_children(items):
+            sorted_items = [
                 item for item in self.presentation() if item in items
             ]
-            for item in sortedItems:
+            for item in sorted_items:
                 yield item
                 children = self.children(item)
                 if children:
-                    for child in yieldItemsAndChildren(children):
+                    for child in yield_items_and_children(children):
                         yield child
 
-        for item in yieldItemsAndChildren(self.getRootItems()):
+        for item in yield_items_and_children(self.get_root_items()):
             yield item
 
-    def getRootItems(self):
+    def get_root_items(self):
         """Allow for overriding what the rootItems are."""
         return self.presentation().rootItems()
 
-    def getItemParent(self, item):
+    def get_item_parent(self, item):
         """Allow for overriding what the parent of an item is."""
         return item.parent() if item is not None else None
 
-    def getItemExpanded(self, item):
+    def get_item_expanded(self, item):
         return item.isExpanded(context=self.settingsSection())
 
     def children(self, parent=None):
@@ -1021,7 +1061,7 @@ class TreeViewer(Viewer):  # pylint: disable=W0223
             else:
                 return []
         else:
-            return self.getRootItems()
+            return self.get_root_items()
 
     def getItemText(self, item):
         return item.subject()
@@ -1320,7 +1360,7 @@ class ViewerWithColumns(Viewer):  # pylint: disable=W0223
         # pylint: disable=E1101
         # pylint: disable=E1101
         return (
-            not self.getItemExpanded(item)
+            not self.get_item_expanded(item)
             if self.is_tree_viewer() and item.children()
             else False
         )

--- a/taskcoachlib/gui/viewer/task.py
+++ b/taskcoachlib/gui/viewer/task.py
@@ -2249,17 +2249,17 @@ class TaskViewer(
         ):
             super().onEverySecond(event)
 
-    def getRootItems(self):
+    def get_root_items(self):
         """If the viewer is in tree mode, return the real root items. If the
         viewer is in list mode, return all items."""
         return (
-            super().getRootItems()
+            super().get_root_items()
             if self.is_tree_viewer()
             else self.presentation()
         )
 
-    def getItemParent(self, item):
-        return super().getItemParent(item) if self.is_tree_viewer() else None
+    def get_item_parent(self, item):
+        return super().get_item_parent(item) if self.is_tree_viewer() else None
 
     def children(self, item=None):
         return (

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -44,10 +44,10 @@ import re
 # =============================================================================
 
 version = "2.0.2"  # Major.Minor.Milestone
-patch = "21"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.2.21
+patch = "22"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.2.22
 
-release_day = "14"  # Day of the release (1-31)
+release_day = "24"  # Day of the release (1-31)
 release_month = "August"  # Month of the release
 release_year = "2026"  # Year of the release
 

--- a/taskcoachlib/persistence/csv/generator.py
+++ b/taskcoachlib/persistence/csv/generator.py
@@ -143,7 +143,7 @@ def viewer2csv(
     isTree = viewer.is_tree_viewer()
     columns = columns or viewer.visibleColumns()
     rowBuilder = RowBuilder(columns, isTree, separateDateAndTimeColumns)
-    items = viewer.visibleItems()
+    items = viewer.visible_items()
     if selectionOnly:
         items = [item for item in items if viewer.isselected(item)]
         if isTree:

--- a/taskcoachlib/persistence/html/generator.py
+++ b/taskcoachlib/persistence/html/generator.py
@@ -220,7 +220,7 @@ class Viewer2HTMLConverter(object):
         tree = self.viewer.is_tree_viewer()
         self.count = 0
         tableBodyContent = []
-        for item in self.viewer.visibleItems():
+        for item in self.viewer.visible_items():
             if selectionOnly and not self.viewer.isselected(item):
                 continue
             self.count += 1

--- a/taskcoachlib/persistence/html/writer.py
+++ b/taskcoachlib/persistence/html/writer.py
@@ -70,7 +70,7 @@ class _ViewerProxy(object):
     def is_tree_viewer(self):
         return False
 
-    def visibleItems(self):
+    def visible_items(self):
         return self._items
 
     def isselected(self, item):

--- a/taskcoachlib/persistence/icalendar/writer.py
+++ b/taskcoachlib/persistence/icalendar/writer.py
@@ -62,7 +62,7 @@ class iCalendarWriter(object):
             items = list(taskFile.efforts())
         else:
             # Normal viewer-based export
-            items = viewer.visibleItems()
+            items = viewer.visible_items()
             if selectionOnly:
                 selection = viewer.curselection()
                 if viewer.is_tree_viewer():

--- a/taskcoachlib/persistence/todotxt/writer.py
+++ b/taskcoachlib/persistence/todotxt/writer.py
@@ -33,7 +33,7 @@ class TodoTxtWriter(object):
         if isinstance(viewer, str) and viewer == self.ALL_TASKS:
             tasks = list(taskFile.tasks()) if taskFile else []
         else:
-            tasks = viewer.visibleItems()
+            tasks = viewer.visible_items()
             if selectionOnly:
                 tasks = [task for task in tasks if viewer.isselected(task)]
         return self.writeTasks(tasks)

--- a/taskcoachlib/widgets/hcalendar.py
+++ b/taskcoachlib/widgets/hcalendar.py
@@ -184,7 +184,7 @@ class HierarchicalCalendar(tooltip.ToolTipMixin, CalendarCanvas):
         return self.__drawNow
 
     def SetTodayColor(self, xxx_todo_changeme):
-        (r, g, b) = xxx_todo_changeme
+        r, g, b = xxx_todo_changeme
         super().SetTodayColor(wx.Colour(r, g, b))
 
     def TodayColor(self):
@@ -248,7 +248,7 @@ class HierarchicalCalendar(tooltip.ToolTipMixin, CalendarCanvas):
             super()._DrawNow(gc, h)
 
     def GetRootEvents(self):
-        return self.__adapter.getRootItems()
+        return self.__adapter.get_root_items()
 
     def GetChildren(self, task):
         return self.__adapter.children(task)

--- a/taskcoachlib/widgets/itemctrl.py
+++ b/taskcoachlib/widgets/itemctrl.py
@@ -41,7 +41,7 @@ class _CtrlWithItemsMixin(object):
         try:
             return self.GetItemPyData(item)  # TreeListCtrl
         except AttributeError:
-            return self.getItemWithIndex(item)  # ListCtrl
+            return self.get_item_with_index(item)  # ListCtrl
 
     def SelectItem(self, item, *args, **kwargs):
         try:

--- a/taskcoachlib/widgets/listctrl.py
+++ b/taskcoachlib/widgets/listctrl.py
@@ -150,8 +150,8 @@ class VirtualListCtrl(
         # doesn't properly receive drag/drop events.
         return self
 
-    def getItemWithIndex(self, rowIndex):
-        return self.__parent.getItemWithIndex(rowIndex)
+    def get_item_with_index(self, rowIndex):
+        return self.__parent.get_item_with_index(rowIndex)
 
     def getItemText(self, domainObject, columnIndex):
         return self.__parent.getItemText(domainObject, columnIndex)
@@ -166,35 +166,35 @@ class VirtualListCtrl(
 
     def OnGetItemText(self, rowIndex, columnIndex):
         try:
-            item = self.getItemWithIndex(rowIndex)
+            item = self.get_item_with_index(rowIndex)
         except IndexError:
             return ""
         return self.getItemText(item, columnIndex)
 
     def OnGetItemTooltipData(self, rowIndex, columnIndex):
         try:
-            item = self.getItemWithIndex(rowIndex)
+            item = self.get_item_with_index(rowIndex)
         except IndexError:
             return None
         return self.getItemTooltipData(item)
 
     def OnGetItemImage(self, rowIndex):
         try:
-            item = self.getItemWithIndex(rowIndex)
+            item = self.get_item_with_index(rowIndex)
         except IndexError:
             return -1
         return self.getItemImage(item)
 
     def OnGetItemColumnImage(self, rowIndex, columnIndex):
         try:
-            item = self.getItemWithIndex(rowIndex)
+            item = self.get_item_with_index(rowIndex)
         except IndexError:
             return -1
         return self.getItemImage(item, columnIndex)
 
     def OnGetItemAttr(self, rowIndex):
         try:
-            item = self.getItemWithIndex(rowIndex)
+            item = self.get_item_with_index(rowIndex)
         except IndexError:
             return None
         foreground_color = item.foregroundColor(recursive=True)
@@ -263,7 +263,7 @@ class VirtualListCtrl(
         """Refresh specific items."""
         if len(items) <= 7:
             for item in items:
-                self.RefreshItem(self.__parent.getIndexOfItem(item))
+                self.RefreshItem(self.__parent.get_index_of_item(item))
         else:
             self.RefreshAllItems(self.GetItemCount())
 
@@ -295,19 +295,19 @@ class VirtualListCtrl(
         # callback executes after window destruction (e.g., closing
         # nested dialogs)
         try:
-            # Filter out None values - getItemWithIndex can return None
+            # Filter out None values - get_item_with_index can return None
             # for some indices
             return [
                 item
                 for index in self.__curselection_indices()
-                if (item := self.getItemWithIndex(index)) is not None
+                if (item := self.get_item_with_index(index)) is not None
             ]
         except RuntimeError:
             # wrapped C/C++ object has been deleted
             return []
 
     def select(self, items):
-        indices = [self.__parent.getIndexOfItem(item) for item in items]
+        indices = [self.__parent.get_index_of_item(item) for item in items]
         for index in range(self.GetItemCount()):
             self.Select(index, index in indices)
         if self.curselection():

--- a/taskcoachlib/widgets/treectrl.py
+++ b/taskcoachlib/widgets/treectrl.py
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from taskcoachlib import operating_system
 from wx.lib.agw import customtreectrl as customtree, hypertreelist
 from taskcoachlib.widgets import itemctrl, draganddrop
+import contextlib
 import wx
 
 # pylint: disable=E1101,E1103
@@ -206,6 +207,93 @@ class HyperTreeList(draganddrop.TreeCtrlDragAndDropMixin, BaseHyperTreeList):
             self.SelectAll()
         self.selectCommand()
 
+    def _recalculated_main_window(self):
+        """Return the main window with item positions up to date.
+
+        Item positions drive both the scrollbar range and GetY(), but
+        AdjustMyScrollbars() never recalculates them; only ScrollTo()
+        does, guarded on the _dirty flag. Both it and CalculatePositions()
+        also return early while the window is frozen, so after a
+        freeze/thaw rebuild the positions are still stale and anything
+        reading them silently works off the old layout.
+
+        The flag is deliberately left set, exactly as upstream ScrollTo()
+        leaves it: customtreectrl only ever sets _dirty, it never clears
+        it, so clearing it here would suppress recalculations upstream
+        still expects to happen.
+        """
+        main = self.GetMainWindow()
+        if getattr(main, "_dirty", False):
+            main.CalculatePositions()
+        return main
+
+    def selection_neighbours(self):
+        """Return the objects displayed around the current selection.
+
+        The result is a tuple (above, below).  "above" holds the objects
+        displayed above the topmost selected row, nearest row first;
+        "below" holds the objects displayed below the bottommost
+        selected row, again nearest row first.  Callers use this to pick
+        a replacement selection when the selected rows disappear.
+
+        Rows scrolled out of the viewport count as neighbours, which is
+        why this walks the tree itself instead of using upstream
+        GetPrevVisible/GetNextVisible: those also test whether the row
+        is on screen.
+        """
+        try:
+            selections = self.GetSelections()
+        except RuntimeError:
+            # wrapped C/C++ object has been deleted
+            return [], []
+        if not selections:
+            return [], []
+        # GetY() drives the ordering, so make sure positions are current
+        self._recalculated_main_window()
+        rows = sorted(selections, key=lambda item: item.GetY())
+        return (
+            list(self.__walk_rows(rows[0], self.__row_above)),
+            list(self.__walk_rows(rows[-1], self.__row_below)),
+        )
+
+    def __walk_rows(self, item, step):
+        """Yield the objects of the rows reached by repeating step."""
+        root_item = self.GetRootItem()
+        item = step(item)
+        while item is not None and item != root_item:
+            data = self.GetItemPyData(item)
+            if data is not None:
+                yield data
+            item = step(item)
+
+    def __row_above(self, item):
+        """Return the row displayed directly above item, or None."""
+        sibling = self.GetPrevSibling(item)
+        if sibling is None:
+            parent = self.GetItemParent(item)
+            return None if parent == self.GetRootItem() else parent
+        # The row above a sibling is that sibling's last open descendant
+        while self.IsExpanded(sibling):
+            last_child = self.GetLastChild(sibling)
+            if last_child is None:
+                break
+            sibling = last_child
+        return sibling
+
+    def __row_below(self, item):
+        """Return the row displayed directly below item, or None."""
+        if self.IsExpanded(item):
+            first_child = self.GetFirstChild(item)[0]
+            if first_child is not None:
+                return first_child
+        root_item = self.GetRootItem()
+        while item is not None and item != root_item:
+            sibling = self.GetNextSibling(item)
+            if sibling is not None:
+                return sibling
+            item = self.GetItemParent(item)
+        return None
+
     def IsLabelBeingEdited(self):
         return bool(self.GetLabelTextCtrl())
 
@@ -352,7 +440,7 @@ class TreeListCtrl(
         result = []
         for child_object in self.__adapter.children(parent_object):
             result.append(child_object.id())
-            if self.__adapter.getItemExpanded(child_object):
+            if self.__adapter.get_item_expanded(child_object):
                 result.extend(self._snapshot_adapter(child_object))
         return result
 
@@ -426,7 +514,7 @@ class TreeListCtrl(
             # Keep the viewport where the user left it. This also undoes
             # the implicit EnsureVisible triggered by restoring the
             # selection.
-            main = self.GetMainWindow()
+            main = self._recalculated_main_window()
             main.AdjustMyScrollbars()
             main.Scroll(*saved_view)
         # Immediate repaint - no blank screen
@@ -440,6 +528,27 @@ class TreeListCtrl(
         if settings is None:
             return True
         return settings.getboolean("view", "autoscrollselection")
+
+    @contextlib.contextmanager
+    def stable_viewport(self):
+        """Keep the viewport where it is while the block runs.
+
+        Selecting an item makes upstream customtreectrl call
+        EnsureVisible, so any programmatic selection scrolls the view.
+        When auto-scroll is off the viewport has to be put back
+        afterwards, the same way _do_full_rebuild does once it has
+        restored its own selection.
+        """
+        if self._auto_scroll_enabled():
+            yield
+            return
+        saved_view = self.GetMainWindow().GetViewStart()
+        try:
+            yield
+        finally:
+            main = self._recalculated_main_window()
+            main.AdjustMyScrollbars()
+            main.Scroll(*saved_view)
 
     def scroll_to_selection(self):
         """Scroll minimally to make first selected item visible."""
@@ -497,7 +606,7 @@ class TreeListCtrl(
                 data=child_object,
             )
             self._refresh_object_minimally(child_item, child_object)
-            expanded = self.__adapter.getItemExpanded(child_object)
+            expanded = self.__adapter.get_item_expanded(child_object)
             if expanded:
                 self._add_object_recursively(child_item, child_object)
                 # Call Expand on the item instead of on the tree

--- a/tests/unittests/guiTests/EffortViewerTest.py
+++ b/tests/unittests/guiTests/EffortViewerTest.py
@@ -371,14 +371,14 @@ class RoundingTestsMixin(object):
         self.assertEqual(
             self.expectedPeriodRendering,
             self.viewer.widget.getItemText(
-                self.viewer.widget.getItemWithIndex(0), 3
+                self.viewer.widget.get_item_with_index(0), 3
             ),
         )
         if self.aggregation != "details":
             self.assertEqual(
                 self.expectedTotalPeriodRendering,
                 self.viewer.widget.getItemText(
-                    self.viewer.widget.getItemWithIndex(0), 4
+                    self.viewer.widget.get_item_with_index(0), 4
                 ),
             )
 

--- a/tests/unittests/guiTests/ViewerTest.py
+++ b/tests/unittests/guiTests/ViewerTest.py
@@ -629,7 +629,7 @@ class ViewerIteratorTestCase(test.wxTestCase):
         self.taskFile.stop()
 
     def getItemsFromIterator(self):
-        return list(self.viewer.visibleItems())  # pylint: disable=E1101
+        return list(self.viewer.visible_items())  # pylint: disable=E1101
 
 
 class ViewerIteratorTestsMixin(object):

--- a/tests/unittests/widgetTests/ListCtrlTest.py
+++ b/tests/unittests/widgetTests/ListCtrlTest.py
@@ -26,8 +26,8 @@ class VirtualListCtrlTestCase(test.wxTestCase):
     onSelect = lambda *args: None
 
     def createListCtrl(self):
-        self.frame.getItemWithIndex = lambda index: index
-        self.frame.getIndexOfItem = lambda item: (
+        self.frame.get_item_with_index = lambda index: index
+        self.frame.get_index_of_item = lambda item: (
             item if type(item) == type(0) else 0
         )
         self.frame.getItemText = lambda item, column: ""

--- a/tests/unittests/widgetTests/TreeCtrlTest.py
+++ b/tests/unittests/widgetTests/TreeCtrlTest.py
@@ -40,7 +40,7 @@ class TreeCtrlTestCase(test.wxTestCase):
             wx.TreeItemIcon_Normal: -1
         }
         self.frame.getIsItemChecked = lambda item: False
-        self.frame.getItemExpanded = (
+        self.frame.get_item_expanded = (
             lambda item: item not in self.collapsedItems
         )
         self.item0 = DummyDomainObject("item 0")


### PR DESCRIPTION
Deleting a task moved the selection to the first row and scrolled the list to the top. These were two separate defects.

Selection: _capture_selection_info looked up the deleted item's index in children(parent), which reads the presentation. The domain layer removes the item before the event fires, so the lookup always missed and the index fell back to 0. Read the neighbouring rows from the widget instead, which still holds the pre-delete order, and select the row above the deleted one, falling back to the row below when the deleted row was the topmost. Walking chains of neighbours rather than a single row also covers multi-select deletes.

Scroll: the auto-scroll-off viewport restore in _do_full_rebuild calls AdjustMyScrollbars() then Scroll(), but AdjustMyScrollbars() sizes the range from the item positions without recalculating them, unlike ScrollTo(). After a freeze/thaw rebuild those positions are still dirty, so the range was stale and the Scroll was clamped to the top. Add _recalculated_main_window() and use it wherever a freshly rebuilt tree's positions are read.

Give all seven build workflows the same triggers. build-flatpak.yml was the only one building on fix/** and feat/** pushes, so pushing a branch built one packaging target and skipped the other six. Branch-name patterns are the wrong mechanism regardless: a branch named anything else got no build, while a branch with an open PR was already covered, since the default pull_request types include synchronize. The trigger set is now pull request, merge to master, release tag and manual dispatch:

- Drop the fix/** and feat/** patterns, so a build never depends on how a branch is named and pushing a branch with no PR costs nothing.
- Drop the main branch from every trigger list. This repository has only master, so those entries could never fire.
- Narrow the release tag filter from 'v*' to the four-part version scheme. 'v*' matched all 111 v-prefixed tags including v1.5.0-starofrainnight, which is not a release; the new pattern matches every real release tag and nothing else.
- Add ready_for_review to the pull_request types, so marking a draft ready rebuilds instead of relying on runs from while it was a draft.

The trigger policy, and the cases that deliberately do not build, are recorded in docs/PACKAGING.md.

Also migrate the surrounding navigation methods to snake_case per docs/PEP8_MIGRATION.md, document both root causes in docs/LIST_MANAGEMENT.md, and bump the version to 2.0.2.22.

Stay on top when complete a recurrent task #465