### PR TITLE
Restore pane layout when instance numbers have a gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,20 @@ Download the package for your system from the [latest release](https://github.co
 
 | Platform | Package |
 |----------|---------|
-| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.22-x86_64.AppImage` |
-| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.22-arch.pkg.tar.zst` |
-| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.22_debian-12-bookworm.deb` |
-| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.22_debian-13-trixie.deb` |
-| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.22_debian-sid.deb` |
-| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.22-fedora43.rpm` |
-| [Flatpak (any Linux)](#flatpak) | `TaskCoach-2.0.2.22-x86_64.flatpak` |
+| [Any Linux (x86_64)](#appimage) | `TaskCoach-2.0.2.23-x86_64.AppImage` |
+| [Arch Linux / Manjaro](#arch-linux--manjaro) | `taskcoach-2.0.2.23-arch.pkg.tar.zst` |
+| [Debian 12 (Bookworm)](#debian--ubuntu) | `taskcoach_2.0.2.23_debian-12-bookworm.deb` |
+| [Debian 13 (Trixie)](#debian--ubuntu) | `taskcoach_2.0.2.23_debian-13-trixie.deb` |
+| [Debian Sid](#debian--ubuntu) | `taskcoach_2.0.2.23_debian-sid.deb` |
+| [Fedora 42/43](#fedora) | `taskcoach-2.0.2.23-fedora43.rpm` |
+| [Flatpak (any Linux)](#flatpak) | `TaskCoach-2.0.2.23-x86_64.flatpak` |
 | [Linux Mint](#debian--ubuntu) | Use Ubuntu `.deb` (Mint is Ubuntu-based) |
-| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.22-macos-arm64.dmg` |
-| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.22-macos-intel.dmg` |
-| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.22_ubuntu-22.04-jammy.deb` |
-| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.22_ubuntu-24.04-noble.deb` |
-| [Windows](#windows) | `TaskCoach-2.0.2.22-windows-x64-setup.exe` |
-| [Windows (portable)](#windows) | `TaskCoach-2.0.2.22-windows-x64-portable.zip` |
+| [macOS (Apple Silicon)](#macos) | `TaskCoach-2.0.2.23-macos-arm64.dmg` |
+| [macOS (Intel)](#macos) | `TaskCoach-2.0.2.23-macos-intel.dmg` |
+| [Ubuntu 22.04 (Jammy)](#debian--ubuntu) | `taskcoach_2.0.2.23_ubuntu-22.04-jammy.deb` |
+| [Ubuntu 24.04 (Noble)](#debian--ubuntu) | `taskcoach_2.0.2.23_ubuntu-24.04-noble.deb` |
+| [Windows](#windows) | `TaskCoach-2.0.2.23-windows-x64-setup.exe` |
+| [Windows (portable)](#windows) | `TaskCoach-2.0.2.23-windows-x64-portable.zip` |
 
 After installing, Task Coach should be in normal system launchers (Applications → Office → Task Coach). For CLI, the launch command is `taskcoach.py`.
 
@@ -43,8 +43,8 @@ Install instructions for Debian Trixie (similar for other Debian/Ubuntu systems,
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.22_debian-13-trixie.deb
-sudo apt install ./taskcoach_2.0.2.22_debian-13-trixie.deb
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach_2.0.2.23_debian-13-trixie.deb
+sudo apt install ./taskcoach_2.0.2.23_debian-13-trixie.deb
 ```
 
 To uninstall:
@@ -57,8 +57,8 @@ sudo apt autoremove  # optional: remove unused dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.22-arch.pkg.tar.zst
-sudo pacman -U taskcoach-2.0.2.22-arch.pkg.tar.zst
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.23-arch.pkg.tar.zst
+sudo pacman -U taskcoach-2.0.2.23-arch.pkg.tar.zst
 ```
 
 To uninstall:
@@ -71,8 +71,8 @@ sudo pacman -Qdtq | sudo pacman -Rs -  # optional: remove orphaned dependencies
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.22-fedora43.rpm
-sudo dnf install ./taskcoach-2.0.2.22-fedora43.rpm
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/taskcoach-2.0.2.23-fedora43.rpm
+sudo dnf install ./taskcoach-2.0.2.23-fedora43.rpm
 ```
 
 To uninstall:
@@ -87,13 +87,13 @@ Run on any Linux without installation:
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.22-x86_64.AppImage
-chmod +x TaskCoach-2.0.2.22-x86_64.AppImage
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.23-x86_64.AppImage
+chmod +x TaskCoach-2.0.2.23-x86_64.AppImage
 ```
 
 To launch the AppImage, open the file or run:
 ```
-./TaskCoach-2.0.2.22-x86_64.AppImage
+./TaskCoach-2.0.2.23-x86_64.AppImage
 ```
 
 To remove: simply delete the AppImage file.
@@ -105,8 +105,8 @@ the first install pulls the GNOME runtime from Flathub.
 
 ```bash
 cd ~/Downloads
-wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.22-x86_64.flatpak
-flatpak install ./TaskCoach-2.0.2.22-x86_64.flatpak
+wget https://github.com/taskcoach/taskcoach/releases/latest/download/TaskCoach-2.0.2.23-x86_64.flatpak
+flatpak install ./TaskCoach-2.0.2.23-x86_64.flatpak
 flatpak run io.github.taskcoach.TaskCoach
 ```
 

--- a/docs/AUI.md
+++ b/docs/AUI.md
@@ -5,6 +5,8 @@ This document covers AUI-related topics for Task Coach, which uses wxPython's AG
 ## Contents
 
 1. [Layout Persistence](#layout-persistence)
+   - [Pane Names Carry Instance Numbers](#pane-names-carry-instance-numbers)
+   - [AUI-Generated Panes](#aui-generated-panes)
 2. [Sash Cursor Seep-Through Fix](#sash-cursor-seep-through-fix)
 3. [Related Documentation](#related-documentation)
 
@@ -75,6 +77,65 @@ def __restore_perspective(self):
         self.manager.LoadPerspective("")  # Fall back to default
 ```
 
+### Pane Names Carry Instance Numbers
+
+A pane's name is `viewer.settingsSection()`, which appends the viewer's
+instance number for every instance after the first: `taskviewer`,
+`taskviewer1`, `taskviewer2`. `NumberedInstances` (in
+`patterns/metaclass.py`) hands out the lowest number not held by a live
+instance.
+
+This matters because the layout is persisted in two places that encode
+different things:
+
+| What | Where | Encodes |
+|------|-------|---------|
+| Pane layout | `[view] perspective` | Pane **names**, so instance numbers |
+| Viewer set | `[view] <type>count` | **Cardinality** only |
+
+Closing any viewer other than the highest-numbered one leaves a gap in
+the names. Close `taskviewer1` of three and the surviving panes are
+`taskviewer` and `taskviewer2`, while the count is 2. A count cannot
+express a gap, so recreating from it alone yields `taskviewer` and
+`taskviewer1`: AUI then ignores the saved `taskviewer2` (no window with
+that name) and leaves the new `taskviewer1` at its default position.
+Part of the layout silently fails to restore.
+
+**Therefore: the perspective is the source of truth for which instance
+numbers to recreate**, not the count.
+`addViewers._instance_numbers_to_add()` reads the numbers back out of
+the perspective and passes each one explicitly to the viewer
+constructor; `NumberedInstances` honours an explicitly supplied
+`instanceNumber` instead of assigning the lowest unused one. The count
+remains only as a fallback for viewer types the perspective has no panes
+for, such as on a first run.
+
+The name match is anchored on the separator (`name=<section>(\d*)`
+followed by `;`, `|`, or end of string) so that `effortviewer` does not
+also match `effortviewerforselectedtasks`. That substring collision is
+the same trap described in "Why Custom Validation Is Harmful" above.
+
+### AUI-Generated Panes
+
+Dragging panes together creates a tab group, and AUI adds a pane of its
+own named `__notebook_0`, `__notebook_1`, and so on, with the tabbed
+viewers becoming notebook pages referring to it by `notebook_id`. These
+names appear in the saved perspective but match no window we create.
+
+**They are recreated by `LoadPerspective` itself and need no handling.**
+Verified against wxPython 4.2.0 / AGW: a 13-pane layout containing an
+auto-notebook restored with every pane's dock direction, layer, row,
+position, proportion and size identical to what was saved. The manager
+gained the `__notebook_0` pane during the load.
+
+This is worth stating because upstream reports say otherwise. A
+[wxPython-users thread](https://groups.google.com/g/wxpython-users/c/HmNe0lvnwMY)
+describes panes dragged into a spontaneously generated notebook
+disappearing on restore, and the AGW maintainer confirmed it as a bug.
+That does not reproduce on the version in use here, so do not spend time
+working around it, and do not treat `__notebook_*` entries with no
+matching window as evidence of a problem.
+
 ### Perspective String Format
 
 The perspective string uses this format:
@@ -108,8 +169,10 @@ The name is determined by `viewer.settingsSection()` in `taskcoachlib/gui/viewer
 
 | File | Purpose |
 |------|---------|
-| `taskcoachlib/gui/mainwindow.py` | `__restore_perspective()`, `__save_perspective()` |
+| `taskcoachlib/gui/mainwindow.py` | `__restore_perspective()`, `__save_perspective()`, `__save_viewer_counts()` |
 | `taskcoachlib/gui/viewer/base.py` | `settingsSection()` - generates unique pane names |
+| `taskcoachlib/gui/viewer/factory.py` | `_instance_numbers_to_add()` - reads instance numbers back from the perspective |
+| `taskcoachlib/patterns/metaclass.py` | `NumberedInstances` - assigns instance numbers, honours an explicit one |
 | `taskcoachlib/gui/viewer/container.py` | `addViewer()` - adds panes to AUI manager |
 | `taskcoachlib/widgets/frame.py` | `addPane()` - configures AuiPaneInfo |
 | `taskcoachlib/config/settings.py` | Stores perspective in INI file |

--- a/taskcoachlib/gui/mainwindow.py
+++ b/taskcoachlib/gui/mainwindow.py
@@ -42,6 +42,8 @@ from taskcoachlib.powermgt import PowerStateMixin
 from taskcoachlib.help.balloontips import BalloonTipManager
 from pubsub import pub
 from taskcoachlib.config.settings import Settings
+from taskcoachlib.meta.debug import log_step
+import re
 import wx.lib.agw.aui as aui
 import wx, ctypes
 
@@ -185,8 +187,40 @@ class MainWindow(
         # events from AUI LoadPerspective() and GTK window realization.
         # Events are bound immediately in __init__, no manual start needed.
 
+    @staticmethod
+    def __unmatched_pane_names(perspective, panes):
+        """Pane names that cannot be matched between saved and existing.
+
+        A name in the perspective with no window is ignored by AUI, and a
+        window with no entry in the perspective keeps its default
+        position. Either way part of the layout silently fails to
+        restore, so it is worth a line in the log. __notebook_N panes are
+        excluded because AUI creates those itself while loading the
+        perspective; they are legitimately absent beforehand.
+        """
+        saved = [
+            name
+            for name in re.findall(r"name=([^;|]+)", perspective or "")
+            if not name.startswith("__notebook_")
+        ]
+        existing = [pane.name for pane in panes]
+        return (
+            [name for name in saved if name not in existing],
+            [name for name in existing if name not in saved],
+        )
+
     def __restore_perspective(self):
         perspective = self.settings.get("view", "perspective")
+        no_window, no_entry = self.__unmatched_pane_names(
+            perspective, self.manager.GetAllPanes()
+        )
+        if no_window or no_entry:
+            log_step(
+                "layout will not fully restore. Saved panes with no "
+                "window: %s. Panes with no saved entry: %s"
+                % (no_window or "none", no_entry or "none"),
+                prefix="AUI",
+            )
         # Note: We intentionally do NOT validate viewer counts before loading.
         # AUI's LoadPerspective handles mismatches gracefully:
         # - Panes in perspective without matching windows are ignored
@@ -279,7 +313,7 @@ If this happens again, please make a copy of your TaskCoach.ini file """
 
     def __save_viewer_counts(self):
         """Save the number of viewers for each viewer type."""
-        for viewer_type in viewer.viewerTypes():
+        for viewer_type in viewer.viewer_types():
 
             if hasattr(self, "viewer"):
                 count = len(

--- a/taskcoachlib/gui/viewer/__init__.py
+++ b/taskcoachlib/gui/viewer/__init__.py
@@ -35,7 +35,7 @@ from .effort import EffortViewer, EffortViewerForSelectedTasks
 from .note import NoteViewer, BaseNoteViewer
 from .attachment import AttachmentViewer
 from .container import ViewerContainer
-from .factory import viewerTypes, addViewers, addOneViewer
+from .factory import viewer_types, addViewers, addOneViewer
 
 from taskcoachlib import operating_system
 

--- a/taskcoachlib/gui/viewer/factory.py
+++ b/taskcoachlib/gui/viewer/factory.py
@@ -16,6 +16,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+import re
+
 from taskcoachlib import operating_system
 
 from . import effort
@@ -24,7 +26,7 @@ from . import category
 from . import note
 
 
-def viewerTypes():
+def viewer_types():
     """Return the available viewer types, using the names as used in the
     settings."""
     types = [
@@ -97,14 +99,45 @@ class addViewers(object):  # pylint: disable=C0103, R0903
     def __add_viewers(self, viewer_class):
         """Open viewers of the specified viewer class as saved previously in
         the settings."""
-        number_of_viewers_to_add = self._number_of_viewers_to_add(viewer_class)
-        for _ in range(number_of_viewers_to_add):
-            viewer_instance = viewer_class(
-                *self.__viewer_init_args, **self._viewer_kwargs(viewer_class)
-            )
+        for instance_number in self._instance_numbers_to_add(viewer_class):
+            kwargs = self._viewer_kwargs(viewer_class)
+            if instance_number is not None:
+                kwargs["instanceNumber"] = instance_number
+            viewer_instance = viewer_class(*self.__viewer_init_args, **kwargs)
             self.__viewer_container.add_viewer(
                 viewer_instance, floating=self.floating
             )
+
+    def _instance_numbers_to_add(self, viewer_class):
+        """Return the instance numbers to recreate for this viewer class.
+
+        The pane names in the saved perspective embed these numbers, and
+        closing any viewer other than the highest-numbered one leaves a
+        gap in them: closing taskviewer1 of three leaves taskviewer and
+        taskviewer2. A count cannot express that gap, so recreating from
+        the count alone would produce taskviewer and taskviewer1, and
+        AUI would match neither pane by name - it ignores the saved
+        taskviewer2 and leaves the new taskviewer1 at its default
+        position. Take the numbers from the perspective, which is the
+        only place that records them.
+
+        Falls back to the count when the perspective has no panes for
+        this class, which is the case on a first run and for a viewer
+        type the user has never opened.
+        """
+        section = viewer_class.__name__.lower()
+        perspective = self.__settings.get("view", "perspective")
+        # Anchored on the name separator so that effortviewer does not
+        # also match effortviewerforselectedtasks.
+        numbers = sorted(
+            int(match.group(1) or 0)
+            for match in re.finditer(
+                r"name=%s(\d*)(?=[;|]|$)" % re.escape(section), perspective
+            )
+        )
+        if numbers:
+            return numbers
+        return list(range(self._number_of_viewers_to_add(viewer_class)))
 
     def _number_of_viewers_to_add(self, viewer_class):
         """Return the number of viewers of the specified viewer class the
@@ -136,8 +169,10 @@ class addOneViewer(addViewers):  # pylint: disable=C0103, R0903
         self.__kwargs = kwargs
         super().__init__(viewer_container, task_file, settings)
 
-    def _number_of_viewers_to_add(self, viewer_class):
-        return 1 if viewer_class == self.__viewer_class else 0
+    def _instance_numbers_to_add(self, viewer_class):
+        # A brand new viewer, not a restored one: None lets the metaclass
+        # pick the lowest free number rather than reusing a saved one.
+        return [None] if viewer_class == self.__viewer_class else []
 
     def _viewer_kwargs(self, viewer_class):
         kwargs = super()._viewer_kwargs(viewer_class)

--- a/taskcoachlib/meta/data.py
+++ b/taskcoachlib/meta/data.py
@@ -44,8 +44,8 @@ import re
 # =============================================================================
 
 version = "2.0.2"  # Major.Minor.Milestone
-patch = "22"  # Patch number - INCREMENT THIS for each release
-version_full = f"{version}.{patch}"  # Full version: 2.0.2.22
+patch = "23"  # Patch number - INCREMENT THIS for each release
+version_full = f"{version}.{patch}"  # Full version: 2.0.2.23
 
 release_day = "24"  # Day of the release (1-31)
 release_month = "August"  # Month of the release

--- a/taskcoachlib/patterns/metaclass.py
+++ b/taskcoachlib/patterns/metaclass.py
@@ -27,22 +27,29 @@ class NumberedInstances(type):
     class Numbered:
         __metaclass__ = NumberedInstances
     Each instance of class Numbered will have an attribute instanceNumber
-    that is unique."""
+    that is unique.
+
+    Callers may pass an explicit instanceNumber to reuse a specific
+    number instead of the lowest unused one. Restoring a saved layout
+    needs that: the numbers it has to reproduce may contain a gap, which
+    lowest_unused_number would fill in and thereby rename the pane."""
 
     count = dict()
 
     def __call__(cls, *args, **kwargs):
         if cls not in NumberedInstances.count:
             NumberedInstances.count[cls] = weakref.WeakKeyDictionary()
-        instanceNumber = NumberedInstances.lowestUnusedNumber(cls)
-        kwargs["instanceNumber"] = instanceNumber
+        instance_number = kwargs.get("instanceNumber")
+        if instance_number is None:
+            instance_number = NumberedInstances.lowest_unused_number(cls)
+        kwargs["instanceNumber"] = instance_number
         instance = super(NumberedInstances, cls).__call__(*args, **kwargs)
-        NumberedInstances.count[cls][instance] = instanceNumber
+        NumberedInstances.count[cls][instance] = instance_number
         return instance
 
-    def lowestUnusedNumber(cls):
-        usedNumbers = sorted(NumberedInstances.count[cls].values())
-        for index, usedNumber in enumerate(usedNumbers):
-            if usedNumber != index:
+    def lowest_unused_number(cls):
+        used_numbers = sorted(NumberedInstances.count[cls].values())
+        for index, used_number in enumerate(used_numbers):
+            if used_number != index:
                 return index
-        return len(usedNumbers)
+        return len(used_numbers)


### PR DESCRIPTION
A pane's name is viewer.settingsSection(), which appends the viewer's instance number for every instance after the first: taskviewer, taskviewer1, taskviewer2. The layout was persisted in two forms that encode different things. The perspective records those names, while <type>count records only how many viewers exist.

Closing any viewer other than the highest-numbered one leaves a gap in the names. Close taskviewer1 of three and the surviving panes are taskviewer and taskviewer2 while the count is 2. A count cannot express that gap, so recreating from it produced taskviewer and taskviewer1: AUI then ignored the saved taskviewer2, having no window of that name, and left the new taskviewer1 at its default position. Part of the layout silently failed to restore.

Take the instance numbers from the perspective instead, which is the only place that records them, and pass each one explicitly to the viewer constructor. NumberedInstances now honours an explicitly supplied instanceNumber rather than always assigning the lowest unused one. The count remains as a fallback for viewer types the perspective has no panes for, such as on a first run. The name match is anchored on the separator so that effortviewer does not also match effortviewerforselectedtasks.

Log a single line when saved and existing pane names cannot be matched, since that always means part of the layout is about to be lost. __notebook_N panes are excluded from that check: AUI creates them while loading the perspective, so they are legitimately absent beforehand.

Document both in docs/AUI.md, including the verified finding that AGW does recreate auto-generated notebook panes correctly on the wxPython version in use, contrary to upstream reports, so that nobody works around a bug that is not there.

Bump the version to 2.0.2.23.